### PR TITLE
Add the Scrawlix rehype adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,12 @@ A change in one layer should rarely require logic in another.
 - `packages/core` — language-neutral matching, segmentation, generic coverage, custom-word helpers
 - `packages/en` — English profanity rules, English-specific coverage helpers, English regression corpus
 - `packages/react` — React renderer and appearance/reveal behavior
+- `packages/rehype` — HAST/rehype transformer for syntax-tree prose
 - `apps/demo` — public interactive proof sheet and integration consumer
+- `fixtures/consumer` — external packed-package smoke consumer
 - `docs` — design and extension guidance
 
-Planned adapters are tracked in GitHub issues for rehype/Markdown, arbitrary DOM, browser extension, and Scrapbook adoption.
+Planned adapters are tracked in GitHub issues for arbitrary DOM, the browser extension, and Scrapbook adoption.
 
 ## Commands
 
@@ -67,6 +69,14 @@ Visual censorship is decorative. When text is transformed, React keeps exactly o
 
 Passive reveal modes (`hover`, `never`) stay outside the tab order. Keyboard-driven reveal modes must retain an operable focus path and regression coverage.
 
+### Keep syntax-tree adapters semantic
+
+`@scrawlix/rehype` operates on HAST text nodes and emits covered spans with stable data attributes. It preserves the original text as text content and leaves appearance/reveal policy to consumers.
+
+Keep code/pre/script/style/textarea exclusions safe by default. Preserve inline elements and link boundaries. Never match across separate text nodes or markup seams unless a future API explicitly introduces a higher-level tokenization pass with corpus evidence.
+
+The rehype transform must stay idempotent: existing `data-scrawlix-cover` output is an excluded subtree.
+
 ### Add corpus cases for learned linguistic behavior
 
 When a bug or rule change teaches a durable positive or false-positive example, add it to the relevant pack corpus. Prefer data cases over one-off matcher test code.
@@ -98,4 +108,4 @@ Ask whether the behavior is language-neutral. Generic positional coverage may li
 
 Scrawlix is pre-release, so breaking changes are still possible. Use that freedom to remove surprising defaults and awkward names early. Once packages are published, favor additive changes and explicit deprecation paths.
 
-Packed-package smoke tests are a release gate: external consumers must receive compiled JavaScript, declarations, CSS exports, and valid package metadata rather than workspace-only source imports.
+Packed-package smoke tests are a release gate: external consumers must receive compiled JavaScript, declarations, CSS exports, and valid package metadata rather than workspace-only source imports. Every new public package belongs in `scripts/smoke-packages.mjs` and `fixtures/consumer`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Scrawlix began as a censor/reveal primitive in [Scrapbook](https://github.com/te
 
 ## Quick start
 
-Scrawlix does not choose a language for you. Pick a rule pack explicitly:
+Scrawlix asks callers to pick a rule pack explicitly:
 
 ```ts
 import { createScrawlix } from '@scrawlix/core';
@@ -50,6 +50,34 @@ import '@scrawlix/react/styles.css';
 Current appearances: `scrawl`, `bar`, `blur`, `asterisk`, and `grawlix`.
 
 Current reveal modes: `hover`, `focus`, `click`, and `never`.
+
+## Markdown / rehype
+
+`@scrawlix/rehype` walks HAST text nodes and marks covered ranges while leaving the source text intact:
+
+```tsx
+import { englishProfanityRules } from '@scrawlix/en';
+import { rehypeScrawlix } from '@scrawlix/rehype';
+import ReactMarkdown from 'react-markdown';
+
+<ReactMarkdown
+  rehypePlugins={[
+    [
+      rehypeScrawlix,
+      {
+        rules: englishProfanityRules,
+        coverage: 'middle',
+      },
+    ],
+  ]}
+>
+  {markdown}
+</ReactMarkdown>;
+```
+
+Covered fragments become spans carrying `data-scrawlix-cover` and `data-scrawlix-rules`. The adapter keeps appearance policy out of the syntax-tree pass, so a site can style those spans with its own editorial language.
+
+`code`, `pre`, `script`, `style`, and `textarea` subtrees are skipped by default. Applications can add excluded tags, place `data-scrawlix-ignore` on a subtree, or provide a `shouldSkip` predicate. The transformer also skips its own output, so repeated processing stays idempotent.
 
 ## Custom words and phrases
 
@@ -103,7 +131,7 @@ The repository includes `vercel.json` at the root. Importing the Git repository 
 - build: `pnpm build`
 - output: `apps/demo/dist`
 
-No server runtime is required; the demo builds to static assets.
+The demo builds to static assets.
 
 ## Contributing
 
@@ -113,6 +141,7 @@ Run the whole workspace with:
 pnpm typecheck
 pnpm test
 pnpm build
+pnpm smoke:packages
 ```
 
 `AGENTS.md` is the maintainer/agent map: package responsibilities, invariants, commands, and extension rules. Corpus regressions should be data-first: when a matcher bug teaches us a durable example, add that example to the relevant language corpus.
@@ -129,6 +158,7 @@ pnpm build
 - [Corpus-driven regressions](https://github.com/teamleaderleo/scrawlix/issues/11)
 - [Language packs](https://github.com/teamleaderleo/scrawlix/issues/12)
 - [Human and agent adoption ergonomics](https://github.com/teamleaderleo/scrawlix/issues/13)
+- [First public release readiness](https://github.com/teamleaderleo/scrawlix/issues/18)
 
 ## Status
 

--- a/apps/demo/public/llms.txt
+++ b/apps/demo/public/llms.txt
@@ -8,6 +8,7 @@ Packages:
 - @scrawlix/core — language-neutral matching and segmentation
 - @scrawlix/en — English profanity rules, English vowel coverage, regression corpus
 - @scrawlix/react — React renderer and visual/reveal presets
+- @scrawlix/rehype — HAST/rehype transformer for Markdown-rendered prose
 
 Canonical React usage:
 
@@ -37,7 +38,21 @@ const engine = createScrawlix({
 });
 ```
 
-Core is deliberately language-neutral. Select language/rule packs explicitly; do not assume automatic language detection. Custom names, spoilers, and phrases can be supplied with `censorRuleFromWords()`.
+Canonical rehype usage:
+
+```ts
+import { englishProfanityRules } from '@scrawlix/en';
+import { rehypeScrawlix } from '@scrawlix/rehype';
+
+const plugin = [
+  rehypeScrawlix,
+  { rules: englishProfanityRules, coverage: 'middle' },
+];
+```
+
+The rehype adapter emits spans with `data-scrawlix-cover` and `data-scrawlix-rules`, preserves the original text as text content, and skips code/pre/script/style/textarea by default.
+
+Core is deliberately language-neutral. Select language/rule packs explicitly. Custom names, spoilers, and phrases can be supplied with `censorRuleFromWords()`.
 
 Generic coverage presets: full, tail, middle, inner.
 English-specific helper: englishVowelCoverage.
@@ -46,3 +61,4 @@ React reveal modes: hover, focus, click, never.
 
 Maintainer guidance: https://github.com/teamleaderleo/scrawlix/blob/main/AGENTS.md
 Language packs: https://github.com/teamleaderleo/scrawlix/blob/main/docs/language-packs.md
+Release readiness: https://github.com/teamleaderleo/scrawlix/issues/18

--- a/fixtures/consumer/src/main.tsx
+++ b/fixtures/consumer/src/main.tsx
@@ -1,5 +1,6 @@
 import { createScrawlix } from '@scrawlix/core';
 import { englishProfanityRules } from '@scrawlix/en';
+import { transformHast } from '@scrawlix/rehype';
 import { CensoredText } from '@scrawlix/react';
 import '@scrawlix/react/styles.css';
 import React from 'react';
@@ -13,6 +14,38 @@ const engine = createScrawlix({
 const matches = engine.find('well, fuck');
 if (matches.length !== 1 || matches[0]?.targetText.toLowerCase() !== 'fuck') {
   throw new Error('Scrawlix core/English package smoke assertion failed.');
+}
+
+const tree: Parameters<typeof transformHast>[0] = {
+  type: 'root',
+  children: [
+    {
+      type: 'element',
+      tagName: 'p',
+      properties: {},
+      children: [{ type: 'text', value: 'well, fuck' }],
+    },
+  ],
+};
+
+transformHast(tree, {
+  rules: englishProfanityRules,
+  coverage: 'middle',
+});
+
+const paragraph = tree.children[0];
+if (
+  paragraph?.type !== 'element' ||
+  !paragraph.children.some(
+    child =>
+      child.type === 'element' &&
+      Object.prototype.hasOwnProperty.call(
+        child.properties,
+        'data-scrawlix-cover'
+      )
+  )
+) {
+  throw new Error('Scrawlix rehype package smoke assertion failed.');
 }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "pnpm build:packages && pnpm --filter scrawlix-demo build",
-    "build:packages": "pnpm --filter @scrawlix/core build && pnpm --filter @scrawlix/en build && pnpm --filter @scrawlix/react build",
+    "build:packages": "pnpm --filter @scrawlix/core build && pnpm --filter @scrawlix/en build && pnpm --filter @scrawlix/react build && pnpm --filter @scrawlix/rehype build",
     "dev": "pnpm --filter scrawlix-demo dev",
     "smoke:packages": "node scripts/smoke-packages.mjs",
     "test": "pnpm build:packages && pnpm -r --if-present test",

--- a/packages/rehype/package.json
+++ b/packages/rehype/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@scrawlix/rehype",
+  "version": "0.0.0",
+  "description": "HAST/rehype adapter for applying Scrawlix coverage throughout Markdown-rendered prose.",
+  "type": "module",
+  "sideEffects": false,
+  "files": ["dist"],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/teamleaderleo/scrawlix.git",
+    "directory": "packages/rehype"
+  },
+  "homepage": "https://github.com/teamleaderleo/scrawlix#readme",
+  "bugs": {
+    "url": "https://github.com/teamleaderleo/scrawlix/issues"
+  },
+  "keywords": ["rehype", "markdown", "hast", "censor", "scrawlix"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@scrawlix/core": "workspace:*",
+    "@types/hast": "^3.0.5"
+  },
+  "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.build.json",
+    "prepack": "pnpm build",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  }
+}

--- a/packages/rehype/src/index.test.ts
+++ b/packages/rehype/src/index.test.ts
@@ -1,0 +1,166 @@
+import { censorRuleFromWords } from '@scrawlix/core';
+import type { Element, Root, RootContent } from 'hast';
+import { describe, expect, it } from 'vitest';
+import { rehypeScrawlix, transformHast } from './index';
+
+const rules = [censorRuleFromWords('fuck', ['fuck'])] as const;
+
+function text(value: string): RootContent {
+  return { type: 'text', value };
+}
+
+function element(
+  tagName: string,
+  children: RootContent[],
+  properties: Element['properties'] = {}
+): Element {
+  return {
+    type: 'element',
+    tagName,
+    properties,
+    children: children as Element['children'],
+  };
+}
+
+function root(...children: RootContent[]): Root {
+  return { type: 'root', children };
+}
+
+function textContent(node: Root | RootContent): string {
+  if (node.type === 'text') return node.value;
+  if ('children' in node && Array.isArray(node.children)) {
+    return node.children.map(child => textContent(child)).join('');
+  }
+  return '';
+}
+
+function coveredElements(node: Root | RootContent): Element[] {
+  const found: Element[] = [];
+
+  if (node.type === 'element') {
+    if (
+      Object.prototype.hasOwnProperty.call(
+        node.properties ?? {},
+        'data-scrawlix-cover'
+      )
+    ) {
+      found.push(node);
+    }
+  }
+
+  if ('children' in node && Array.isArray(node.children)) {
+    for (const child of node.children) {
+      found.push(...coveredElements(child));
+    }
+  }
+
+  return found;
+}
+
+describe('@scrawlix/rehype', () => {
+  it('splits covered ranges while preserving the exact source text', () => {
+    const tree = root(element('p', [text('well, fuck this')]))
+    const original = textContent(tree);
+
+    transformHast(tree, { rules, coverage: 'middle' });
+
+    expect(textContent(tree)).toBe(original);
+    const covers = coveredElements(tree);
+    expect(covers).toHaveLength(1);
+    expect(textContent(covers[0]!)).toBe('uc');
+    expect(covers[0]!.properties['data-scrawlix-rules']).toBe('fuck');
+  });
+
+  it('transforms text inside ordinary inline elements without replacing the element', () => {
+    const link = element('a', [text('fuck')], { href: '/somewhere' });
+    const tree = root(element('p', [text('say '), link, text(' here')]))
+
+    transformHast(tree, { rules, coverage: 'full' });
+
+    const paragraph = tree.children[0] as Element;
+    expect(paragraph.children[1]).toBe(link);
+    expect(link.properties.href).toBe('/somewhere');
+    expect(coveredElements(link)).toHaveLength(1);
+    expect(textContent(tree)).toBe('say fuck here');
+  });
+
+  it('does not match across inline markup boundaries', () => {
+    const tree = root(
+      element('p', [text('fu'), element('em', [text('ck')])])
+    );
+
+    transformHast(tree, { rules, coverage: 'full' });
+
+    expect(coveredElements(tree)).toHaveLength(0);
+    expect(textContent(tree)).toBe('fuck');
+  });
+
+  it.each(['code', 'pre', 'script', 'style', 'textarea'])(
+    'skips <%s> subtrees by default',
+    tagName => {
+      const tree = root(element(tagName, [text('fuck')]))
+
+      transformHast(tree, { rules, coverage: 'full' });
+
+      expect(coveredElements(tree)).toHaveLength(0);
+      expect(textContent(tree)).toBe('fuck');
+    }
+  );
+
+  it('supports additional excluded tags', () => {
+    const tree = root(element('a', [text('fuck')]))
+
+    transformHast(tree, {
+      rules,
+      coverage: 'full',
+      excludeTags: ['a'],
+    });
+
+    expect(coveredElements(tree)).toHaveLength(0);
+  });
+
+  it('supports an ignore attribute for application-owned subtrees', () => {
+    const tree = root(
+      element('div', [text('fuck')], { 'data-scrawlix-ignore': '' })
+    );
+
+    transformHast(tree, { rules, coverage: 'full' });
+
+    expect(coveredElements(tree)).toHaveLength(0);
+  });
+
+  it('supports a caller-defined element skip predicate', () => {
+    const tree = root(
+      element('div', [text('fuck')], { className: ['private-copy'] })
+    );
+
+    transformHast(tree, {
+      rules,
+      coverage: 'full',
+      shouldSkip: node =>
+        Array.isArray(node.properties.className) &&
+        node.properties.className.includes('private-copy'),
+    });
+
+    expect(coveredElements(tree)).toHaveLength(0);
+  });
+
+  it('is idempotent and does not wrap its own covered output again', () => {
+    const tree = root(element('p', [text('fuck')]))
+
+    transformHast(tree, { rules, coverage: 'full' });
+    transformHast(tree, { rules, coverage: 'full' });
+
+    expect(coveredElements(tree)).toHaveLength(1);
+    expect(textContent(tree)).toBe('fuck');
+  });
+
+  it('provides a rehype-compatible transformer factory', () => {
+    const tree = root(element('p', [text('fuck')]))
+    const transform = rehypeScrawlix({ rules, coverage: 'full' });
+
+    transform(tree);
+
+    expect(coveredElements(tree)).toHaveLength(1);
+  });
+});

--- a/packages/rehype/src/index.ts
+++ b/packages/rehype/src/index.ts
@@ -1,0 +1,145 @@
+import {
+  createScrawlix,
+  type CensorRule,
+  type CoverageSelector,
+  type ScrawlixSegment,
+} from '@scrawlix/core';
+import type { Element, Root, RootContent, Text } from 'hast';
+
+const DEFAULT_EXCLUDED_TAGS = ['code', 'pre', 'script', 'style', 'textarea'] as const;
+
+export type RehypeScrawlixOptions = {
+  rules: readonly CensorRule[];
+  coverage?: CoverageSelector;
+  /** Additional element tag names whose complete subtrees should be left untouched. */
+  excludeTags?: readonly string[];
+  /**
+   * Skip any subtree rooted at an element carrying this property.
+   * Defaults to `data-scrawlix-ignore`. Set to `false` to disable the attribute check.
+   */
+  ignoreAttribute?: string | false;
+  /** Caller-defined escape hatch for application-specific element exclusions. */
+  shouldSkip?: (element: Element) => boolean;
+};
+
+type HastParent = Root | Element;
+
+type PreparedOptions = {
+  engine: ReturnType<typeof createScrawlix>;
+  excludedTags: ReadonlySet<string>;
+  ignoreAttribute: string | false;
+  shouldSkip?: (element: Element) => boolean;
+};
+
+function isText(node: RootContent): node is Text {
+  return node.type === 'text';
+}
+
+function isElement(node: RootContent): node is Element {
+  return node.type === 'element';
+}
+
+function hasProperty(element: Element, name: string) {
+  return Object.prototype.hasOwnProperty.call(element.properties ?? {}, name);
+}
+
+function shouldSkipElement(element: Element, options: PreparedOptions) {
+  if (hasProperty(element, 'data-scrawlix-cover')) return true;
+  if (options.excludedTags.has(element.tagName.toLowerCase())) return true;
+  if (
+    options.ignoreAttribute &&
+    hasProperty(element, options.ignoreAttribute)
+  ) {
+    return true;
+  }
+  return options.shouldSkip?.(element) === true;
+}
+
+function coveredElement(segment: ScrawlixSegment): Element {
+  return {
+    type: 'element',
+    tagName: 'span',
+    properties: {
+      'data-scrawlix-cover': '',
+      'data-scrawlix-rules': segment.ruleIds.join(','),
+    },
+    children: [{ type: 'text', value: segment.text }],
+  };
+}
+
+function replacementNodes(value: string, options: PreparedOptions): RootContent[] | null {
+  const segments = options.engine.segment(value);
+  if (!segments.some(segment => segment.covered)) return null;
+
+  return segments.map(segment =>
+    segment.covered
+      ? coveredElement(segment)
+      : ({ type: 'text', value: segment.text } satisfies Text)
+  );
+}
+
+function transformParent(parent: HastParent, options: PreparedOptions) {
+  // Text and element replacements are valid children of both Root and Element.
+  const children = parent.children as RootContent[];
+
+  for (let index = 0; index < children.length; index += 1) {
+    const child = children[index]!;
+
+    if (isText(child)) {
+      const replacements = replacementNodes(child.value, options);
+      if (!replacements) continue;
+
+      children.splice(index, 1, ...replacements);
+      index += replacements.length - 1;
+      continue;
+    }
+
+    if (isElement(child) && !shouldSkipElement(child, options)) {
+      transformParent(child, options);
+    }
+  }
+}
+
+function prepareOptions(options: RehypeScrawlixOptions): PreparedOptions {
+  const excludedTags = new Set(
+    [...DEFAULT_EXCLUDED_TAGS, ...(options.excludeTags ?? [])].map(tag =>
+      tag.toLowerCase()
+    )
+  );
+
+  return {
+    engine: createScrawlix({
+      rules: options.rules,
+      coverage: options.coverage,
+    }),
+    excludedTags,
+    ignoreAttribute: options.ignoreAttribute ?? 'data-scrawlix-ignore',
+    shouldSkip: options.shouldSkip,
+  };
+}
+
+/**
+ * Transform a HAST tree directly. The tree is mutated in place and returned for
+ * convenient composition and testing.
+ */
+export function transformHast(
+  tree: Root,
+  options: RehypeScrawlixOptions
+): Root {
+  transformParent(tree, prepareOptions(options));
+  return tree;
+}
+
+/**
+ * Rehype-compatible plugin. Pass as `[rehypeScrawlix, options]` to unified,
+ * react-markdown, or another rehype consumer.
+ */
+export function rehypeScrawlix(options: RehypeScrawlixOptions) {
+  const prepared = prepareOptions(options);
+
+  return function transform(tree: Root) {
+    transformParent(tree, prepared);
+  };
+}
+
+export default rehypeScrawlix;

--- a/packages/rehype/tsconfig.build.json
+++ b/packages/rehype/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "paths": {}
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/rehype/tsconfig.json
+++ b/packages/rehype/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/smoke-packages.mjs
+++ b/scripts/smoke-packages.mjs
@@ -60,6 +60,7 @@ try {
   const coreTarball = packPackage('packages/core');
   const englishTarball = packPackage('packages/en');
   const reactTarball = packPackage('packages/react');
+  const rehypeTarball = packPackage('packages/rehype');
 
   cpSync(resolve(root, 'fixtures/consumer'), consumerDirectory, {
     recursive: true,
@@ -74,6 +75,7 @@ try {
     '@scrawlix/core': asFileDependency(coreTarball),
     '@scrawlix/en': asFileDependency(englishTarball),
     '@scrawlix/react': asFileDependency(reactTarball),
+    '@scrawlix/rehype': asFileDependency(rehypeTarball),
   };
   packageJson.pnpm = {
     overrides: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
       "@scrawlix/core": ["packages/core/src/index.ts"],
       "@scrawlix/en": ["packages/en/src/index.ts"],
       "@scrawlix/en/corpus": ["packages/en/src/corpus.ts"],
-      "@scrawlix/react": ["packages/react/src/index.tsx"]
+      "@scrawlix/react": ["packages/react/src/index.tsx"],
+      "@scrawlix/rehype": ["packages/rehype/src/index.ts"]
     }
   }
 }


### PR DESCRIPTION
Closes #3.
Progresses #13.

### `@scrawlix/rehype`
- adds a language-neutral HAST/rehype transformer backed by `@scrawlix/core`
- marks covered ranges with `data-scrawlix-cover` and `data-scrawlix-rules`
- preserves the original source as actual text content
- preserves ordinary inline elements and link boundaries
- deliberately avoids matching across separate text nodes / markup seams
- skips `code`, `pre`, `script`, `style`, and `textarea` subtrees by default
- supports additional excluded tags, `data-scrawlix-ignore`, and a caller `shouldSkip` predicate
- skips its own output so repeated transforms are idempotent
- exports both a rehype-compatible plugin and direct `transformHast(...)` helper

### Regression coverage
- source reconstruction
- semantic middle coverage
- link preservation
- markup-boundary behavior
- default and custom exclusions
- application ignore hooks
- idempotency
- plugin factory behavior

### Package ergonomics
- builds declarations/ESM into `dist`
- joins the workspace build
- joins the packed-tarball external consumer smoke test
- README, AGENTS.md, and llms.txt now document the Markdown path

Appearance remains a consumer concern so Scrapbook can keep its own hatch treatment while using the shared matcher/AST adapter.