### PR TITLE
Add React presets and interactive demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  core:
+  verify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,3 +18,4 @@ jobs:
       - run: pnpm install --no-frozen-lockfile
       - run: pnpm typecheck
       - run: pnpm test
+      - run: pnpm build

--- a/apps/demo/index.html
+++ b/apps/demo/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Scrawlix — programmable censorship for text and the web."
+    />
+    <meta name="theme-color" content="#f2eee5" />
+    <title>Scrawlix — programmable censorship</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "scrawlix-demo",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@scrawlix/core": "workspace:*",
+    "@scrawlix/react": "workspace:*",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.0.4",
+    "vite": "^7.1.7"
+  }
+}

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -1,0 +1,244 @@
+import { type CoveragePreset } from '@scrawlix/core';
+import {
+  CensoredText,
+  type ScrawlixAppearance,
+  type ScrawlixReveal,
+} from '@scrawlix/react';
+import { useMemo, useState } from 'react';
+
+const appearances: readonly ScrawlixAppearance[] = [
+  'scrawl',
+  'bar',
+  'blur',
+  'asterisk',
+  'grawlix',
+];
+
+const coverages: readonly CoveragePreset[] = [
+  'middle',
+  'vowel',
+  'inner',
+  'tail',
+  'full',
+];
+
+const reveals: readonly ScrawlixReveal[] = ['hover', 'focus', 'click', 'never'];
+
+const defaultText =
+  'This fucking delightful little thing can censor shit without flattening every word into the same black rectangle.';
+
+const specimens = [
+  'fuck',
+  'fucking',
+  'motherfucker',
+  'Well, shit. That actually works.',
+] as const;
+
+function SegmentControl<T extends string>({
+  label,
+  value,
+  values,
+  onChange,
+}: {
+  label: string;
+  value: T;
+  values: readonly T[];
+  onChange: (value: T) => void;
+}) {
+  return (
+    <fieldset className="control-group">
+      <legend>{label}</legend>
+      <div className="segmented-control">
+        {values.map(option => (
+          <button
+            className={option === value ? 'is-active' : ''}
+            key={option}
+            onClick={() => onChange(option)}
+            type="button"
+          >
+            {option}
+          </button>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+export function App() {
+  const [appearance, setAppearance] = useState<ScrawlixAppearance>('scrawl');
+  const [coverage, setCoverage] = useState<CoveragePreset>('middle');
+  const [reveal, setReveal] = useState<ScrawlixReveal>('hover');
+  const [text, setText] = useState(defaultText);
+
+  const code = useMemo(
+    () => `<CensoredText\n  text={copy}\n  coverage="${coverage}"\n  appearance="${appearance}"\n  reveal="${reveal}"\n/>`,
+    [appearance, coverage, reveal]
+  );
+
+  return (
+    <main>
+      <header className="masthead">
+        <a className="wordmark" href="#top" id="top" aria-label="Scrawlix home">
+          scrawlix<span aria-hidden="true">*</span>
+        </a>
+        <p>programmable censorship for text and the web</p>
+        <a
+          className="github-link"
+          href="https://github.com/teamleaderleo/scrawlix"
+          rel="noreferrer"
+          target="_blank"
+        >
+          GitHub ↗
+        </a>
+      </header>
+
+      <section className="hero" aria-labelledby="hero-title">
+        <div className="hero-copy">
+          <p className="eyebrow">01 / live proof</p>
+          <h1 id="hero-title">
+            Keep the word.
+            <br />
+            Choose the <em>damage.</em>
+          </h1>
+          <p className="lede">
+            Scrawlix finds the semantic core of a censored term, then lets you decide
+            which letters disappear and how they disappear.
+          </p>
+        </div>
+
+        <div className="proof-card">
+          <p className="proof-label">rendered output</p>
+          <div className="proof-output">
+            <CensoredText
+              appearance={appearance}
+              coverage={coverage}
+              reveal={reveal}
+              text={text}
+            />
+          </div>
+          <p className="proof-hint">
+            {reveal === 'hover' && 'hover the proof to reveal'}
+            {reveal === 'focus' && 'tab into the proof to reveal'}
+            {reveal === 'click' && 'click or press enter to toggle reveal'}
+            {reveal === 'never' && 'this proof stays censored'}
+          </p>
+        </div>
+      </section>
+
+      <section className="workbench" aria-label="Scrawlix controls">
+        <div className="controls-panel">
+          <SegmentControl
+            label="appearance"
+            onChange={setAppearance}
+            value={appearance}
+            values={appearances}
+          />
+          <SegmentControl
+            label="coverage"
+            onChange={setCoverage}
+            value={coverage}
+            values={coverages}
+          />
+          <SegmentControl
+            label="reveal"
+            onChange={setReveal}
+            value={reveal}
+            values={reveals}
+          />
+        </div>
+
+        <label className="text-editor">
+          <span>write something impolite</span>
+          <textarea
+            onChange={event => setText(event.target.value)}
+            rows={5}
+            spellCheck="true"
+            value={text}
+          />
+        </label>
+      </section>
+
+      <section className="specimen-section" aria-labelledby="specimen-title">
+        <div className="section-heading">
+          <p className="eyebrow">02 / specimen sheet</p>
+          <h2 id="specimen-title">Five ways to lose your fucking vowels.</h2>
+          <p>
+            Same matcher. Same coverage rule. Different presentation. Swap the visual
+            treatment without teaching your text parser anything new.
+          </p>
+        </div>
+
+        <div className="specimen-grid">
+          {appearances.map((style, index) => (
+            <article className="specimen-card" key={style}>
+              <header>
+                <span>{String(index + 1).padStart(2, '0')}</span>
+                <h3>{style}</h3>
+              </header>
+              <div className="specimen-list">
+                {specimens.map(sample => (
+                  <p key={sample}>
+                    <CensoredText
+                      appearance={style}
+                      coverage={coverage}
+                      reveal="hover"
+                      text={sample}
+                    />
+                  </p>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="semantic-section" aria-labelledby="semantic-title">
+        <div className="section-heading compact">
+          <p className="eyebrow">03 / the useful bit</p>
+          <h2 id="semantic-title">Censor the swear, keep the sentence.</h2>
+        </div>
+        <div className="semantic-grid">
+          <div className="semantic-example">
+            <span>fuck</span>
+            <span>→</span>
+            <strong>f██k</strong>
+          </div>
+          <div className="semantic-example">
+            <span>fucking</span>
+            <span>→</span>
+            <strong>f██king</strong>
+          </div>
+          <div className="semantic-example">
+            <span>motherfucker</span>
+            <span>→</span>
+            <strong>motherf██ker</strong>
+          </div>
+        </div>
+        <p className="semantic-note">
+          The matcher can target <code>fuck</code> inside an inflected or compound match,
+          so coverage operates on the semantic term instead of swallowing the whole token.
+        </p>
+      </section>
+
+      <section className="code-section" aria-labelledby="code-title">
+        <div>
+          <p className="eyebrow">04 / use it</p>
+          <h2 id="code-title">The component stays small.</h2>
+          <p>
+            Matching lives in <code>@scrawlix/core</code>. React only renders the ranges it
+            receives.
+          </p>
+        </div>
+        <pre>
+          <code>{code}</code>
+        </pre>
+      </section>
+
+      <footer>
+        <span>Scrawlix</span>
+        <span>made for words with sharp edges</span>
+        <a href="#top">back to top ↑</a>
+      </footer>
+    </main>
+  );
+}

--- a/apps/demo/src/main.tsx
+++ b/apps/demo/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import '@scrawlix/react/styles.css';
+import { App } from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/demo/src/styles.css
+++ b/apps/demo/src/styles.css
@@ -1,0 +1,532 @@
+:root {
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #171512;
+  background: #f2eee5;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background:
+    linear-gradient(rgba(23, 21, 18, 0.035) 1px, transparent 1px),
+    #f2eee5;
+  background-size: 100% 28px;
+}
+
+button,
+textarea {
+  font: inherit;
+}
+
+button,
+a {
+  color: inherit;
+}
+
+button:focus-visible,
+a:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid #171512;
+  outline-offset: 3px;
+}
+
+main {
+  width: min(1440px, 100%);
+  margin: 0 auto;
+  padding: 0 28px 48px;
+}
+
+.masthead {
+  min-height: 82px;
+  border-bottom: 1px solid #171512;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 24px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.wordmark {
+  justify-self: start;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: -0.06em;
+  text-decoration: none;
+  text-transform: lowercase;
+}
+
+.wordmark span {
+  display: inline-block;
+  margin-left: 2px;
+  transform: rotate(11deg);
+}
+
+.masthead p {
+  margin: 0;
+}
+
+.github-link {
+  justify-self: end;
+  text-underline-offset: 4px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+  gap: 58px;
+  padding: 92px 0 68px;
+  align-items: end;
+}
+
+.eyebrow,
+.proof-label,
+.control-group legend,
+.text-editor > span {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.eyebrow {
+  margin: 0 0 24px;
+}
+
+.hero h1,
+.section-heading h2,
+.code-section h2 {
+  font-family: Georgia, "Times New Roman", serif;
+  font-weight: 400;
+  letter-spacing: -0.065em;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(58px, 7.5vw, 116px);
+  line-height: 0.84;
+}
+
+.hero h1 em {
+  font-weight: 700;
+  text-decoration: line-through;
+  text-decoration-thickness: 0.08em;
+}
+
+.lede {
+  width: min(610px, 92%);
+  margin: 42px 0 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(19px, 1.8vw, 27px);
+  line-height: 1.35;
+}
+
+.proof-card {
+  min-height: 420px;
+  border: 2px solid #171512;
+  background: #fbf8f0;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 9px 9px 0 #171512;
+}
+
+.proof-label {
+  margin: 0;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #171512;
+}
+
+.proof-output {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  padding: 44px 8px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(32px, 4vw, 61px);
+  line-height: 1.08;
+  letter-spacing: -0.035em;
+}
+
+.proof-hint {
+  margin: 0;
+  padding-top: 14px;
+  border-top: 1px solid #171512;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.workbench {
+  border-block: 1px solid #171512;
+  padding: 28px 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 0.72fr);
+  gap: 40px;
+}
+
+.controls-panel {
+  display: grid;
+  gap: 24px;
+}
+
+.control-group {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.control-group legend {
+  margin-bottom: 9px;
+}
+
+.segmented-control {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.segmented-control button {
+  border: 1px solid #171512;
+  background: transparent;
+  padding: 9px 12px;
+  cursor: pointer;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.segmented-control button:hover,
+.segmented-control button.is-active {
+  background: #171512;
+  color: #f2eee5;
+}
+
+.text-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.text-editor textarea {
+  resize: vertical;
+  width: 100%;
+  min-height: 150px;
+  border: 1px solid #171512;
+  border-radius: 0;
+  background: #fbf8f0;
+  color: #171512;
+  padding: 16px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 20px;
+  line-height: 1.45;
+}
+
+.specimen-section,
+.semantic-section,
+.code-section {
+  padding: 86px 0;
+  border-bottom: 1px solid #171512;
+}
+
+.section-heading {
+  display: grid;
+  grid-template-columns: 160px minmax(0, 1fr) minmax(260px, 0.5fr);
+  align-items: end;
+  gap: 28px;
+  margin-bottom: 45px;
+}
+
+.section-heading .eyebrow {
+  align-self: start;
+  margin-top: 8px;
+}
+
+.section-heading h2,
+.code-section h2 {
+  margin: 0;
+  font-size: clamp(44px, 5.5vw, 82px);
+  line-height: 0.92;
+}
+
+.section-heading > p:last-child,
+.code-section > div > p:last-child,
+.semantic-note {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 18px;
+  line-height: 1.45;
+}
+
+.specimen-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border: 1px solid #171512;
+}
+
+.specimen-card {
+  min-width: 0;
+  min-height: 330px;
+  padding: 16px;
+  border-right: 1px solid #171512;
+  background: rgba(251, 248, 240, 0.55);
+}
+
+.specimen-card:last-child {
+  border-right: 0;
+}
+
+.specimen-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  border-bottom: 1px solid #171512;
+  padding-bottom: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  text-transform: uppercase;
+}
+
+.specimen-card h3 {
+  margin: 0;
+  font-size: 11px;
+}
+
+.specimen-card header span {
+  font-size: 9px;
+}
+
+.specimen-list {
+  padding-top: 26px;
+}
+
+.specimen-list p {
+  margin: 0 0 24px;
+  overflow-wrap: anywhere;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(22px, 2.1vw, 34px);
+  line-height: 1.05;
+}
+
+.section-heading.compact {
+  grid-template-columns: 160px 1fr;
+}
+
+.semantic-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-block: 1px solid #171512;
+}
+
+.semantic-example {
+  min-height: 150px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 16px;
+  padding: 24px;
+  border-right: 1px solid #171512;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: clamp(14px, 1.35vw, 20px);
+}
+
+.semantic-example:last-child {
+  border-right: 0;
+}
+
+.semantic-example strong {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(22px, 2.5vw, 39px);
+  letter-spacing: -0.04em;
+}
+
+.semantic-note {
+  width: min(760px, 100%);
+  margin-top: 28px;
+}
+
+code,
+pre {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.semantic-note code,
+.code-section p code {
+  border-bottom: 1px solid currentColor;
+  font-size: 0.82em;
+}
+
+.code-section {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(360px, 1fr);
+  gap: 64px;
+  align-items: end;
+}
+
+.code-section .eyebrow {
+  margin-bottom: 20px;
+}
+
+.code-section > div > p:last-child {
+  margin-top: 28px;
+  max-width: 570px;
+}
+
+.code-section pre {
+  margin: 0;
+  min-height: 290px;
+  background: #171512;
+  color: #f2eee5;
+  padding: 30px;
+  display: flex;
+  align-items: center;
+  overflow-x: auto;
+  box-shadow: 9px 9px 0 #cfc5b3;
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+footer {
+  min-height: 110px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: end;
+  gap: 24px;
+  padding-top: 42px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+footer a {
+  justify-self: end;
+  text-underline-offset: 4px;
+}
+
+@media (max-width: 1000px) {
+  .masthead {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .masthead p {
+    display: none;
+  }
+
+  .hero,
+  .workbench,
+  .code-section {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    padding-top: 64px;
+  }
+
+  .proof-card {
+    min-height: 340px;
+  }
+
+  .section-heading,
+  .section-heading.compact {
+    grid-template-columns: 1fr;
+  }
+
+  .section-heading .eyebrow {
+    margin-bottom: 0;
+  }
+
+  .specimen-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .specimen-card {
+    border-bottom: 1px solid #171512;
+  }
+
+  .semantic-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .semantic-example,
+  .semantic-example:last-child {
+    border-right: 0;
+    border-bottom: 1px solid #171512;
+  }
+
+  .semantic-example:last-child {
+    border-bottom: 0;
+  }
+}
+
+@media (max-width: 620px) {
+  main {
+    padding-inline: 16px;
+  }
+
+  .masthead {
+    min-height: 70px;
+  }
+
+  .wordmark {
+    font-size: 26px;
+  }
+
+  .github-link {
+    font-size: 9px;
+  }
+
+  .hero {
+    gap: 42px;
+  }
+
+  .hero h1 {
+    font-size: clamp(54px, 18vw, 78px);
+  }
+
+  .proof-card,
+  .code-section pre {
+    box-shadow: 5px 5px 0 #171512;
+  }
+
+  .proof-output {
+    font-size: 34px;
+  }
+
+  .specimen-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .specimen-card,
+  .specimen-card:last-child {
+    border-right: 0;
+    border-bottom: 1px solid #171512;
+  }
+
+  .specimen-card:last-child {
+    border-bottom: 0;
+  }
+
+  footer {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  footer span:nth-child(2) {
+    display: none;
+  }
+}

--- a/apps/demo/tsconfig.json
+++ b/apps/demo/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "scrawlix-workspace",
   "private": true,
   "scripts": {
-    "test": "pnpm --filter @scrawlix/core test",
-    "typecheck": "pnpm --filter @scrawlix/core typecheck"
+    "build": "pnpm --filter scrawlix-demo build",
+    "dev": "pnpm --filter scrawlix-demo dev",
+    "test": "pnpm -r --if-present test",
+    "typecheck": "pnpm -r --if-present typecheck"
   },
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,6 +14,10 @@
   "peerDependencies": {
     "react": ">=18"
   },
+  "devDependencies": {
+    "@types/react": "^19.2.7",
+    "react": "^19.2.1"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@scrawlix/react",
+  "version": "0.0.0",
+  "type": "module",
+  "sideEffects": ["./src/styles.css"],
+  "exports": {
+    ".": "./src/index.tsx",
+    "./styles.css": "./src/styles.css"
+  },
+  "types": "./src/index.tsx",
+  "dependencies": {
+    "@scrawlix/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  }
+}

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,0 +1,116 @@
+import {
+  createScrawlix,
+  type CensorRule,
+  type CoverageSelector,
+} from '@scrawlix/core';
+import { useMemo, useState, type KeyboardEvent } from 'react';
+
+export type ScrawlixAppearance =
+  | 'scrawl'
+  | 'bar'
+  | 'blur'
+  | 'asterisk'
+  | 'grawlix';
+
+export type ScrawlixReveal = 'hover' | 'focus' | 'click' | 'never';
+
+export type CensoredTextProps = {
+  text: string;
+  rules?: readonly CensorRule[];
+  coverage?: CoverageSelector;
+  appearance?: ScrawlixAppearance;
+  reveal?: ScrawlixReveal;
+  className?: string;
+  title?: string;
+};
+
+const GRAWLIX = '@#$%&!';
+
+function symbolsFor(text: string, appearance: ScrawlixAppearance) {
+  const characters = Array.from(text);
+  if (appearance === 'asterisk') return characters.map(() => '*').join('');
+  if (appearance === 'grawlix') {
+    return characters
+      .map((_, index) => GRAWLIX[index % GRAWLIX.length])
+      .join('');
+  }
+  return text;
+}
+
+export function CensoredText({
+  text,
+  rules,
+  coverage = 'middle',
+  appearance = 'scrawl',
+  reveal = 'hover',
+  className = '',
+  title = 'Censored text',
+}: CensoredTextProps) {
+  const engine = useMemo(
+    () => createScrawlix({ rules, coverage }),
+    [rules, coverage]
+  );
+  const segments = engine.segment(text);
+  const hasCoveredText = segments.some(segment => segment.covered);
+  const [revealed, setRevealed] = useState(false);
+
+  if (!hasCoveredText) return <>{text}</>;
+
+  const interactive = reveal === 'focus' || reveal === 'click';
+
+  function onKeyDown(event: KeyboardEvent<HTMLSpanElement>) {
+    if (reveal !== 'click') return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      setRevealed(value => !value);
+    }
+  }
+
+  return (
+    <span
+      aria-label={text}
+      className={className}
+      data-scrawlix-root
+      data-reveal={reveal}
+      data-revealed={revealed ? 'true' : 'false'}
+      tabIndex={interactive ? 0 : undefined}
+      onClick={reveal === 'click' ? () => setRevealed(value => !value) : undefined}
+      onKeyDown={onKeyDown}
+    >
+      {segments.map((segment, index) => {
+        if (!segment.covered) {
+          return (
+            <span aria-hidden="true" key={`${index}-${segment.text}`}>
+              {segment.text}
+            </span>
+          );
+        }
+
+        const symbolAppearance =
+          appearance === 'asterisk' || appearance === 'grawlix';
+
+        return (
+          <span
+            aria-hidden="true"
+            data-scrawlix-cover
+            data-appearance={appearance}
+            data-rules={segment.ruleIds.join(',')}
+            key={`${index}-${segment.text}`}
+            title={title}
+          >
+            {symbolAppearance ? (
+              <>
+                <span data-scrawlix-mask>
+                  {symbolsFor(segment.text, appearance)}
+                </span>
+                <span data-scrawlix-source>{segment.text}</span>
+              </>
+            ) : (
+              segment.text
+            )}
+          </span>
+        );
+      })}
+    </span>
+  );
+}

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1,0 +1,86 @@
+[data-scrawlix-root] {
+  --scrawlix-soft-ink: color-mix(in srgb, currentColor 24%, transparent);
+  --scrawlix-fuzzy-ink: color-mix(in srgb, currentColor 58%, transparent);
+}
+
+[data-scrawlix-root]:focus-visible {
+  outline: 1px solid currentColor;
+  outline-offset: 0.2em;
+  border-radius: 0.12em;
+}
+
+[data-scrawlix-cover] {
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  display: inline;
+  position: relative;
+  transition:
+    filter 140ms ease,
+    background 140ms ease,
+    text-shadow 140ms ease,
+    -webkit-text-fill-color 140ms ease;
+}
+
+[data-scrawlix-cover][data-appearance='scrawl'] {
+  -webkit-text-fill-color: transparent;
+  background: repeating-linear-gradient(
+    -13deg,
+    var(--scrawlix-soft-ink) 0 0.08em,
+    transparent 0.08em 0.18em
+  );
+  border-radius: 0.18em;
+  padding-inline: 0.04em;
+  text-shadow: 0 0 0.34em var(--scrawlix-fuzzy-ink);
+}
+
+[data-scrawlix-cover][data-appearance='bar'] {
+  -webkit-text-fill-color: transparent;
+  background: linear-gradient(currentColor, currentColor) center / 100% 0.72em no-repeat;
+  border-radius: 0.06em;
+}
+
+[data-scrawlix-cover][data-appearance='blur'] {
+  filter: blur(0.17em);
+  user-select: none;
+}
+
+[data-scrawlix-cover][data-appearance='asterisk'],
+[data-scrawlix-cover][data-appearance='grawlix'] {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.92em;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+
+[data-scrawlix-source] {
+  display: none;
+}
+
+[data-scrawlix-root][data-reveal='hover']:hover [data-scrawlix-cover],
+[data-scrawlix-root][data-reveal='focus']:focus [data-scrawlix-cover],
+[data-scrawlix-root][data-reveal='click'][data-revealed='true'] [data-scrawlix-cover] {
+  -webkit-text-fill-color: currentColor;
+  background: none;
+  filter: none;
+  padding-inline: 0;
+  text-shadow: none;
+  user-select: text;
+}
+
+[data-scrawlix-root][data-reveal='hover']:hover [data-scrawlix-mask],
+[data-scrawlix-root][data-reveal='focus']:focus [data-scrawlix-mask],
+[data-scrawlix-root][data-reveal='click'][data-revealed='true'] [data-scrawlix-mask] {
+  display: none;
+}
+
+[data-scrawlix-root][data-reveal='hover']:hover [data-scrawlix-source],
+[data-scrawlix-root][data-reveal='focus']:focus [data-scrawlix-source],
+[data-scrawlix-root][data-reveal='click'][data-revealed='true'] [data-scrawlix-source] {
+  display: inline;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-scrawlix-cover] {
+    transition: none;
+  }
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}


### PR DESCRIPTION
Closes #2.

Progresses #8 with a deploy-ready Vite demo app.

### React adapter
- `CensoredText` powered entirely by `@scrawlix/core`
- `scrawl`, `bar`, `blur`, `asterisk`, and `grawlix` appearances
- `hover`, `focus`, `click`, and `never` reveal modes
- keyboard-toggleable click reveal
- accessible source text without duplicate spoken fragments
- reduced-motion support

### Demo
- live editable proof
- appearance, coverage, and reveal controls
- five-style specimen sheet
- semantic `fuck` / `fucking` / `motherfucker` examples
- live API snippet
- responsive editorial proof-sheet styling
- Vite static build suitable for Vercel or GitHub Pages

CI now verifies the workspace, core tests, React/demo typechecking, and the production demo build.

The remaining part of #8 is the public deployment URL.