### PR TITLE
Make the demo turnkey for Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ That means the same word can become `████`, `f███`, `f██k`, `f
 
 Scrawlix began as a censor/reveal primitive in [Scrapbook](https://github.com/teamleaderleo/scrapbook). The standalone project turns that experiment into a small framework-independent engine with adapters for React, Markdown, the DOM, and eventually a browser extension.
 
-## Direction
+## Core
 
 ```ts
 import { createScrawlix, profanityRules } from '@scrawlix/core';
@@ -26,7 +26,46 @@ const scrawlix = createScrawlix({
 scrawlix.segment('what the fuck');
 ```
 
-The core stays independent of React and browser APIs. Presentation belongs to adapters.
+The core understands semantic targets inside larger matches, so `fuck`, `fucking`, and `motherfucker` can all apply coverage specifically to the `fuck` portion.
+
+## React
+
+```tsx
+import { CensoredText } from '@scrawlix/react';
+import '@scrawlix/react/styles.css';
+
+<CensoredText
+  text="what the fuck"
+  coverage="middle"
+  appearance="scrawl"
+  reveal="hover"
+/>;
+```
+
+Current appearances: `scrawl`, `bar`, `blur`, `asterisk`, and `grawlix`.
+
+Current reveal modes: `hover`, `focus`, `click`, and `never`.
+
+## Demo
+
+The interactive demo lives in `apps/demo`. It is a small Vite app that consumes the workspace packages exactly like an external React application would.
+
+```sh
+pnpm install
+pnpm dev
+```
+
+The demo includes an editable live proof, coverage and reveal controls, a five-style specimen sheet, semantic-match examples, and a live component snippet.
+
+### Vercel
+
+The repository includes `vercel.json` at the root. Importing the Git repository into Vercel uses:
+
+- install: `pnpm install --no-frozen-lockfile`
+- build: `pnpm build`
+- output: `apps/demo/dist`
+
+No server runtime is required; the demo builds to static assets.
 
 ## Roadmap
 
@@ -36,6 +75,7 @@ The core stays independent of React and browser APIs. Presentation belongs to ad
 - [DOM adapter](https://github.com/teamleaderleo/scrawlix/issues/4)
 - [Browser extension](https://github.com/teamleaderleo/scrawlix/issues/5)
 - [Scrapbook adoption](https://github.com/teamleaderleo/scrawlix/issues/6)
+- [Interactive demo and deployment](https://github.com/teamleaderleo/scrawlix/issues/8)
 
 ## Status
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "installCommand": "pnpm install --no-frozen-lockfile",
+  "buildCommand": "pnpm build",
+  "outputDirectory": "apps/demo/dist"
+}


### PR DESCRIPTION
Progresses #8.

- adds root `vercel.json`
- builds the workspace demo with `pnpm build`
- serves `apps/demo/dist` as static output
- promotes the React adapter and demo into the README
- documents local demo development and Vercel import settings

The connected Vercel project-discovery/deploy actions are currently returning connector errors, so #8 stays open until there is a public deployment URL.