### PR TITLE
Lock down React accessibility and reveal regressions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,10 @@ pnpm install
 pnpm typecheck
 pnpm test
 pnpm build
+pnpm smoke:packages
 ```
 
-The demo build is part of the workspace build and acts as an integration check across core, language packs, and React.
+The demo build is part of the workspace build and acts as an integration check across core, language packs, and React. The package smoke test installs packed tarballs into a consumer outside the workspace dependency graph.
 
 ## Invariants
 
@@ -62,7 +63,9 @@ When a larger match contains the meaningful censored core, use a named capture g
 
 ### Treat accessibility as source truth
 
-Visual fragments are decorative. React currently exposes the full source once through `aria-label` and hides rendered fragments from assistive tech. Preserve a single accessible reading of the source and avoid duplicate speech.
+Visual censorship is decorative. When text is transformed, React keeps exactly one visually-hidden source copy in the accessibility tree (`data-scrawlix-a11y`) and marks the complete rendered visual tree `aria-hidden="true"`. Preserve that single accessible reading of the source across every appearance and reveal mode.
+
+Passive reveal modes (`hover`, `never`) stay outside the tab order. Keyboard-driven reveal modes must retain an operable focus path and regression coverage.
 
 ### Add corpus cases for learned linguistic behavior
 
@@ -85,7 +88,7 @@ When a bug or rule change teaches a durable positive or false-positive example, 
 3. Prefer CSS/data-attribute presentation over rebuilding source strings.
 4. Add the appearance to the demo specimen sheet.
 5. Preserve reveal modes and reduced-motion behavior.
-6. Add rendered/visual regression coverage when issue #11 lands that layer.
+6. Extend rendered regressions for any new DOM contract or interaction.
 
 ## Adding a coverage behavior
 
@@ -95,4 +98,4 @@ Ask whether the behavior is language-neutral. Generic positional coverage may li
 
 Scrawlix is pre-release, so breaking changes are still possible. Use that freedom to remove surprising defaults and awkward names early. Once packages are published, favor additive changes and explicit deprecation paths.
 
-Before the first public release, issue #13 requires packed-package smoke tests so external consumers receive compiled JavaScript, declarations, CSS exports, and valid package metadata rather than workspace-only source imports.
+Packed-package smoke tests are a release gate: external consumers must receive compiled JavaScript, declarations, CSS exports, and valid package metadata rather than workspace-only source imports.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,11 +36,15 @@
   },
   "devDependencies": {
     "@types/react": "^19.2.7",
-    "react": "^19.2.1"
+    "@types/react-dom": "^19.2.3",
+    "jsdom": "^26.1.0",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1"
   },
   "scripts": {
     "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.build.json && node ../../scripts/copy-file.mjs src/styles.css dist/styles.css",
     "prepack": "pnpm build",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   }
 }

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -1,0 +1,160 @@
+/** @vitest-environment jsdom */
+
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CensoredText } from './index';
+
+const rules = [
+  {
+    id: 'fuck',
+    pattern: /(?<![\p{L}\p{N}_])fuck(?![\p{L}\p{N}_])/giu,
+  },
+] as const;
+
+const mountedRoots: Array<{ root: Root; container: HTMLDivElement }> = [];
+
+function render(element: ReactElement) {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+  mountedRoots.push({ root, container });
+
+  act(() => {
+    root.render(element);
+  });
+
+  return container;
+}
+
+afterEach(() => {
+  while (mountedRoots.length > 0) {
+    const mounted = mountedRoots.pop()!;
+    act(() => mounted.root.unmount());
+    mounted.container.remove();
+  }
+});
+
+describe('CensoredText', () => {
+  it('renders ordinary text directly when no rule matches', () => {
+    const container = render(
+      <CensoredText rules={rules} text="a perfectly ordinary sentence" />
+    );
+
+    expect(container.textContent).toBe('a perfectly ordinary sentence');
+    expect(container.querySelector('[data-scrawlix-root]')).toBeNull();
+  });
+
+  it('keeps one accessible source copy and hides the visual tree from assistive tech', () => {
+    const text = 'well, fuck';
+    const container = render(
+      <CensoredText appearance="bar" rules={rules} text={text} />
+    );
+
+    const root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
+    const accessible = root.querySelector<HTMLElement>('[data-scrawlix-a11y]')!;
+    const visual = root.querySelector<HTMLElement>('[data-scrawlix-visual]')!;
+    const covers = visual.querySelectorAll('[data-scrawlix-cover]');
+
+    expect(root.getAttribute('aria-label')).toBeNull();
+    expect(accessible.textContent).toBe(text);
+    expect(accessible.getAttribute('aria-hidden')).toBeNull();
+    expect(visual.getAttribute('aria-hidden')).toBe('true');
+    expect(covers).toHaveLength(1);
+    expect(covers[0]?.getAttribute('data-rules')).toBe('fuck');
+    expect(covers[0]?.getAttribute('data-appearance')).toBe('bar');
+  });
+
+  it('keeps hover and never reveal passive in the tab order', () => {
+    for (const reveal of ['hover', 'never'] as const) {
+      const container = render(
+        <CensoredText reveal={reveal} rules={rules} text="fuck" />
+      );
+      const root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
+
+      expect(root.getAttribute('tabindex')).toBeNull();
+      expect(root.dataset.reveal).toBe(reveal);
+      expect(root.dataset.revealed).toBe('false');
+    }
+  });
+
+  it('makes focus reveal keyboard-focusable without click state', () => {
+    const container = render(
+      <CensoredText reveal="focus" rules={rules} text="fuck" />
+    );
+    const root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
+
+    expect(root.tabIndex).toBe(0);
+    act(() => root.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(root.dataset.revealed).toBe('false');
+  });
+
+  it('toggles click reveal with pointer activation', () => {
+    const container = render(
+      <CensoredText reveal="click" rules={rules} text="fuck" />
+    );
+    const root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
+
+    expect(root.tabIndex).toBe(0);
+    expect(root.dataset.revealed).toBe('false');
+
+    act(() => root.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(root.dataset.revealed).toBe('true');
+
+    act(() => root.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(root.dataset.revealed).toBe('false');
+  });
+
+  it.each(['Enter', ' '])('toggles click reveal with %j', key => {
+    const container = render(
+      <CensoredText reveal="click" rules={rules} text="fuck" />
+    );
+    const root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
+
+    act(() =>
+      root.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          key,
+        })
+      )
+    );
+
+    expect(root.dataset.revealed).toBe('true');
+  });
+
+  it('renders symbol masks while retaining the exact covered source substring', () => {
+    const container = render(
+      <CensoredText
+        appearance="asterisk"
+        coverage="middle"
+        rules={rules}
+        text="fuck"
+      />
+    );
+
+    const cover = container.querySelector<HTMLElement>('[data-scrawlix-cover]')!;
+    const mask = cover.querySelector<HTMLElement>('[data-scrawlix-mask]')!;
+    const source = cover.querySelector<HTMLElement>('[data-scrawlix-source]')!;
+
+    expect(mask.textContent).toBe('**');
+    expect(source.textContent).toBe('uc');
+  });
+
+  it('cycles grawlix symbols by covered grapheme count', () => {
+    const fullRule = [{ id: 'whole', pattern: /abcdef/giu }] as const;
+    const container = render(
+      <CensoredText
+        appearance="grawlix"
+        coverage="full"
+        rules={fullRule}
+        text="abcdef"
+      />
+    );
+
+    expect(
+      container.querySelector<HTMLElement>('[data-scrawlix-mask]')?.textContent
+    ).toBe('@#$%&!');
+  });
+});

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -68,7 +68,6 @@ export function CensoredText({
 
   return (
     <span
-      aria-label={text}
       className={className}
       data-scrawlix-root
       data-reveal={reveal}
@@ -77,40 +76,38 @@ export function CensoredText({
       onClick={reveal === 'click' ? () => setRevealed(value => !value) : undefined}
       onKeyDown={onKeyDown}
     >
-      {segments.map((segment, index) => {
-        if (!segment.covered) {
+      <span data-scrawlix-a11y>{text}</span>
+      <span aria-hidden="true" data-scrawlix-visual>
+        {segments.map((segment, index) => {
+          if (!segment.covered) {
+            return <span key={`${index}-${segment.text}`}>{segment.text}</span>;
+          }
+
+          const symbolAppearance =
+            appearance === 'asterisk' || appearance === 'grawlix';
+
           return (
-            <span aria-hidden="true" key={`${index}-${segment.text}`}>
-              {segment.text}
+            <span
+              data-scrawlix-cover
+              data-appearance={appearance}
+              data-rules={segment.ruleIds.join(',')}
+              key={`${index}-${segment.text}`}
+              title={title}
+            >
+              {symbolAppearance ? (
+                <>
+                  <span data-scrawlix-mask>
+                    {symbolsFor(segment.text, appearance)}
+                  </span>
+                  <span data-scrawlix-source>{segment.text}</span>
+                </>
+              ) : (
+                segment.text
+              )}
             </span>
           );
-        }
-
-        const symbolAppearance =
-          appearance === 'asterisk' || appearance === 'grawlix';
-
-        return (
-          <span
-            aria-hidden="true"
-            data-scrawlix-cover
-            data-appearance={appearance}
-            data-rules={segment.ruleIds.join(',')}
-            key={`${index}-${segment.text}`}
-            title={title}
-          >
-            {symbolAppearance ? (
-              <>
-                <span data-scrawlix-mask>
-                  {symbolsFor(segment.text, appearance)}
-                </span>
-                <span data-scrawlix-source>{segment.text}</span>
-              </>
-            ) : (
-              segment.text
-            )}
-          </span>
-        );
-      })}
+        })}
+      </span>
     </span>
   );
 }

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -3,6 +3,19 @@
   --scrawlix-fuzzy-ink: color-mix(in srgb, currentColor 58%, transparent);
 }
 
+[data-scrawlix-a11y] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 [data-scrawlix-root]:focus-visible {
   outline: 1px solid currentColor;
   outline-offset: 0.2em;

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -9,5 +9,6 @@
     "outDir": "dist",
     "paths": {}
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
Progresses #11 and #13.

### Accessibility contract
- replaces the fragile `aria-label`-on-generic-span approach with one visually-hidden source copy (`data-scrawlix-a11y`)
- marks the complete rendered censor tree `aria-hidden="true"`
- keeps passive hover/never modes outside the tab order
- preserves focusability for focus/click reveal

### Rendered regressions
- adds jsdom-backed React tests for ordinary unmatched text
- asserts the single accessible source / decorative visual split
- asserts rule and appearance data attributes
- tests pointer click reveal toggling
- tests Enter and Space keyboard toggling
- verifies focus reveal stays independent of click state
- verifies asterisk/grawlix masks preserve the exact covered source substring

### Maintainer ergonomics
- updates `AGENTS.md` with the explicit accessibility DOM invariant and packed-package smoke command
- excludes test files from React package artifacts

This turns the React DOM into an intentional adapter contract instead of incidental markup.