### PR TITLE
Make Scrawlix language-neutral and add English corpora

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,98 @@
+# AGENTS.md
+
+This file is the maintainer map for humans and coding agents working on Scrawlix.
+
+## Mission
+
+Scrawlix is programmable censorship for text and the web. Keep four concerns independent:
+
+1. matching — find a semantic term or phrase
+2. coverage — choose which part of that semantic target is covered
+3. appearance — render the covered range
+4. reveal — decide when the source becomes visible
+
+A change in one layer should rarely require logic in another.
+
+## Workspace map
+
+- `packages/core` — language-neutral matching, segmentation, generic coverage, custom-word helpers
+- `packages/en` — English profanity rules, English-specific coverage helpers, English regression corpus
+- `packages/react` — React renderer and appearance/reveal behavior
+- `apps/demo` — public interactive proof sheet and integration consumer
+- `docs` — design and extension guidance
+
+Planned adapters are tracked in GitHub issues for rehype/Markdown, arbitrary DOM, browser extension, and Scrapbook adoption.
+
+## Commands
+
+Run these before opening or merging a PR:
+
+```sh
+pnpm install
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+The demo build is part of the workspace build and acts as an integration check across core, language packs, and React.
+
+## Invariants
+
+### Preserve source text exactly
+
+`engine.segment(text).map(segment => segment.text).join('')` must always equal the original `text` byte-for-byte at the JavaScript string level. Rendering may obscure glyphs; matching must never rewrite the caller's source.
+
+### Keep core language-neutral
+
+Do not add profanity lists, locale-specific morphology, or language-specific character classification to `@scrawlix/core`. Put those in a language/rule pack.
+
+Generic coverage belongs in core. A behavior such as “cover English vowels” belongs in `@scrawlix/en`.
+
+### Require deliberate rule selection
+
+`createScrawlix()` with zero rules is a no-op. Adapters should receive rules explicitly. Avoid hidden language detection or surprise bundled moderation behavior.
+
+### Preserve caller-owned RegExp state
+
+The engine compiles its own RegExp copies. Never mutate a caller's `lastIndex`. Repeated `find()` / `segment()` calls on the same engine must be stable.
+
+### Keep semantic targets explicit
+
+When a larger match contains the meaningful censored core, use a named capture group and `target: { group: '...' }`. Coverage should operate on the target, not blindly on the full inflected or compound match.
+
+### Treat accessibility as source truth
+
+Visual fragments are decorative. React currently exposes the full source once through `aria-label` and hides rendered fragments from assistive tech. Preserve a single accessible reading of the source and avoid duplicate speech.
+
+### Add corpus cases for learned linguistic behavior
+
+When a bug or rule change teaches a durable positive or false-positive example, add it to the relevant pack corpus. Prefer data cases over one-off matcher test code.
+
+## Adding a language pack
+
+1. Create `packages/<locale-or-pack-name>` with a dependency on `@scrawlix/core`.
+2. Export one or more `CensorRule[]` collections and a `CensorRulePack` value with locale metadata.
+3. Keep morphology and language-specific coverage helpers inside that package.
+4. Add a reviewable positive corpus and a clean/false-positive corpus.
+5. Test semantic target text, casing, punctuation, compounds/inflections, and known ambiguity.
+6. For phrase lists that can sit beside other letters, use `censorRuleFromWords(..., { boundary: 'substring' })` deliberately.
+7. Document dialect/severity assumptions. Do not imply complete language coverage from a small pack.
+
+## Adding a visual appearance
+
+1. Add the appearance name to `ScrawlixAppearance` in `packages/react`.
+2. Keep matching logic out of React.
+3. Prefer CSS/data-attribute presentation over rebuilding source strings.
+4. Add the appearance to the demo specimen sheet.
+5. Preserve reveal modes and reduced-motion behavior.
+6. Add rendered/visual regression coverage when issue #11 lands that layer.
+
+## Adding a coverage behavior
+
+Ask whether the behavior is language-neutral. Generic positional coverage may live in core. Character classes, syllables, morphology, or locale-specific rules belong in a pack and can be implemented as `CoverageSelector` callbacks.
+
+## Public API discipline
+
+Scrawlix is pre-release, so breaking changes are still possible. Use that freedom to remove surprising defaults and awkward names early. Once packages are published, favor additive changes and explicit deprecation paths.
+
+Before the first public release, issue #13 requires packed-package smoke tests so external consumers receive compiled JavaScript, declarations, CSS exports, and valid package metadata rather than workspace-only source imports.

--- a/README.md
+++ b/README.md
@@ -11,31 +11,36 @@ Scrawlix separates the interesting parts of censorship so they can be mixed deli
 
 That means the same word can become `████`, `f███`, `f██k`, `f█ck`, `f**k`, a blur, an inked-over scrawl, or a grawlix — while callers keep control of the underlying source text.
 
-Scrawlix began as a censor/reveal primitive in [Scrapbook](https://github.com/teamleaderleo/scrapbook). The standalone project turns that experiment into a small framework-independent engine with adapters for React, Markdown, the DOM, and eventually a browser extension.
+Scrawlix began as a censor/reveal primitive in [Scrapbook](https://github.com/teamleaderleo/scrapbook). The standalone project turns that experiment into a small language-neutral engine with rule packs and adapters for React, Markdown, the DOM, and eventually a browser extension.
 
-## Core
+## Quick start
+
+Scrawlix does not choose a language for you. Pick a rule pack explicitly:
 
 ```ts
-import { createScrawlix, profanityRules } from '@scrawlix/core';
+import { createScrawlix } from '@scrawlix/core';
+import { englishProfanityRules } from '@scrawlix/en';
 
 const scrawlix = createScrawlix({
-  rules: profanityRules,
+  rules: englishProfanityRules,
   coverage: 'middle',
 });
 
 scrawlix.segment('what the fuck');
 ```
 
-The core understands semantic targets inside larger matches, so `fuck`, `fucking`, and `motherfucker` can all apply coverage specifically to the `fuck` portion.
+The English pack understands semantic targets inside larger matches, so `fuck`, `fucking`, and `motherfucker` can all apply coverage specifically to the `fuck` portion.
 
 ## React
 
 ```tsx
+import { englishProfanityRules } from '@scrawlix/en';
 import { CensoredText } from '@scrawlix/react';
 import '@scrawlix/react/styles.css';
 
 <CensoredText
   text="what the fuck"
+  rules={englishProfanityRules}
   coverage="middle"
   appearance="scrawl"
   reveal="hover"
@@ -45,6 +50,39 @@ import '@scrawlix/react/styles.css';
 Current appearances: `scrawl`, `bar`, `blur`, `asterisk`, and `grawlix`.
 
 Current reveal modes: `hover`, `focus`, `click`, and `never`.
+
+## Custom words and phrases
+
+Profanity is only one rule pack. Callers can censor names, spoilers, codenames, or arbitrary phrases:
+
+```ts
+import { censorRuleFromWords, createScrawlix } from '@scrawlix/core';
+
+const privateTerms = censorRuleFromWords('private', [
+  'Project Velvet',
+  'Mothbit',
+]);
+
+const censor = createScrawlix({
+  rules: [privateTerms],
+  coverage: 'full',
+});
+```
+
+`censorRuleFromWords` uses Unicode-aware word boundaries by default. Packs for scripts where matches can sit directly beside other letters can opt into `boundary: 'substring'`.
+
+## Language packs
+
+`@scrawlix/core` owns matching mechanics and generic coverage (`full`, `tail`, `middle`, `inner`). Linguistic assumptions live in packages such as `@scrawlix/en`.
+
+The English package currently exports:
+
+- `englishProfanityRules`
+- `englishStrongProfanityPack`
+- `englishVowelCoverage`
+- a small regression corpus at `@scrawlix/en/corpus`
+
+Future language packs can carry their own rules, locale metadata, coverage helpers, and regression corpora. Consumers can combine packs with `rulesFromPacks(...)`. See `docs/language-packs.md`.
 
 ## Demo
 
@@ -67,6 +105,18 @@ The repository includes `vercel.json` at the root. Importing the Git repository 
 
 No server runtime is required; the demo builds to static assets.
 
+## Contributing
+
+Run the whole workspace with:
+
+```sh
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+`AGENTS.md` is the maintainer/agent map: package responsibilities, invariants, commands, and extension rules. Corpus regressions should be data-first: when a matcher bug teaches us a durable example, add that example to the relevant language corpus.
+
 ## Roadmap
 
 - [Core engine: matching, semantic targets, and coverage](https://github.com/teamleaderleo/scrawlix/issues/1)
@@ -76,6 +126,9 @@ No server runtime is required; the demo builds to static assets.
 - [Browser extension](https://github.com/teamleaderleo/scrawlix/issues/5)
 - [Scrapbook adoption](https://github.com/teamleaderleo/scrawlix/issues/6)
 - [Interactive demo and deployment](https://github.com/teamleaderleo/scrawlix/issues/8)
+- [Corpus-driven regressions](https://github.com/teamleaderleo/scrawlix/issues/11)
+- [Language packs](https://github.com/teamleaderleo/scrawlix/issues/12)
+- [Human and agent adoption ergonomics](https://github.com/teamleaderleo/scrawlix/issues/13)
 
 ## Status
 

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@scrawlix/core": "workspace:*",
+    "@scrawlix/en": "workspace:*",
     "@scrawlix/react": "workspace:*",
     "react": "^19.2.1",
     "react-dom": "^19.2.1"

--- a/apps/demo/public/llms.txt
+++ b/apps/demo/public/llms.txt
@@ -1,0 +1,48 @@
+# Scrawlix
+
+Scrawlix is programmable censorship for text and the web. It separates matching, coverage, appearance, and reveal behavior while preserving the caller's original source text.
+
+Source: https://github.com/teamleaderleo/scrawlix
+
+Packages:
+- @scrawlix/core — language-neutral matching and segmentation
+- @scrawlix/en — English profanity rules, English vowel coverage, regression corpus
+- @scrawlix/react — React renderer and visual/reveal presets
+
+Canonical React usage:
+
+```tsx
+import { englishProfanityRules } from '@scrawlix/en';
+import { CensoredText } from '@scrawlix/react';
+import '@scrawlix/react/styles.css';
+
+<CensoredText
+  text="what the fuck"
+  rules={englishProfanityRules}
+  coverage="middle"
+  appearance="scrawl"
+  reveal="hover"
+/>
+```
+
+Canonical core usage:
+
+```ts
+import { createScrawlix } from '@scrawlix/core';
+import { englishProfanityRules } from '@scrawlix/en';
+
+const engine = createScrawlix({
+  rules: englishProfanityRules,
+  coverage: 'middle',
+});
+```
+
+Core is deliberately language-neutral. Select language/rule packs explicitly; do not assume automatic language detection. Custom names, spoilers, and phrases can be supplied with `censorRuleFromWords()`.
+
+Generic coverage presets: full, tail, middle, inner.
+English-specific helper: englishVowelCoverage.
+React appearances: scrawl, bar, blur, asterisk, grawlix.
+React reveal modes: hover, focus, click, never.
+
+Maintainer guidance: https://github.com/teamleaderleo/scrawlix/blob/main/AGENTS.md
+Language packs: https://github.com/teamleaderleo/scrawlix/blob/main/docs/language-packs.md

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -1,4 +1,8 @@
-import { type CoveragePreset } from '@scrawlix/core';
+import { type CoveragePreset, type CoverageSelector } from '@scrawlix/core';
+import {
+  englishProfanityRules,
+  englishVowelCoverage,
+} from '@scrawlix/en';
 import {
   CensoredText,
   type ScrawlixAppearance,
@@ -14,7 +18,9 @@ const appearances: readonly ScrawlixAppearance[] = [
   'grawlix',
 ];
 
-const coverages: readonly CoveragePreset[] = [
+type CoverageChoice = CoveragePreset | 'vowel';
+
+const coverages: readonly CoverageChoice[] = [
   'middle',
   'vowel',
   'inner',
@@ -33,6 +39,10 @@ const specimens = [
   'motherfucker',
   'Well, shit. That actually works.',
 ] as const;
+
+function selectorForCoverage(coverage: CoverageChoice): CoverageSelector {
+  return coverage === 'vowel' ? englishVowelCoverage : coverage;
+}
 
 function SegmentControl<T extends string>({
   label,
@@ -66,14 +76,19 @@ function SegmentControl<T extends string>({
 
 export function App() {
   const [appearance, setAppearance] = useState<ScrawlixAppearance>('scrawl');
-  const [coverage, setCoverage] = useState<CoveragePreset>('middle');
+  const [coverage, setCoverage] = useState<CoverageChoice>('middle');
   const [reveal, setReveal] = useState<ScrawlixReveal>('hover');
   const [text, setText] = useState(defaultText);
+  const coverageSelector = selectorForCoverage(coverage);
 
-  const code = useMemo(
-    () => `<CensoredText\n  text={copy}\n  coverage="${coverage}"\n  appearance="${appearance}"\n  reveal="${reveal}"\n/>`,
-    [appearance, coverage, reveal]
-  );
+  const code = useMemo(() => {
+    const coverageLine =
+      coverage === 'vowel'
+        ? '  coverage={englishVowelCoverage}'
+        : `  coverage="${coverage}"`;
+
+    return `import { englishProfanityRules${coverage === 'vowel' ? ', englishVowelCoverage' : ''} } from '@scrawlix/en';\nimport { CensoredText } from '@scrawlix/react';\n\n<CensoredText\n  text={copy}\n  rules={englishProfanityRules}\n${coverageLine}\n  appearance="${appearance}"\n  reveal="${reveal}"\n/>`;
+  }, [appearance, coverage, reveal]);
 
   return (
     <main>
@@ -111,8 +126,9 @@ export function App() {
           <div className="proof-output">
             <CensoredText
               appearance={appearance}
-              coverage={coverage}
+              coverage={coverageSelector}
               reveal={reveal}
+              rules={englishProfanityRules}
               text={text}
             />
           </div>
@@ -180,8 +196,9 @@ export function App() {
                   <p key={sample}>
                     <CensoredText
                       appearance={style}
-                      coverage={coverage}
+                      coverage={coverageSelector}
                       reveal="hover"
+                      rules={englishProfanityRules}
                       text={sample}
                     />
                   </p>
@@ -215,18 +232,19 @@ export function App() {
           </div>
         </div>
         <p className="semantic-note">
-          The matcher can target <code>fuck</code> inside an inflected or compound match,
-          so coverage operates on the semantic term instead of swallowing the whole token.
+          The English pack targets <code>fuck</code> inside an inflected or compound
+          match, so coverage operates on the semantic term instead of swallowing the
+          whole token.
         </p>
       </section>
 
       <section className="code-section" aria-labelledby="code-title">
         <div>
           <p className="eyebrow">04 / use it</p>
-          <h2 id="code-title">The component stays small.</h2>
+          <h2 id="code-title">Pick the language. Pick the damage.</h2>
           <p>
-            Matching lives in <code>@scrawlix/core</code>. React only renders the ranges it
-            receives.
+            Matching rules live in explicit language or custom packs. The core stays
+            neutral; React only renders the ranges it receives.
           </p>
         </div>
         <pre>

--- a/docs/language-packs.md
+++ b/docs/language-packs.md
@@ -1,0 +1,106 @@
+# Language packs
+
+Scrawlix keeps linguistic knowledge outside `@scrawlix/core`.
+
+The core knows how to execute rules, preserve semantic target ranges, apply coverage, merge overlaps, and return source-preserving segments. A language pack decides which terms exist, how they inflect or combine, and which language-specific coverage helpers make sense.
+
+## Minimal pack
+
+```ts
+import type { CensorRulePack } from '@scrawlix/core';
+
+export const examplePack: CensorRulePack = {
+  id: 'xx-example',
+  locale: 'xx',
+  rules: [
+    {
+      id: 'example-term',
+      pattern: /.../giu,
+    },
+  ],
+};
+```
+
+Consumers can combine packs explicitly:
+
+```ts
+import { createScrawlix, rulesFromPacks } from '@scrawlix/core';
+import { englishStrongProfanityPack } from '@scrawlix/en';
+
+const engine = createScrawlix({
+  rules: rulesFromPacks(englishStrongProfanityPack, myPrivateTermsPack),
+  coverage: 'middle',
+});
+```
+
+Scrawlix deliberately avoids automatic language detection. Applications know more about their content and can choose one pack, several packs, or caller-authored rules.
+
+## Boundaries
+
+`censorRuleFromWords()` defaults to `boundary: 'word'`, using Unicode letter/number-aware lookarounds. This works well for many whitespace-delimited words and prevents substring false positives such as a short term firing inside a longer ordinary word.
+
+Some scripts and phrase lists need direct substring matching:
+
+```ts
+const rule = censorRuleFromWords('ja-example', ['くそ'], {
+  boundary: 'substring',
+});
+```
+
+`substring` means exactly that: a listed phrase may match while adjacent to other letters. A language pack should choose it deliberately and carry regression cases that demonstrate expected behavior.
+
+Future packs may need richer tokenization than either mode. Add that capability when a real corpus demonstrates the need; keep the simple path small.
+
+## Semantic targets
+
+A rule can match a larger inflection or compound while identifying the semantic core with a named capture group:
+
+```ts
+const rule = {
+  id: 'example',
+  pattern: /prefix(?<core>term)suffix/giu,
+  target: { group: 'core' },
+};
+```
+
+Coverage runs against `core`, while `find()` still reports the full match and both full/target ranges.
+
+## Coverage helpers
+
+Core coverage presets are positional and language-neutral:
+
+- `full`
+- `tail`
+- `middle`
+- `inner`
+
+Language-specific character classes belong in packs. `@scrawlix/en`, for example, exports `englishVowelCoverage` as a `CoverageSelector` callback instead of teaching core what an English vowel is.
+
+A pack can export several named helpers without changing the core API.
+
+## Corpora
+
+Every language pack should grow a small, reviewable regression corpus alongside its rules. A useful corpus contains:
+
+- positive matches
+- expected semantic targets
+- casing and punctuation variants
+- compounds and inflections
+- false-positive traps
+- Unicode context
+- dialect or severity cases when relevant
+
+Keep corpus entries simple enough to add during a bug fix. The English pack exports its current corpus from `@scrawlix/en/corpus` and uses the same data directly in tests.
+
+A corpus is evidence about expected behavior, not a claim of linguistic completeness. Pack docs should say which dialect, register, severity band, and edge cases the pack intentionally covers.
+
+## Naming and scope
+
+Prefer narrowly described packs over giant universal lists. Examples:
+
+- `en-strong-profanity`
+- `en-mild-profanity`
+- `ja-example-profanity`
+- an application-owned private-name pack
+
+A caller can compose several packs. Smaller packs keep policy choices visible and make corpus regressions easier to understand.

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -2,9 +2,17 @@ import { describe, expect, it } from 'vitest';
 import {
   censorRuleFromWords,
   createScrawlix,
-  STRONG_PROFANITY_RULES,
+  rulesFromPacks,
+  type CensorRule,
   type ScrawlixSegment,
 } from './index';
+
+const semanticRule: CensorRule = {
+  id: 'semantic-test',
+  pattern:
+    /(?<![\p{L}\p{N}_])(?:mother)?(?<core>fuck)(?:ing|ed|er|ers|s)?(?![\p{L}\p{N}_])/giu,
+  target: { group: 'core' },
+};
 
 function marked(segments: readonly ScrawlixSegment[]) {
   return segments
@@ -12,9 +20,23 @@ function marked(segments: readonly ScrawlixSegment[]) {
     .join('');
 }
 
+function source(segments: readonly ScrawlixSegment[]) {
+  return segments.map(segment => segment.text).join('');
+}
+
 describe('Scrawlix core', () => {
-  it('covers the semantic profanity core instead of the whole inflected match', () => {
-    const scrawlix = createScrawlix({ coverage: 'middle' });
+  it('is language-neutral and does nothing until rules are supplied', () => {
+    expect(createScrawlix().segment('fuck')).toEqual([
+      { text: 'fuck', covered: false, ruleIds: [] },
+    ]);
+    expect(createScrawlix().find('fuck')).toEqual([]);
+  });
+
+  it('covers a semantic target inside a larger match', () => {
+    const scrawlix = createScrawlix({
+      rules: [semanticRule],
+      coverage: 'middle',
+    });
 
     expect(marked(scrawlix.segment('fuck fucking motherfucker'))).toBe(
       'f[uc]k f[uc]king motherf[uc]ker'
@@ -22,7 +44,7 @@ describe('Scrawlix core', () => {
 
     expect(scrawlix.find('motherfucker')).toEqual([
       {
-        ruleId: 'fuck',
+        ruleId: 'semantic-test',
         text: 'motherfucker',
         start: 0,
         end: 12,
@@ -38,9 +60,8 @@ describe('Scrawlix core', () => {
     ['tail', 'f[uck]'],
     ['middle', 'f[uc]k'],
     ['inner', 'f[uc]k'],
-    ['vowel', 'f[u]ck'],
   ] as const)('supports the %s coverage preset', (coverage, expected) => {
-    const scrawlix = createScrawlix({ coverage });
+    const scrawlix = createScrawlix({ rules: [semanticRule], coverage });
     expect(marked(scrawlix.segment('fuck'))).toBe(expected);
   });
 
@@ -67,7 +88,7 @@ describe('Scrawlix core', () => {
     );
   });
 
-  it('uses Unicode-aware boundaries for custom words', () => {
+  it('uses Unicode-aware word boundaries for custom words', () => {
     const cafe = censorRuleFromWords('cafe', ['café']);
     const scrawlix = createScrawlix({ rules: [cafe], coverage: 'full' });
 
@@ -76,25 +97,50 @@ describe('Scrawlix core', () => {
     );
   });
 
+  it('supports substring boundary mode for scripts without whitespace-delimited words', () => {
+    const japanesePhrase = censorRuleFromWords('ja-example', ['くそ'], {
+      boundary: 'substring',
+    });
+    const scrawlix = createScrawlix({
+      rules: [japanesePhrase],
+      coverage: 'full',
+    });
+
+    expect(marked(scrawlix.segment('これはくそだ'))).toBe('これは[くそ]だ');
+  });
+
   it('does not mutate caller-owned RegExp cursors', () => {
-    const pattern = /fuck/gi;
+    const pattern = /secret/gi;
     pattern.lastIndex = 2;
     const scrawlix = createScrawlix({
       rules: [{ id: 'test', pattern }],
       coverage: 'full',
     });
 
-    scrawlix.segment('fuck fuck');
+    scrawlix.segment('secret secret');
 
     expect(pattern.lastIndex).toBe(2);
   });
 
+  it('does not leak compiled RegExp cursor state between calls', () => {
+    const scrawlix = createScrawlix({
+      rules: [censorRuleFromWords('secret', ['secret'])],
+      coverage: 'full',
+    });
+
+    const first = scrawlix.segment('secret secret');
+    const second = scrawlix.segment('secret secret');
+    const afterFind = scrawlix.find('secret secret');
+    const third = scrawlix.segment('secret secret');
+
+    expect(second).toEqual(first);
+    expect(afterFind).toHaveLength(2);
+    expect(third).toEqual(first);
+  });
+
   it('merges overlapping covered ranges and keeps contributing rule ids', () => {
     const scrawlix = createScrawlix({
-      rules: [
-        ...STRONG_PROFANITY_RULES,
-        { id: 'whole', pattern: /motherfucker/gi },
-      ],
+      rules: [semanticRule, { id: 'whole', pattern: /motherfucker/gi }],
       coverage: 'full',
     });
 
@@ -104,11 +150,15 @@ describe('Scrawlix core', () => {
       text: 'motherfucker',
       covered: true,
     });
-    expect([...segments[0]!.ruleIds].sort()).toEqual(['fuck', 'whole']);
+    expect([...segments[0]!.ruleIds].sort()).toEqual([
+      'semantic-test',
+      'whole',
+    ]);
   });
 
   it('allows a coverage callback', () => {
     const scrawlix = createScrawlix({
+      rules: [semanticRule],
       coverage: context => [
         {
           start: 1,
@@ -121,25 +171,80 @@ describe('Scrawlix core', () => {
   });
 
   it('lets a rule override the engine coverage', () => {
-    const rule = {
-      ...STRONG_PROFANITY_RULES[0]!,
-      coverage: 'vowel' as const,
+    const rule: CensorRule = {
+      ...semanticRule,
+      coverage: context => [{ start: 1, end: context.targetText.length - 1 }],
     };
     const scrawlix = createScrawlix({ rules: [rule], coverage: 'full' });
 
-    expect(marked(scrawlix.segment('fuck'))).toBe('f[u]ck');
+    expect(marked(scrawlix.segment('fuck'))).toBe('f[uc]k');
   });
 
-  it('reconstructs the original input exactly from segments', () => {
-    const text = '🔥 Fuck this shit — exactly as written.';
-    const segments = createScrawlix({ coverage: 'vowel' }).segment(text);
+  it('combines explicit rule packs', () => {
+    const privatePack = {
+      id: 'private',
+      rules: [censorRuleFromWords('private', ['Velvet'])],
+    };
+    const spoilerPack = {
+      id: 'spoiler',
+      rules: [censorRuleFromWords('spoiler', ['Rosebud'])],
+    };
+    const scrawlix = createScrawlix({
+      rules: rulesFromPacks(privatePack, spoilerPack),
+      coverage: 'full',
+    });
 
-    expect(segments.map(segment => segment.text).join('')).toBe(text);
+    expect(marked(scrawlix.segment('Velvet and Rosebud'))).toBe(
+      '[Velvet] and [Rosebud]'
+    );
   });
 
-  it('returns ordinary text when there are no rules', () => {
-    expect(createScrawlix({ rules: [] }).segment('fuck')).toEqual([
-      { text: 'fuck', covered: false, ruleIds: [] },
-    ]);
+  it('preserves core segmentation invariants across deterministic fuzz cases', () => {
+    const scrawlix = createScrawlix({
+      rules: [
+        censorRuleFromWords('bad', ['bad']),
+        censorRuleFromWords('secret', ['secret']),
+      ],
+      coverage: 'middle',
+    });
+
+    let state = 0x5c12a11;
+    const next = () => {
+      state = (state * 1664525 + 1013904223) >>> 0;
+      return state;
+    };
+    const atoms = [
+      'bad',
+      'secret',
+      'good',
+      '🔥',
+      ' café ',
+      '—',
+      'word',
+      '\n',
+      ' BAD ',
+    ] as const;
+
+    for (let caseIndex = 0; caseIndex < 250; caseIndex += 1) {
+      const atomCount = (next() % 16) + 1;
+      let text = '';
+      for (let atomIndex = 0; atomIndex < atomCount; atomIndex += 1) {
+        text += atoms[next() % atoms.length];
+      }
+
+      const first = scrawlix.segment(text);
+      const second = scrawlix.segment(text);
+
+      expect(source(first)).toBe(text);
+      expect(second).toEqual(first);
+      for (const segment of first) {
+        expect(segment.text.length).toBeGreaterThan(0);
+        if (segment.covered) {
+          expect(segment.ruleIds.length).toBeGreaterThan(0);
+        } else {
+          expect(segment.ruleIds).toEqual([]);
+        }
+      }
+    }
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export type CoveragePreset = 'full' | 'tail' | 'middle' | 'inner' | 'vowel';
+export type CoveragePreset = 'full' | 'tail' | 'middle' | 'inner';
 
 export type RelativeRange = {
   start: number;
@@ -29,6 +29,14 @@ export type CensorRule = {
   target?: CensorTarget;
   coverage?: CoverageSelector;
 };
+
+export type CensorRulePack = {
+  id: string;
+  locale?: string | readonly string[];
+  rules: readonly CensorRule[];
+};
+
+export type WordBoundaryMode = 'word' | 'substring';
 
 export type ScrawlixMatch = {
   ruleId: string;
@@ -158,17 +166,6 @@ function coverageForPreset(
 
     case 'middle':
       return middleCoverage(value);
-
-    case 'vowel': {
-      const vowels = graphemes.filter(range => {
-        const grapheme = value
-          .slice(range.start, range.end)
-          .normalize('NFD')
-          .replace(/\p{M}/gu, '');
-        return /[aeiou]/iu.test(grapheme);
-      });
-      return vowels.length > 0 ? vowels : middleCoverage(value);
-    }
   }
 }
 
@@ -349,7 +346,12 @@ export function censorRuleFromWords(
   {
     caseSensitive = false,
     coverage,
-  }: { caseSensitive?: boolean; coverage?: CoverageSelector } = {}
+    boundary = 'word',
+  }: {
+    caseSensitive?: boolean;
+    coverage?: CoverageSelector;
+    boundary?: WordBoundaryMode;
+  } = {}
 ): CensorRule {
   const alternatives = [...new Set(words.map(word => word.trim()).filter(Boolean))]
     .sort((left, right) => right.length - left.length)
@@ -359,53 +361,27 @@ export function censorRuleFromWords(
     throw new Error('A censor rule needs at least one non-empty word.');
   }
 
+  const source = `(?:${alternatives.join('|')})`;
+  const boundedSource =
+    boundary === 'word'
+      ? `(?<![\\p{L}\\p{N}_])${source}(?![\\p{L}\\p{N}_])`
+      : source;
+
   return {
     id,
     coverage,
-    pattern: new RegExp(
-      `(?<![\\p{L}\\p{N}_])(?:${alternatives.join('|')})(?![\\p{L}\\p{N}_])`,
-      caseSensitive ? 'gu' : 'giu'
-    ),
+    pattern: new RegExp(boundedSource, caseSensitive ? 'gu' : 'giu'),
   };
 }
 
-export const STRONG_PROFANITY_RULES: readonly CensorRule[] = [
-  {
-    id: 'fuck',
-    pattern:
-      /(?<![\p{L}\p{N}_])(?:mother)?(?<core>fuck)(?:ing|ed|er|ers|s)?(?![\p{L}\p{N}_])/giu,
-    target: { group: 'core' },
-  },
-  {
-    id: 'shit',
-    pattern:
-      /(?<![\p{L}\p{N}_])(?:bull)?(?<core>shit)(?:ting|ted|ter|ters|s|ty)?(?![\p{L}\p{N}_])/giu,
-    target: { group: 'core' },
-  },
-  {
-    id: 'bitch',
-    pattern:
-      /(?<![\p{L}\p{N}_])(?<core>bitch)(?:es|ing|ed|y)?(?![\p{L}\p{N}_])/giu,
-    target: { group: 'core' },
-  },
-  {
-    id: 'asshole',
-    pattern:
-      /(?<![\p{L}\p{N}_])(?<core>asshole)s?(?![\p{L}\p{N}_])/giu,
-    target: { group: 'core' },
-  },
-  {
-    id: 'cunt',
-    pattern:
-      /(?<![\p{L}\p{N}_])(?<core>cunt)s?(?![\p{L}\p{N}_])/giu,
-    target: { group: 'core' },
-  },
-] as const;
-
-export const profanityRules = STRONG_PROFANITY_RULES;
+export function rulesFromPacks(
+  ...packs: readonly CensorRulePack[]
+): CensorRule[] {
+  return packs.flatMap(pack => pack.rules);
+}
 
 export function createScrawlix({
-  rules = STRONG_PROFANITY_RULES,
+  rules = [],
   coverage = 'middle',
 }: ScrawlixOptions = {}): ScrawlixEngine {
   const compiledRules: CompiledRule[] = rules.map(rule => ({

--- a/packages/en/package.json
+++ b/packages/en/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@scrawlix/en",
+  "version": "0.0.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./corpus": "./src/corpus.ts"
+  },
+  "types": "./src/index.ts",
+  "dependencies": {
+    "@scrawlix/core": "workspace:*"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  }
+}

--- a/packages/en/src/corpus.ts
+++ b/packages/en/src/corpus.ts
@@ -1,0 +1,84 @@
+export type EnglishCorpusMatch = {
+  ruleId: string;
+  text: string;
+  targetText: string;
+};
+
+export type EnglishCorpusCase = {
+  id: string;
+  text: string;
+  matches: readonly EnglishCorpusMatch[];
+};
+
+/**
+ * Small, reviewable regression corpus for the bundled English profanity rules.
+ * Add a case whenever a bug report or rule change teaches us something durable.
+ */
+export const englishProfanityCorpus: readonly EnglishCorpusCase[] = [
+  {
+    id: 'fuck-base',
+    text: 'fuck',
+    matches: [{ ruleId: 'fuck', text: 'fuck', targetText: 'fuck' }],
+  },
+  {
+    id: 'fuck-uppercase-inflection',
+    text: 'FUCKING',
+    matches: [{ ruleId: 'fuck', text: 'FUCKING', targetText: 'FUCK' }],
+  },
+  {
+    id: 'fuck-mother-compound',
+    text: 'motherfucker',
+    matches: [
+      { ruleId: 'fuck', text: 'motherfucker', targetText: 'fuck' },
+    ],
+  },
+  {
+    id: 'fuck-punctuation',
+    text: 'well, fuck!',
+    matches: [{ ruleId: 'fuck', text: 'fuck', targetText: 'fuck' }],
+  },
+  {
+    id: 'shit-bull-compound',
+    text: 'bullshit',
+    matches: [{ ruleId: 'shit', text: 'bullshit', targetText: 'shit' }],
+  },
+  {
+    id: 'shit-inflection',
+    text: 'shitty',
+    matches: [{ ruleId: 'shit', text: 'shitty', targetText: 'shit' }],
+  },
+  {
+    id: 'bitch-plural',
+    text: 'bitches',
+    matches: [{ ruleId: 'bitch', text: 'bitches', targetText: 'bitch' }],
+  },
+  {
+    id: 'asshole-plural',
+    text: 'assholes',
+    matches: [
+      { ruleId: 'asshole', text: 'assholes', targetText: 'asshole' },
+    ],
+  },
+  {
+    id: 'cunt-plural',
+    text: 'cunts',
+    matches: [{ ruleId: 'cunt', text: 'cunts', targetText: 'cunt' }],
+  },
+  {
+    id: 'multiple-rules',
+    text: 'fuck this shit',
+    matches: [
+      { ruleId: 'fuck', text: 'fuck', targetText: 'fuck' },
+      { ruleId: 'shit', text: 'shit', targetText: 'shit' },
+    ],
+  },
+] as const;
+
+/** Cases that contain suspicious substrings but should remain untouched. */
+export const englishCleanCorpus: readonly EnglishCorpusCase[] = [
+  { id: 'scunthorpe', text: 'Scunthorpe', matches: [] },
+  { id: 'shitake', text: 'shitake mushrooms', matches: [] },
+  { id: 'classhole', text: 'classhole', matches: [] },
+  { id: 'motherfuckerish', text: 'motherfuckerish', matches: [] },
+  { id: 'ordinary-prose', text: 'a perfectly ordinary sentence', matches: [] },
+] as const;

--- a/packages/en/src/index.test.ts
+++ b/packages/en/src/index.test.ts
@@ -1,0 +1,50 @@
+import { createScrawlix, type ScrawlixSegment } from '@scrawlix/core';
+import { describe, expect, it } from 'vitest';
+import { englishCleanCorpus, englishProfanityCorpus } from './corpus';
+import {
+  englishProfanityRules,
+  englishStrongProfanityPack,
+  englishVowelCoverage,
+} from './index';
+
+function marked(segments: readonly ScrawlixSegment[]) {
+  return segments
+    .map(segment => (segment.covered ? `[${segment.text}]` : segment.text))
+    .join('');
+}
+
+describe('@scrawlix/en', () => {
+  const engine = createScrawlix({
+    rules: englishProfanityRules,
+    coverage: 'full',
+  });
+
+  it.each(englishProfanityCorpus)('$id', corpusCase => {
+    const matches = engine.find(corpusCase.text).map(match => ({
+      ruleId: match.ruleId,
+      text: match.text,
+      targetText: match.targetText,
+    }));
+
+    expect(matches).toEqual(corpusCase.matches);
+  });
+
+  it.each(englishCleanCorpus)('$id stays clean', corpusCase => {
+    expect(engine.find(corpusCase.text)).toEqual([]);
+  });
+
+  it('exports a composable language pack with locale metadata', () => {
+    expect(englishStrongProfanityPack.id).toBe('en-strong-profanity');
+    expect(englishStrongProfanityPack.locale).toBe('en');
+    expect(englishStrongProfanityPack.rules).toBe(englishProfanityRules);
+  });
+
+  it('keeps English-specific vowel coverage in the English package', () => {
+    const vowelEngine = createScrawlix({
+      rules: englishProfanityRules,
+      coverage: englishVowelCoverage,
+    });
+
+    expect(marked(vowelEngine.segment('fuck shit'))).toBe('f[u]ck sh[i]t');
+  });
+});

--- a/packages/en/src/index.ts
+++ b/packages/en/src/index.ts
@@ -1,0 +1,83 @@
+import type {
+  CensorRule,
+  CensorRulePack,
+  CoverageSelector,
+  RelativeRange,
+} from '@scrawlix/core';
+
+const graphemeSegmenter =
+  typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
+    ? new Intl.Segmenter('en', { granularity: 'grapheme' })
+    : null;
+
+function graphemeRanges(value: string): RelativeRange[] {
+  if (!value) return [];
+
+  if (graphemeSegmenter) {
+    return [...graphemeSegmenter.segment(value)].map(part => ({
+      start: part.index,
+      end: part.index + part.segment.length,
+    }));
+  }
+
+  const ranges: RelativeRange[] = [];
+  let cursor = 0;
+  for (const character of Array.from(value)) {
+    ranges.push({ start: cursor, end: cursor + character.length });
+    cursor += character.length;
+  }
+  return ranges;
+}
+
+/**
+ * Covers orthographic English vowels (a/e/i/o/u) inside the semantic target.
+ * Diacritics are normalized before classification. `y` is intentionally omitted
+ * because its vowel/consonant role depends on the word.
+ */
+export const englishVowelCoverage: CoverageSelector = context =>
+  graphemeRanges(context.targetText).filter(range => {
+    const grapheme = context.targetText
+      .slice(range.start, range.end)
+      .normalize('NFD')
+      .replace(/\p{M}/gu, '');
+    return /[aeiou]/iu.test(grapheme);
+  });
+
+export const englishProfanityRules: readonly CensorRule[] = [
+  {
+    id: 'fuck',
+    pattern:
+      /(?<![\p{L}\p{N}_])(?:mother)?(?<core>fuck)(?:ing|ed|er|ers|s)?(?![\p{L}\p{N}_])/giu,
+    target: { group: 'core' },
+  },
+  {
+    id: 'shit',
+    pattern:
+      /(?<![\p{L}\p{N}_])(?:bull)?(?<core>shit)(?:ting|ted|ter|ters|s|ty)?(?![\p{L}\p{N}_])/giu,
+    target: { group: 'core' },
+  },
+  {
+    id: 'bitch',
+    pattern:
+      /(?<![\p{L}\p{N}_])(?<core>bitch)(?:es|ing|ed|y)?(?![\p{L}\p{N}_])/giu,
+    target: { group: 'core' },
+  },
+  {
+    id: 'asshole',
+    pattern:
+      /(?<![\p{L}\p{N}_])(?<core>asshole)s?(?![\p{L}\p{N}_])/giu,
+    target: { group: 'core' },
+  },
+  {
+    id: 'cunt',
+    pattern:
+      /(?<![\p{L}\p{N}_])(?<core>cunt)s?(?![\p{L}\p{N}_])/giu,
+    target: { group: 'core' },
+  },
+] as const;
+
+export const englishStrongProfanityPack: CensorRulePack = {
+  id: 'en-strong-profanity',
+  locale: 'en',
+  rules: englishProfanityRules,
+};

--- a/packages/en/tsconfig.json
+++ b/packages/en/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -16,7 +16,7 @@ export type ScrawlixReveal = 'hover' | 'focus' | 'click' | 'never';
 
 export type CensoredTextProps = {
   text: string;
-  rules?: readonly CensorRule[];
+  rules: readonly CensorRule[];
   coverage?: CoverageSelector;
   appearance?: ScrawlixAppearance;
   reveal?: ScrawlixReveal;


### PR DESCRIPTION
Closes #12.
Progresses #11 and #13.

### Language-neutral core
- removes bundled English profanity defaults from `@scrawlix/core`
- keeps generic `full`, `tail`, `middle`, and `inner` coverage in core
- adds explicit `CensorRulePack` metadata and `rulesFromPacks(...)`
- adds `word` vs `substring` boundary modes for custom phrase lists
- makes a zero-rule engine an intentional no-op
- adds deterministic invariant/fuzz coverage and a non-Latin substring regression

### English pack
- adds `@scrawlix/en`
- moves the existing semantic profanity rules into `englishProfanityRules`
- exports `englishStrongProfanityPack`
- moves English-specific vowel classification into `englishVowelCoverage`
- adds a data-first positive/clean regression corpus, including substring false-positive traps such as Scunthorpe and shitake

### Adoption ergonomics
- React now requires rules explicitly
- demo selects `@scrawlix/en` and maps its vowel control to the English helper
- README documents language packs and custom phrases
- adds `docs/language-packs.md`
- adds root `AGENTS.md` with maintainer invariants and extension recipes
- adds `apps/demo/public/llms.txt` for coding-agent discovery

This intentionally uses pre-release freedom to remove surprising English defaults before package publication.