### PR TITLE
Build and smoke-test publishable npm artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,4 @@ jobs:
       - run: pnpm typecheck
       - run: pnpm test
       - run: pnpm build
+      - run: pnpm smoke:packages

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^19.2.1"
   },
   "devDependencies": {
+    "@types/node": "^24.6.2",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.0.4",

--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -1,6 +1,29 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const workspaceFile = (path: string) => fileURLToPath(new URL(path, import.meta.url));
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: [
+      {
+        find: '@scrawlix/react/styles.css',
+        replacement: workspaceFile('../../packages/react/src/styles.css'),
+      },
+      {
+        find: '@scrawlix/react',
+        replacement: workspaceFile('../../packages/react/src/index.tsx'),
+      },
+      {
+        find: '@scrawlix/en',
+        replacement: workspaceFile('../../packages/en/src/index.ts'),
+      },
+      {
+        find: '@scrawlix/core',
+        replacement: workspaceFile('../../packages/core/src/index.ts'),
+      },
+    ],
+  },
 });

--- a/fixtures/consumer/index.html
+++ b/fixtures/consumer/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Scrawlix package smoke test</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/fixtures/consumer/package.json
+++ b/fixtures/consumer/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "scrawlix-smoke-consumer",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^5.2.2",
+    "vite": "^7.1.7"
+  }
+}

--- a/fixtures/consumer/src/main.tsx
+++ b/fixtures/consumer/src/main.tsx
@@ -1,0 +1,28 @@
+import { createScrawlix } from '@scrawlix/core';
+import { englishProfanityRules } from '@scrawlix/en';
+import { CensoredText } from '@scrawlix/react';
+import '@scrawlix/react/styles.css';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+const engine = createScrawlix({
+  rules: englishProfanityRules,
+  coverage: 'middle',
+});
+
+const matches = engine.find('well, fuck');
+if (matches.length !== 1 || matches[0]?.targetText.toLowerCase() !== 'fuck') {
+  throw new Error('Scrawlix core/English package smoke assertion failed.');
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <CensoredText
+      appearance="scrawl"
+      coverage="middle"
+      reveal="hover"
+      rules={englishProfanityRules}
+      text="well, fuck"
+    />
+  </React.StrictMode>
+);

--- a/fixtures/consumer/tsconfig.json
+++ b/fixtures/consumer/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "scrawlix-workspace",
   "private": true,
   "scripts": {
-    "build": "pnpm --filter scrawlix-demo build",
+    "build": "pnpm build:packages && pnpm --filter scrawlix-demo build",
+    "build:packages": "pnpm --filter @scrawlix/core build && pnpm --filter @scrawlix/en build && pnpm --filter @scrawlix/react build",
     "dev": "pnpm --filter scrawlix-demo dev",
-    "test": "pnpm -r --if-present test",
+    "smoke:packages": "node scripts/smoke-packages.mjs",
+    "test": "pnpm build:packages && pnpm -r --if-present test",
     "typecheck": "pnpm -r --if-present typecheck"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,13 +1,35 @@
 {
   "name": "@scrawlix/core",
   "version": "0.0.0",
+  "description": "Language-neutral matching and coverage engine for Scrawlix.",
   "type": "module",
   "sideEffects": false,
+  "files": ["dist"],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
-  "types": "./src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/teamleaderleo/scrawlix.git",
+    "directory": "packages/core"
+  },
+  "homepage": "https://github.com/teamleaderleo/scrawlix#readme",
+  "bugs": {
+    "url": "https://github.com/teamleaderleo/scrawlix/issues"
+  },
+  "keywords": ["censor", "redaction", "profanity", "text", "filter"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.build.json",
+    "prepack": "pnpm build",
     "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   }

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/en/package.json
+++ b/packages/en/package.json
@@ -1,17 +1,43 @@
 {
   "name": "@scrawlix/en",
   "version": "0.0.0",
+  "description": "English profanity rules, coverage helpers, and regression corpora for Scrawlix.",
   "type": "module",
   "sideEffects": false,
+  "files": ["dist"],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./corpus": "./src/corpus.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./corpus": {
+      "types": "./dist/corpus.d.ts",
+      "import": "./dist/corpus.js",
+      "default": "./dist/corpus.js"
+    }
   },
-  "types": "./src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/teamleaderleo/scrawlix.git",
+    "directory": "packages/en"
+  },
+  "homepage": "https://github.com/teamleaderleo/scrawlix#readme",
+  "bugs": {
+    "url": "https://github.com/teamleaderleo/scrawlix/issues"
+  },
+  "keywords": ["censor", "profanity", "english", "text", "scrawlix"],
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@scrawlix/core": "workspace:*"
   },
   "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.build.json",
+    "prepack": "pnpm build",
     "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   }

--- a/packages/en/tsconfig.build.json
+++ b/packages/en/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/en/tsconfig.build.json
+++ b/packages/en/tsconfig.build.json
@@ -6,7 +6,8 @@
     "declarationMap": true,
     "sourceMap": true,
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "paths": {}
   },
   "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,13 +1,33 @@
 {
   "name": "@scrawlix/react",
   "version": "0.0.0",
+  "description": "React rendering, appearances, and reveal behavior for Scrawlix.",
   "type": "module",
-  "sideEffects": ["./src/styles.css"],
+  "sideEffects": ["./dist/styles.css"],
+  "files": ["dist"],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.tsx",
-    "./styles.css": "./src/styles.css"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./styles.css": "./dist/styles.css"
   },
-  "types": "./src/index.tsx",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/teamleaderleo/scrawlix.git",
+    "directory": "packages/react"
+  },
+  "homepage": "https://github.com/teamleaderleo/scrawlix#readme",
+  "bugs": {
+    "url": "https://github.com/teamleaderleo/scrawlix/issues"
+  },
+  "keywords": ["react", "censor", "redaction", "profanity", "scrawlix"],
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@scrawlix/core": "workspace:*"
   },
@@ -19,6 +39,8 @@
     "react": "^19.2.1"
   },
   "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.build.json && node ../../scripts/copy-file.mjs src/styles.css dist/styles.css",
+    "prepack": "pnpm build",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   }
 }

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -6,7 +6,8 @@
     "declarationMap": true,
     "sourceMap": true,
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "paths": {}
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/scripts/copy-file.mjs
+++ b/scripts/copy-file.mjs
@@ -1,0 +1,14 @@
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const [, , sourceArg, destinationArg] = process.argv;
+
+if (!sourceArg || !destinationArg) {
+  throw new Error('Usage: node scripts/copy-file.mjs <source> <destination>');
+}
+
+const source = resolve(process.cwd(), sourceArg);
+const destination = resolve(process.cwd(), destinationArg);
+
+mkdirSync(dirname(destination), { recursive: true });
+copyFileSync(source, destination);

--- a/scripts/smoke-packages.mjs
+++ b/scripts/smoke-packages.mjs
@@ -1,0 +1,98 @@
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const root = process.cwd();
+const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+const temporaryRoot = mkdtempSync(join(tmpdir(), 'scrawlix-smoke-'));
+const packDirectory = join(temporaryRoot, 'packs');
+const consumerDirectory = join(temporaryRoot, 'consumer');
+let passed = false;
+
+mkdirSync(packDirectory, { recursive: true });
+
+function run(args, cwd = root) {
+  const result = spawnSync(pnpm, args, {
+    cwd,
+    env: process.env,
+    stdio: 'inherit',
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`pnpm ${args.join(' ')} failed with exit code ${result.status}`);
+  }
+}
+
+function packPackage(packageDirectory) {
+  const before = new Set(
+    existsSync(packDirectory)
+      ? readdirSync(packDirectory).filter(name => name.endsWith('.tgz'))
+      : []
+  );
+
+  run(['pack', '--pack-destination', packDirectory], resolve(root, packageDirectory));
+
+  const created = readdirSync(packDirectory).filter(
+    name => name.endsWith('.tgz') && !before.has(name)
+  );
+
+  if (created.length !== 1) {
+    throw new Error(
+      `Expected one tarball from ${packageDirectory}; found ${created.length}.`
+    );
+  }
+
+  return join(packDirectory, created[0]);
+}
+
+try {
+  const coreTarball = packPackage('packages/core');
+  const englishTarball = packPackage('packages/en');
+  const reactTarball = packPackage('packages/react');
+
+  cpSync(resolve(root, 'fixtures/consumer'), consumerDirectory, {
+    recursive: true,
+  });
+
+  const packageJsonPath = join(consumerDirectory, 'package.json');
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  const asFileDependency = path => `file:${path.replaceAll('\\', '/')}`;
+
+  packageJson.dependencies = {
+    ...packageJson.dependencies,
+    '@scrawlix/core': asFileDependency(coreTarball),
+    '@scrawlix/en': asFileDependency(englishTarball),
+    '@scrawlix/react': asFileDependency(reactTarball),
+  };
+  packageJson.pnpm = {
+    overrides: {
+      '@scrawlix/core': asFileDependency(coreTarball),
+    },
+  };
+
+  writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+
+  run(['install', '--no-frozen-lockfile'], consumerDirectory);
+  run(['typecheck'], consumerDirectory);
+  run(['build'], consumerDirectory);
+
+  passed = true;
+  console.log('Scrawlix packed-package smoke test passed.');
+} finally {
+  if (passed) {
+    rmSync(temporaryRoot, { recursive: true, force: true });
+  } else {
+    console.error(`Smoke-test workspace preserved at ${temporaryRoot}`);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,13 @@
     "noEmit": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@scrawlix/core": ["packages/core/src/index.ts"],
+      "@scrawlix/en": ["packages/en/src/index.ts"],
+      "@scrawlix/en/corpus": ["packages/en/src/corpus.ts"],
+      "@scrawlix/react": ["packages/react/src/index.tsx"]
+    }
   }
 }


### PR DESCRIPTION
Closes #15.
Progresses #13.

### Real package output
- `@scrawlix/core`, `@scrawlix/en`, and `@scrawlix/react` now build ESM JavaScript, declarations, declaration maps, and source maps into `dist`
- package exports and `types` point at `dist` instead of workspace TypeScript source
- React copies and exports `dist/styles.css`
- packages publish only intended distribution files
- adds repository/homepage/bugs/keywords/public publish metadata while leaving license selection explicit for the maintainer

### Workspace development
- TypeScript path mappings keep editor/typecheck resolution on source
- the Vite demo aliases workspace source directly for local development
- package build configs deliberately resolve sibling packages through built public exports

### External consumer smoke test
- adds a fixture outside the pnpm workspace
- `scripts/smoke-packages.mjs` packs all three packages to tarballs
- installs those tarballs into the fixture
- forces nested `@scrawlix/core` resolution to the packed core tarball
- typechecks and production-builds a React app importing core, English rules, React, and the CSS subpath
- CI now runs the packed-package smoke test

The remaining release choices are versioning, npm scope ownership, and an explicit open-source license.