### PR TITLE
Build the Scrawlix core engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  core:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm test

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "scrawlix-workspace",
+  "private": true,
+  "scripts": {
+    "test": "pnpm --filter @scrawlix/core test",
+    "typecheck": "pnpm --filter @scrawlix/core typecheck"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@scrawlix/core",
+  "version": "0.0.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "types": "./src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  }
+}

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import {
+  censorRuleFromWords,
+  createScrawlix,
+  STRONG_PROFANITY_RULES,
+  type ScrawlixSegment,
+} from './index';
+
+function marked(segments: readonly ScrawlixSegment[]) {
+  return segments
+    .map(segment => (segment.covered ? `[${segment.text}]` : segment.text))
+    .join('');
+}
+
+describe('Scrawlix core', () => {
+  it('covers the semantic profanity core instead of the whole inflected match', () => {
+    const scrawlix = createScrawlix({ coverage: 'middle' });
+
+    expect(marked(scrawlix.segment('fuck fucking motherfucker'))).toBe(
+      'f[uc]k f[uc]king motherf[uc]ker'
+    );
+
+    expect(scrawlix.find('motherfucker')).toEqual([
+      {
+        ruleId: 'fuck',
+        text: 'motherfucker',
+        start: 0,
+        end: 12,
+        targetText: 'fuck',
+        targetStart: 6,
+        targetEnd: 10,
+      },
+    ]);
+  });
+
+  it.each([
+    ['full', '[fuck]'],
+    ['tail', 'f[uck]'],
+    ['middle', 'f[uc]k'],
+    ['inner', 'f[uc]k'],
+    ['vowel', 'f[u]ck'],
+  ] as const)('supports the %s coverage preset', (coverage, expected) => {
+    const scrawlix = createScrawlix({ coverage });
+    expect(marked(scrawlix.segment('fuck'))).toBe(expected);
+  });
+
+  it('supports custom word and phrase rules', () => {
+    const privateWords = censorRuleFromWords('private', [
+      'Mothbit',
+      'Luna',
+      'C++',
+      'Project Velvet',
+    ]);
+    const scrawlix = createScrawlix({
+      rules: [privateWords],
+      coverage: 'full',
+    });
+
+    expect(
+      marked(
+        scrawlix.segment(
+          'Mothbit met Luna over C++ before Project Velvet shipped.'
+        )
+      )
+    ).toBe(
+      '[Mothbit] met [Luna] over [C++] before [Project Velvet] shipped.'
+    );
+  });
+
+  it('uses Unicode-aware boundaries for custom words', () => {
+    const cafe = censorRuleFromWords('cafe', ['café']);
+    const scrawlix = createScrawlix({ rules: [cafe], coverage: 'full' });
+
+    expect(marked(scrawlix.segment('caféteria café CAFÉ.'))).toBe(
+      'caféteria [café] [CAFÉ].'
+    );
+  });
+
+  it('does not mutate caller-owned RegExp cursors', () => {
+    const pattern = /fuck/gi;
+    pattern.lastIndex = 2;
+    const scrawlix = createScrawlix({
+      rules: [{ id: 'test', pattern }],
+      coverage: 'full',
+    });
+
+    scrawlix.segment('fuck fuck');
+
+    expect(pattern.lastIndex).toBe(2);
+  });
+
+  it('merges overlapping covered ranges and keeps contributing rule ids', () => {
+    const scrawlix = createScrawlix({
+      rules: [
+        ...STRONG_PROFANITY_RULES,
+        { id: 'whole', pattern: /motherfucker/gi },
+      ],
+      coverage: 'full',
+    });
+
+    const segments = scrawlix.segment('motherfucker');
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({
+      text: 'motherfucker',
+      covered: true,
+    });
+    expect([...segments[0]!.ruleIds].sort()).toEqual(['fuck', 'whole']);
+  });
+
+  it('allows a coverage callback', () => {
+    const scrawlix = createScrawlix({
+      coverage: context => [
+        {
+          start: 1,
+          end: Math.min(2, context.targetText.length),
+        },
+      ],
+    });
+
+    expect(marked(scrawlix.segment('fuck'))).toBe('f[u]ck');
+  });
+
+  it('lets a rule override the engine coverage', () => {
+    const rule = {
+      ...STRONG_PROFANITY_RULES[0]!,
+      coverage: 'vowel' as const,
+    };
+    const scrawlix = createScrawlix({ rules: [rule], coverage: 'full' });
+
+    expect(marked(scrawlix.segment('fuck'))).toBe('f[u]ck');
+  });
+
+  it('reconstructs the original input exactly from segments', () => {
+    const text = '🔥 Fuck this shit — exactly as written.';
+    const segments = createScrawlix({ coverage: 'vowel' }).segment(text);
+
+    expect(segments.map(segment => segment.text).join('')).toBe(text);
+  });
+
+  it('returns ordinary text when there are no rules', () => {
+    expect(createScrawlix({ rules: [] }).segment('fuck')).toEqual([
+      { text: 'fuck', covered: false, ruleIds: [] },
+    ]);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,434 @@
+export type CoveragePreset = 'full' | 'tail' | 'middle' | 'inner' | 'vowel';
+
+export type RelativeRange = {
+  start: number;
+  end: number;
+};
+
+export type CoverageContext = {
+  ruleId: string;
+  matchText: string;
+  targetText: string;
+  matchStart: number;
+  matchEnd: number;
+  targetStart: number;
+  targetEnd: number;
+};
+
+export type CoverageSelector =
+  | CoveragePreset
+  | ((context: CoverageContext) => readonly RelativeRange[]);
+
+export type CensorTarget = {
+  group: string;
+};
+
+export type CensorRule = {
+  id: string;
+  pattern: RegExp;
+  target?: CensorTarget;
+  coverage?: CoverageSelector;
+};
+
+export type ScrawlixMatch = {
+  ruleId: string;
+  text: string;
+  start: number;
+  end: number;
+  targetText: string;
+  targetStart: number;
+  targetEnd: number;
+};
+
+export type ScrawlixSegment = {
+  text: string;
+  covered: boolean;
+  ruleIds: readonly string[];
+};
+
+export type ScrawlixOptions = {
+  rules?: readonly CensorRule[];
+  coverage?: CoverageSelector;
+};
+
+export type ScrawlixEngine = {
+  find(text: string): ScrawlixMatch[];
+  segment(text: string): ScrawlixSegment[];
+};
+
+type CompiledRule = Omit<CensorRule, 'pattern'> & {
+  pattern: RegExp;
+};
+
+type ScannedMatch = {
+  match: ScrawlixMatch;
+  rule: CompiledRule;
+};
+
+type CoveredRange = {
+  start: number;
+  end: number;
+  ruleIds: Set<string>;
+};
+
+const graphemeSegmenter =
+  typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
+    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    : null;
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function compilePattern(pattern: RegExp) {
+  const flags = new Set(pattern.flags.replaceAll('y', '').split(''));
+  flags.add('g');
+  flags.add('d');
+  return new RegExp(pattern.source, [...flags].join(''));
+}
+
+function graphemeRanges(value: string): RelativeRange[] {
+  if (!value) return [];
+
+  if (graphemeSegmenter) {
+    return [...graphemeSegmenter.segment(value)].map(part => ({
+      start: part.index,
+      end: part.index + part.segment.length,
+    }));
+  }
+
+  const ranges: RelativeRange[] = [];
+  let cursor = 0;
+  for (const character of Array.from(value)) {
+    ranges.push({ start: cursor, end: cursor + character.length });
+    cursor += character.length;
+  }
+  return ranges;
+}
+
+function fullRange(value: string): RelativeRange[] {
+  return value.length > 0 ? [{ start: 0, end: value.length }] : [];
+}
+
+function middleCoverage(value: string): RelativeRange[] {
+  const graphemes = graphemeRanges(value);
+  if (graphemes.length === 0) return [];
+  if (graphemes.length === 1) return fullRange(value);
+
+  const coverCount = Math.max(1, Math.ceil(graphemes.length / 2));
+  const startIndex = Math.floor((graphemes.length - coverCount) / 2);
+  const endIndex = startIndex + coverCount - 1;
+
+  return [
+    {
+      start: graphemes[startIndex]!.start,
+      end: graphemes[endIndex]!.end,
+    },
+  ];
+}
+
+function coverageForPreset(
+  preset: CoveragePreset,
+  value: string
+): RelativeRange[] {
+  const graphemes = graphemeRanges(value);
+  if (graphemes.length === 0) return [];
+
+  switch (preset) {
+    case 'full':
+      return fullRange(value);
+
+    case 'tail':
+      if (graphemes.length === 1) return fullRange(value);
+      return [
+        {
+          start: graphemes[1]!.start,
+          end: graphemes.at(-1)!.end,
+        },
+      ];
+
+    case 'inner':
+      if (graphemes.length <= 2) return fullRange(value);
+      return [
+        {
+          start: graphemes[1]!.start,
+          end: graphemes.at(-2)!.end,
+        },
+      ];
+
+    case 'middle':
+      return middleCoverage(value);
+
+    case 'vowel': {
+      const vowels = graphemes.filter(range => {
+        const grapheme = value
+          .slice(range.start, range.end)
+          .normalize('NFD')
+          .replace(/\p{M}/gu, '');
+        return /[aeiou]/iu.test(grapheme);
+      });
+      return vowels.length > 0 ? vowels : middleCoverage(value);
+    }
+  }
+}
+
+function sanitizeRanges(
+  ranges: readonly RelativeRange[],
+  targetLength: number
+): RelativeRange[] {
+  return ranges
+    .map(range => {
+      if (!Number.isFinite(range.start) || !Number.isFinite(range.end)) {
+        return null;
+      }
+
+      const start = Math.max(0, Math.min(targetLength, Math.trunc(range.start)));
+      const end = Math.max(0, Math.min(targetLength, Math.trunc(range.end)));
+      if (end <= start) return null;
+      return { start, end };
+    })
+    .filter((range): range is RelativeRange => range !== null)
+    .sort((left, right) => left.start - right.start || left.end - right.end);
+}
+
+function resolveTargetRange(match: RegExpExecArray, rule: CompiledRule) {
+  const fullStart = match.index;
+  const fullEnd = match.index + match[0].length;
+
+  if (!rule.target) {
+    return { start: fullStart, end: fullEnd };
+  }
+
+  const groupRange = match.indices?.groups?.[rule.target.group];
+  if (!groupRange) {
+    return { start: fullStart, end: fullEnd };
+  }
+
+  return { start: groupRange[0], end: groupRange[1] };
+}
+
+function scan(text: string, rules: readonly CompiledRule[]): ScannedMatch[] {
+  const matches: ScannedMatch[] = [];
+
+  for (const rule of rules) {
+    rule.pattern.lastIndex = 0;
+    let rawMatch: RegExpExecArray | null;
+
+    while ((rawMatch = rule.pattern.exec(text)) !== null) {
+      if (!rawMatch[0]) {
+        rule.pattern.lastIndex = rawMatch.index + 1;
+        continue;
+      }
+
+      const target = resolveTargetRange(rawMatch, rule);
+      matches.push({
+        rule,
+        match: {
+          ruleId: rule.id,
+          text: rawMatch[0],
+          start: rawMatch.index,
+          end: rawMatch.index + rawMatch[0].length,
+          targetText: text.slice(target.start, target.end),
+          targetStart: target.start,
+          targetEnd: target.end,
+        },
+      });
+    }
+
+    rule.pattern.lastIndex = 0;
+  }
+
+  matches.sort(
+    (left, right) =>
+      left.match.start - right.match.start ||
+      right.match.end - left.match.end ||
+      left.match.ruleId.localeCompare(right.match.ruleId)
+  );
+
+  return matches;
+}
+
+function collectCoveredRanges(
+  matches: readonly ScannedMatch[],
+  defaultCoverage: CoverageSelector
+) {
+  const ranges: CoveredRange[] = [];
+
+  for (const scanned of matches) {
+    const { match, rule } = scanned;
+    const context: CoverageContext = {
+      ruleId: match.ruleId,
+      matchText: match.text,
+      targetText: match.targetText,
+      matchStart: match.start,
+      matchEnd: match.end,
+      targetStart: match.targetStart,
+      targetEnd: match.targetEnd,
+    };
+    const selector = rule.coverage ?? defaultCoverage;
+    const relativeRanges = sanitizeRanges(
+      typeof selector === 'function'
+        ? selector(context)
+        : coverageForPreset(selector, match.targetText),
+      match.targetText.length
+    );
+
+    for (const relative of relativeRanges) {
+      ranges.push({
+        start: match.targetStart + relative.start,
+        end: match.targetStart + relative.end,
+        ruleIds: new Set([match.ruleId]),
+      });
+    }
+  }
+
+  ranges.sort((left, right) => left.start - right.start || right.end - left.end);
+  return ranges;
+}
+
+function mergeCoveredRanges(ranges: readonly CoveredRange[]) {
+  const merged: CoveredRange[] = [];
+
+  for (const range of ranges) {
+    const previous = merged.at(-1);
+    if (!previous || range.start >= previous.end) {
+      merged.push({
+        start: range.start,
+        end: range.end,
+        ruleIds: new Set(range.ruleIds),
+      });
+      continue;
+    }
+
+    previous.end = Math.max(previous.end, range.end);
+    for (const ruleId of range.ruleIds) previous.ruleIds.add(ruleId);
+  }
+
+  return merged;
+}
+
+function segmentFromRanges(text: string, ranges: readonly CoveredRange[]) {
+  if (ranges.length === 0) {
+    return [{ text, covered: false, ruleIds: [] }] satisfies ScrawlixSegment[];
+  }
+
+  const segments: ScrawlixSegment[] = [];
+  let cursor = 0;
+
+  for (const range of ranges) {
+    if (range.start > cursor) {
+      segments.push({
+        text: text.slice(cursor, range.start),
+        covered: false,
+        ruleIds: [],
+      });
+    }
+
+    segments.push({
+      text: text.slice(range.start, range.end),
+      covered: true,
+      ruleIds: [...range.ruleIds],
+    });
+    cursor = range.end;
+  }
+
+  if (cursor < text.length) {
+    segments.push({
+      text: text.slice(cursor),
+      covered: false,
+      ruleIds: [],
+    });
+  }
+
+  return segments;
+}
+
+export function censorRuleFromWords(
+  id: string,
+  words: readonly string[],
+  {
+    caseSensitive = false,
+    coverage,
+  }: { caseSensitive?: boolean; coverage?: CoverageSelector } = {}
+): CensorRule {
+  const alternatives = [...new Set(words.map(word => word.trim()).filter(Boolean))]
+    .sort((left, right) => right.length - left.length)
+    .map(escapeRegExp);
+
+  if (alternatives.length === 0) {
+    throw new Error('A censor rule needs at least one non-empty word.');
+  }
+
+  return {
+    id,
+    coverage,
+    pattern: new RegExp(
+      `(?<![\\p{L}\\p{N}_])(?:${alternatives.join('|')})(?![\\p{L}\\p{N}_])`,
+      caseSensitive ? 'gu' : 'giu'
+    ),
+  };
+}
+
+export const STRONG_PROFANITY_RULES: readonly CensorRule[] = [
+  {
+    id: 'fuck',
+    pattern:
+      /(?<![\p{L}\p{N}_])(?:mother)?(?<core>fuck)(?:ing|ed|er|ers|s)?(?![\p{L}\p{N}_])/giu,
+    target: { group: 'core' },
+  },
+  {
+    id: 'shit',
+    pattern:
+      /(?<![\p{L}\p{N}_])(?:bull)?(?<core>shit)(?:ting|ted|ter|ters|s|ty)?(?![\p{L}\p{N}_])/giu,
+    target: { group: 'core' },
+  },
+  {
+    id: 'bitch',
+    pattern:
+      /(?<![\p{L}\p{N}_])(?<core>bitch)(?:es|ing|ed|y)?(?![\p{L}\p{N}_])/giu,
+    target: { group: 'core' },
+  },
+  {
+    id: 'asshole',
+    pattern:
+      /(?<![\p{L}\p{N}_])(?<core>asshole)s?(?![\p{L}\p{N}_])/giu,
+    target: { group: 'core' },
+  },
+  {
+    id: 'cunt',
+    pattern:
+      /(?<![\p{L}\p{N}_])(?<core>cunt)s?(?![\p{L}\p{N}_])/giu,
+    target: { group: 'core' },
+  },
+] as const;
+
+export const profanityRules = STRONG_PROFANITY_RULES;
+
+export function createScrawlix({
+  rules = STRONG_PROFANITY_RULES,
+  coverage = 'middle',
+}: ScrawlixOptions = {}): ScrawlixEngine {
+  const compiledRules: CompiledRule[] = rules.map(rule => ({
+    ...rule,
+    pattern: compilePattern(rule.pattern),
+  }));
+
+  return {
+    find(text) {
+      if (!text || compiledRules.length === 0) return [];
+      return scan(text, compiledRules).map(result => result.match);
+    },
+
+    segment(text) {
+      if (!text || compiledRules.length === 0) {
+        return [{ text, covered: false, ruleIds: [] }];
+      }
+
+      const matches = scan(text, compiledRules);
+      const coveredRanges = mergeCoveredRanges(
+        collectCoveredRanges(matches, coverage)
+      );
+      return segmentFromRanges(text, coveredRanges);
+    },
+  };
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'packages/*'
+  - 'apps/*'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "ES2022.Intl", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
Closes #1.

This is the first executable slice of Scrawlix: **programmable censorship for text and the web**.

### What this establishes

- pnpm/TypeScript workspace with `@scrawlix/core`
- compiled, caller-safe regex rules
- semantic target groups inside larger profanity matches
- `full`, `tail`, `middle`, `inner`, and `vowel` coverage presets
- custom coverage callbacks and per-rule overrides
- custom word/phrase rules with Unicode-aware boundaries
- overlap merging while retaining contributing rule IDs
- exact source-text preservation in segmentation
- an initial strong-profanity rule set inherited from the Scrapbook experiment
- tests for semantic targeting, presets, custom terms, Unicode boundaries, overlap, callback coverage, RegExp cursor preservation, and exact reconstruction
- CI for typecheck + tests

The intended behavior is already visible in the core API: `fuck`, `fucking`, and `motherfucker` can all target the semantic `fuck` core, so `middle` coverage yields `f██k`, `f██king`, and `motherf██ker` without treating the entire inflected token as an undifferentiated censor block.

Follow-up adapters are tracked in #2–#6.