### PR TITLE
Add the arbitrary-page DOM adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,12 @@ A change in one layer should rarely require logic in another.
 - `packages/en` — English profanity rules, English-specific coverage helpers, English regression corpus
 - `packages/react` — React renderer and appearance/reveal behavior
 - `packages/rehype` — HAST/rehype transformer for syntax-tree prose
+- `packages/dom` — arbitrary-page text-node transformation, restoration, and mutation observation
 - `apps/demo` — public interactive proof sheet and integration consumer
 - `fixtures/consumer` — external packed-package smoke consumer
 - `docs` — design and extension guidance
 
-Planned adapters are tracked in GitHub issues for arbitrary DOM, the browser extension, and Scrapbook adoption.
+Planned application work is tracked in GitHub issues for the browser extension and Scrapbook adoption.
 
 ## Commands
 
@@ -76,6 +77,18 @@ Passive reveal modes (`hover`, `never`) stay outside the tab order. Keyboard-dri
 Keep code/pre/script/style/textarea exclusions safe by default. Preserve inline elements and link boundaries. Never match across separate text nodes or markup seams unless a future API explicitly introduces a higher-level tokenization pass with corpus evidence.
 
 The rehype transform must stay idempotent: existing `data-scrawlix-cover` output is an excluded subtree.
+
+### Keep arbitrary-page DOM work local and reversible
+
+`@scrawlix/dom` collects eligible text nodes with `TreeWalker`, transforms only nodes with covered ranges, and marks generated roots with `data-scrawlix-dom-root`. Applying the same controller again must leave generated output alone.
+
+Mutation observation must process nodes delivered by `MutationObserver`. Never replace this with a complete document rescan after each mutation.
+
+Keep editable/form/code-like regions and non-HTML namespaces safe by default. Treat `contenteditable="false"` as an explicit island inside an editable ancestor.
+
+Restoration is controller-owned. A controller records exact source strings for roots it creates and must leave author-owned lookalike attributes alone. When observation is active, use the observation handle's atomic `restore()` lifecycle so disconnect happens before source nodes return.
+
+Presentation remains above the DOM adapter. Keep black bars, blur, grawlix masks, site preferences, and extension UI out of `@scrawlix/dom`.
 
 ### Add corpus cases for learned linguistic behavior
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,32 @@ Covered fragments become spans carrying `data-scrawlix-cover` and `data-scrawlix
 
 `code`, `pre`, `script`, `style`, and `textarea` subtrees are skipped by default. Applications can add excluded tags, place `data-scrawlix-ignore` on a subtree, or provide a `shouldSkip` predicate. The transformer also skips its own output, so repeated processing stays idempotent.
 
+## Arbitrary webpages / DOM
+
+`@scrawlix/dom` applies the same rules to an existing DOM and can observe future page mutations:
+
+```ts
+import { createDomScrawlix } from '@scrawlix/dom';
+import { englishProfanityRules } from '@scrawlix/en';
+
+const censor = createDomScrawlix({
+  rules: englishProfanityRules,
+  coverage: 'middle',
+});
+
+const observation = censor.observe(document.body);
+```
+
+Only text nodes with actual covered ranges are wrapped. Generated roots use `data-scrawlix-dom-root`; covered fragments use the same `data-scrawlix-cover` and `data-scrawlix-rules` attributes as the rehype adapter.
+
+Dynamic observation queues only nodes reported by `MutationObserver`. Turning a site off can be one lifecycle call:
+
+```ts
+observation.restore();
+```
+
+That disconnects observation, clears pending work, and restores the controller-owned source strings. Form/editable/code-like regions, non-HTML namespaces, and generated output are skipped by default. See `docs/dom.md` for exclusion and lifecycle details.
+
 ## Custom words and phrases
 
 Profanity is only one rule pack. Callers can censor names, spoilers, codenames, or arbitrary phrases:

--- a/apps/demo/public/llms.txt
+++ b/apps/demo/public/llms.txt
@@ -9,6 +9,7 @@ Packages:
 - @scrawlix/en — English profanity rules, English vowel coverage, regression corpus
 - @scrawlix/react — React renderer and visual/reveal presets
 - @scrawlix/rehype — HAST/rehype transformer for Markdown-rendered prose
+- @scrawlix/dom — arbitrary-page DOM transformation, restoration, and mutation observation
 
 Canonical React usage:
 
@@ -50,7 +51,25 @@ const plugin = [
 ];
 ```
 
+Canonical arbitrary-page usage:
+
+```ts
+import { createDomScrawlix } from '@scrawlix/dom';
+import { englishProfanityRules } from '@scrawlix/en';
+
+const controller = createDomScrawlix({
+  rules: englishProfanityRules,
+  coverage: 'middle',
+});
+
+const observation = controller.observe(document.body);
+// Later, when disabling censorship:
+observation.restore();
+```
+
 The rehype adapter emits spans with `data-scrawlix-cover` and `data-scrawlix-rules`, preserves the original text as text content, and skips code/pre/script/style/textarea by default.
+
+The DOM adapter transforms only matching text nodes, marks controller output with `data-scrawlix-dom-root`, skips editable/form/code/non-HTML regions by default, observes only mutation roots delivered by MutationObserver, and can restore exact controller-owned source strings.
 
 Core is deliberately language-neutral. Select language/rule packs explicitly. Custom names, spoilers, and phrases can be supplied with `censorRuleFromWords()`.
 
@@ -61,4 +80,5 @@ React reveal modes: hover, focus, click, never.
 
 Maintainer guidance: https://github.com/teamleaderleo/scrawlix/blob/main/AGENTS.md
 Language packs: https://github.com/teamleaderleo/scrawlix/blob/main/docs/language-packs.md
+DOM lifecycle: https://github.com/teamleaderleo/scrawlix/blob/main/docs/dom.md
 Release readiness: https://github.com/teamleaderleo/scrawlix/issues/18

--- a/docs/dom.md
+++ b/docs/dom.md
@@ -1,0 +1,114 @@
+# DOM adapter
+
+`@scrawlix/dom` applies Scrawlix to text nodes in an existing webpage. It is intended for browser extensions, enhancement scripts, and other environments where the page did not render through Scrawlix itself.
+
+## Apply once
+
+```ts
+import { createDomScrawlix } from '@scrawlix/dom';
+import { englishProfanityRules } from '@scrawlix/en';
+
+const censor = createDomScrawlix({
+  rules: englishProfanityRules,
+  coverage: 'middle',
+});
+
+censor.apply(document.body);
+```
+
+Only text nodes containing covered ranges are replaced. Each transformed text node gets one `data-scrawlix-dom-root` wrapper. Covered fragments inside it carry `data-scrawlix-cover` and `data-scrawlix-rules`; their text content remains the original source substring.
+
+The returned result reports `transformedTextNodes` and `coveredSegments`.
+
+## Restore
+
+A controller records the exact source strings for wrappers it creates:
+
+```ts
+censor.restore(document.body);
+```
+
+Restoration only touches wrappers owned by that controller. Author-authored elements that happen to carry similar data attributes remain intact.
+
+## Dynamic pages
+
+For SPAs, feeds, chats, and infinite-scroll pages:
+
+```ts
+const observation = censor.observe(document.body);
+```
+
+Observation applies to the initial subtree by default, then watches `childList` and `characterData` mutations. Mutation work is queued from the nodes delivered by `MutationObserver`; the adapter does not rescan the complete document after every update.
+
+To observe only future changes:
+
+```ts
+const observation = censor.observe(document.body, { initial: false });
+```
+
+To disable censorship safely while observation is active:
+
+```ts
+observation.restore();
+```
+
+`observation.restore()` disconnects the observer, clears queued work, and restores controller-owned source text as one lifecycle operation. `disconnect()` leaves current transformed output in place.
+
+## Safe default exclusions
+
+The adapter skips:
+
+- `button`
+- `code`
+- `input`
+- `kbd`
+- `noscript`
+- `option`
+- `pre`
+- `samp`
+- `script`
+- `select`
+- `style`
+- `template`
+- `textarea`
+- inherited editable regions (`contenteditable`, including `plaintext-only`)
+- non-HTML namespaces such as SVG
+- Scrawlix-generated output
+
+A nested `contenteditable="false"` island is eligible again, matching browser editing inheritance.
+
+## Application exclusions
+
+Add tag-level exclusions:
+
+```ts
+createDomScrawlix({
+  rules,
+  excludeTags: ['a'],
+});
+```
+
+Skip an application-owned subtree in markup:
+
+```html
+<div data-scrawlix-ignore>...</div>
+```
+
+Or make the final decision per text node:
+
+```ts
+createDomScrawlix({
+  rules,
+  shouldSkipText(node) {
+    return node.parentElement?.closest('[data-private-editor]') !== null;
+  },
+});
+```
+
+`ignoreAttribute` can be changed or disabled when an application already uses that name.
+
+## Presentation
+
+The DOM adapter is semantic. It emits source-preserving wrappers and cover attributes; it does not impose black bars, blur, grawlix symbols, or reveal interaction.
+
+That separation keeps arbitrary-page mutation small and gives the browser extension a clear layering point: DOM discovery/restoration in `@scrawlix/dom`, site/user state in the extension, and presentation in injected CSS/interaction code.

--- a/fixtures/consumer/src/main.tsx
+++ b/fixtures/consumer/src/main.tsx
@@ -1,4 +1,5 @@
 import { createScrawlix } from '@scrawlix/core';
+import { createDomScrawlix } from '@scrawlix/dom';
 import { englishProfanityRules } from '@scrawlix/en';
 import { transformHast } from '@scrawlix/rehype';
 import { CensoredText } from '@scrawlix/react';
@@ -46,6 +47,20 @@ if (
   )
 ) {
   throw new Error('Scrawlix rehype package smoke assertion failed.');
+}
+
+const domHost = document.createElement('div');
+domHost.textContent = 'well, fuck';
+const domResult = createDomScrawlix({
+  rules: englishProfanityRules,
+  coverage: 'middle',
+}).apply(domHost);
+
+if (
+  domResult.transformedTextNodes !== 1 ||
+  !domHost.querySelector('[data-scrawlix-cover]')
+) {
+  throw new Error('Scrawlix DOM package smoke assertion failed.');
 }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "pnpm build:packages && pnpm --filter scrawlix-demo build",
-    "build:packages": "pnpm --filter @scrawlix/core build && pnpm --filter @scrawlix/en build && pnpm --filter @scrawlix/react build && pnpm --filter @scrawlix/rehype build",
+    "build:packages": "pnpm --filter @scrawlix/core build && pnpm --filter @scrawlix/en build && pnpm --filter @scrawlix/react build && pnpm --filter @scrawlix/rehype build && pnpm --filter @scrawlix/dom build",
     "dev": "pnpm --filter scrawlix-demo dev",
     "smoke:packages": "node scripts/smoke-packages.mjs",
     "test": "pnpm build:packages && pnpm -r --if-present test",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@scrawlix/dom",
+  "version": "0.0.0",
+  "description": "DOM text-node adapter for applying Scrawlix to arbitrary webpages and dynamic content.",
+  "type": "module",
+  "sideEffects": false,
+  "files": ["dist"],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/teamleaderleo/scrawlix.git",
+    "directory": "packages/dom"
+  },
+  "homepage": "https://github.com/teamleaderleo/scrawlix#readme",
+  "bugs": {
+    "url": "https://github.com/teamleaderleo/scrawlix/issues"
+  },
+  "keywords": ["dom", "browser", "censor", "redaction", "scrawlix"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@scrawlix/core": "workspace:*"
+  },
+  "devDependencies": {
+    "jsdom": "^26.1.0"
+  },
+  "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.build.json",
+    "prepack": "pnpm build",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  }
+}

--- a/packages/dom/src/index.test.ts
+++ b/packages/dom/src/index.test.ts
@@ -1,0 +1,209 @@
+/** @vitest-environment jsdom */
+
+import { censorRuleFromWords } from '@scrawlix/core';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createDomScrawlix } from './index';
+
+const rules = [censorRuleFromWords('fuck', ['fuck'])] as const;
+
+function controller() {
+  return createDomScrawlix({ rules, coverage: 'middle' });
+}
+
+function tick() {
+  return new Promise<void>(resolve => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('@scrawlix/dom', () => {
+  it('transforms matching text nodes while preserving their complete text content', () => {
+    document.body.innerHTML = '<p id="copy">well, fuck this</p>';
+    const scrawlix = controller();
+
+    const result = scrawlix.apply(document.body);
+
+    expect(result).toEqual({ transformedTextNodes: 1, coveredSegments: 1 });
+    const paragraph = document.querySelector('#copy')!;
+    const wrapper = paragraph.querySelector('[data-scrawlix-dom-root]')!;
+    const cover = wrapper.querySelector('[data-scrawlix-cover]')!;
+
+    expect(paragraph.textContent).toBe('well, fuck this');
+    expect(cover.textContent).toBe('uc');
+    expect(cover.getAttribute('data-scrawlix-rules')).toBe('fuck');
+  });
+
+  it('leaves safe text nodes untouched', () => {
+    document.body.innerHTML = '<p>a perfectly ordinary sentence</p>';
+    const scrawlix = controller();
+
+    expect(scrawlix.apply(document.body)).toEqual({
+      transformedTextNodes: 0,
+      coveredSegments: 0,
+    });
+    expect(document.querySelector('[data-scrawlix-dom-root]')).toBeNull();
+  });
+
+  it.each(['code', 'pre', 'button', 'textarea', 'kbd', 'samp'])(
+    'skips <%s> content by default',
+    tagName => {
+      const element = document.createElement(tagName);
+      element.textContent = 'fuck';
+      document.body.append(element);
+      const scrawlix = controller();
+
+      scrawlix.apply(document.body);
+
+      expect(element.querySelector('[data-scrawlix-dom-root]')).toBeNull();
+      expect(element.textContent).toBe('fuck');
+    }
+  );
+
+  it('skips contenteditable subtrees', () => {
+    const editable = document.createElement('div');
+    editable.setAttribute('contenteditable', 'true');
+    editable.textContent = 'fuck';
+    document.body.append(editable);
+
+    controller().apply(document.body);
+
+    expect(editable.querySelector('[data-scrawlix-dom-root]')).toBeNull();
+  });
+
+  it('honors nested contenteditable=false islands', () => {
+    const editable = document.createElement('div');
+    editable.setAttribute('contenteditable', 'true');
+    const island = document.createElement('span');
+    island.setAttribute('contenteditable', 'false');
+    island.textContent = 'fuck';
+    editable.append(island);
+    document.body.append(editable);
+
+    controller().apply(document.body);
+
+    expect(island.querySelector('[data-scrawlix-dom-root]')).not.toBeNull();
+  });
+
+  it('skips non-HTML namespaces such as SVG text', () => {
+    document.body.innerHTML =
+      '<svg xmlns="http://www.w3.org/2000/svg"><text>fuck</text></svg>';
+
+    controller().apply(document.body);
+
+    expect(document.querySelector('[data-scrawlix-dom-root]')).toBeNull();
+  });
+
+  it('supports the application ignore attribute and custom excluded tags', () => {
+    document.body.innerHTML = `
+      <div data-scrawlix-ignore>fuck</div>
+      <a href="#">fuck</a>
+      <p>fuck</p>
+    `;
+    const scrawlix = createDomScrawlix({
+      rules,
+      coverage: 'full',
+      excludeTags: ['a'],
+    });
+
+    const result = scrawlix.apply(document.body);
+
+    expect(result.transformedTextNodes).toBe(1);
+    expect(document.querySelector('div [data-scrawlix-dom-root]')).toBeNull();
+    expect(document.querySelector('a [data-scrawlix-dom-root]')).toBeNull();
+    expect(document.querySelector('p [data-scrawlix-dom-root]')).not.toBeNull();
+  });
+
+  it('supports an application text-node veto', () => {
+    document.body.innerHTML = '<p id="skip">fuck</p><p id="keep">fuck</p>';
+    const scrawlix = createDomScrawlix({
+      rules,
+      coverage: 'full',
+      shouldSkipText: node => node.parentElement?.id === 'skip',
+    });
+
+    scrawlix.apply(document.body);
+
+    expect(document.querySelector('#skip [data-scrawlix-dom-root]')).toBeNull();
+    expect(document.querySelector('#keep [data-scrawlix-dom-root]')).not.toBeNull();
+  });
+
+  it('is idempotent and skips generated output', () => {
+    document.body.innerHTML = '<p>fuck</p>';
+    const scrawlix = controller();
+
+    const first = scrawlix.apply(document.body);
+    const second = scrawlix.apply(document.body);
+
+    expect(first.transformedTextNodes).toBe(1);
+    expect(second.transformedTextNodes).toBe(0);
+    expect(document.querySelectorAll('[data-scrawlix-dom-root]')).toHaveLength(1);
+  });
+
+  it('restores the exact original text for wrappers owned by the controller', () => {
+    document.body.innerHTML = '<p id="copy">well, fuck this</p>';
+    const scrawlix = controller();
+    scrawlix.apply(document.body);
+
+    const cover = document.querySelector('[data-scrawlix-cover]')!;
+    cover.textContent = 'changed by presentation code';
+
+    expect(scrawlix.restore(document.body)).toBe(1);
+    expect(document.querySelector('#copy')?.textContent).toBe('well, fuck this');
+    expect(document.querySelector('[data-scrawlix-dom-root]')).toBeNull();
+  });
+
+  it('only restores roots created by the same controller', () => {
+    document.body.innerHTML =
+      '<span data-scrawlix-dom-root>author-owned marker</span><p>fuck</p>';
+    const scrawlix = controller();
+    scrawlix.apply(document.body);
+
+    expect(scrawlix.restore(document.body)).toBe(1);
+    expect(
+      document.querySelector('[data-scrawlix-dom-root]')?.textContent
+    ).toBe('author-owned marker');
+  });
+
+  it('can transform the initial subtree when observation starts', () => {
+    document.body.innerHTML = '<p>fuck</p>';
+    const observation = controller().observe(document.body);
+
+    expect(observation.initialResult.transformedTextNodes).toBe(1);
+    expect(document.querySelector('[data-scrawlix-dom-root]')).not.toBeNull();
+    observation.disconnect();
+  });
+
+  it('observes newly added subtrees without rescanning existing text', async () => {
+    document.body.innerHTML = '<p id="existing">fuck</p>';
+    const scrawlix = controller();
+    const observation = scrawlix.observe(document.body, { initial: false });
+
+    const added = document.createElement('p');
+    added.id = 'added';
+    added.textContent = 'fuck';
+    document.body.append(added);
+
+    await tick();
+
+    expect(document.querySelector('#existing [data-scrawlix-dom-root]')).toBeNull();
+    expect(document.querySelector('#added [data-scrawlix-dom-root]')).not.toBeNull();
+    observation.disconnect();
+  });
+
+  it('observes character-data changes', async () => {
+    const paragraph = document.createElement('p');
+    const text = document.createTextNode('safe');
+    paragraph.append(text);
+    document.body.append(paragraph);
+
+    const observation = controller().observe(document.body, { initial: false });
+    text.data = 'fuck';
+
+    await tick();
+
+    expect(paragraph.querySelector('[data-scrawlix-dom-root]')).not.toBeNull();
+    observation.disconnect();
+  });
+});

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -249,7 +249,9 @@ export function createDomScrawlix(
 
     if ('querySelectorAll' in root) {
       const queryable = root as Node & ParentNode;
-      roots.push(...queryable.querySelectorAll('[data-scrawlix-dom-root]'));
+      roots.push(
+        ...Array.from(queryable.querySelectorAll('[data-scrawlix-dom-root]'))
+      );
     }
 
     return roots;
@@ -314,7 +316,7 @@ export function createDomScrawlix(
           continue;
         }
 
-        for (const added of record.addedNodes) {
+        for (const added of Array.from(record.addedNodes)) {
           pending.add(added);
         }
       }

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -56,6 +56,8 @@ export type DomObservation = {
   /** Process mutation roots already delivered by MutationObserver. */
   flush(): DomApplyResult;
   disconnect(): void;
+  /** Disconnect observation, clear pending work, then restore owned text in one call. */
+  restore(): number;
 };
 
 export type DomScrawlixController = {
@@ -291,6 +293,12 @@ export function createDomScrawlix(
       );
     };
 
+    const stop = () => {
+      scheduled = false;
+      pending.clear();
+      observer.disconnect();
+    };
+
     const schedule = () => {
       if (scheduled) return;
       scheduled = true;
@@ -325,10 +333,10 @@ export function createDomScrawlix(
     return {
       initialResult,
       flush,
-      disconnect() {
-        scheduled = false;
-        pending.clear();
-        observer.disconnect();
+      disconnect: stop,
+      restore() {
+        stop();
+        return restore(root);
       },
     };
   }

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -1,0 +1,339 @@
+import {
+  createScrawlix,
+  type CensorRule,
+  type CoverageSelector,
+  type ScrawlixSegment,
+} from '@scrawlix/core';
+
+const SHOW_TEXT = 4;
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+const DOCUMENT_NODE = 9;
+const HTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+
+const DEFAULT_EXCLUDED_TAGS = [
+  'button',
+  'code',
+  'input',
+  'kbd',
+  'noscript',
+  'option',
+  'pre',
+  'samp',
+  'script',
+  'select',
+  'style',
+  'template',
+  'textarea',
+] as const;
+
+export type DomScrawlixOptions = {
+  rules: readonly CensorRule[];
+  coverage?: CoverageSelector;
+  /** Additional HTML tag names whose complete subtrees should be left untouched. */
+  excludeTags?: readonly string[];
+  /**
+   * Skip subtrees carrying this attribute. Defaults to `data-scrawlix-ignore`.
+   * Set to `false` to disable this escape hatch.
+   */
+  ignoreAttribute?: string | false;
+  /** Application-specific final veto for an otherwise eligible text node. */
+  shouldSkipText?: (node: Text) => boolean;
+};
+
+export type DomApplyResult = {
+  transformedTextNodes: number;
+  coveredSegments: number;
+};
+
+export type DomObserveOptions = {
+  /** Apply Scrawlix to the existing subtree before observing future mutations. */
+  initial?: boolean;
+};
+
+export type DomObservation = {
+  initialResult: DomApplyResult;
+  /** Process mutation roots already delivered by MutationObserver. */
+  flush(): DomApplyResult;
+  disconnect(): void;
+};
+
+export type DomScrawlixController = {
+  apply(root: Node): DomApplyResult;
+  /** Restore wrappers created by this controller within `root`. */
+  restore(root: Node): number;
+  observe(root: Node, options?: DomObserveOptions): DomObservation;
+};
+
+type PreparedOptions = {
+  excludedTags: ReadonlySet<string>;
+  ignoreAttribute: string | false;
+  shouldSkipText?: (node: Text) => boolean;
+};
+
+function emptyResult(): DomApplyResult {
+  return { transformedTextNodes: 0, coveredSegments: 0 };
+}
+
+function addResults(left: DomApplyResult, right: DomApplyResult): DomApplyResult {
+  return {
+    transformedTextNodes:
+      left.transformedTextNodes + right.transformedTextNodes,
+    coveredSegments: left.coveredSegments + right.coveredSegments,
+  };
+}
+
+function ownerDocument(node: Node): Document | null {
+  if (node.nodeType === DOCUMENT_NODE) return node as Document;
+  return node.ownerDocument;
+}
+
+function hasGeneratedAncestor(node: Text) {
+  let element = node.parentElement;
+  while (element) {
+    if (
+      element.hasAttribute('data-scrawlix-dom-root') ||
+      element.hasAttribute('data-scrawlix-cover')
+    ) {
+      return true;
+    }
+    element = element.parentElement;
+  }
+  return false;
+}
+
+function contentEditableState(node: Text): boolean {
+  let element = node.parentElement;
+
+  while (element) {
+    const value = element.getAttribute('contenteditable');
+    if (value !== null) {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === 'false') return false;
+      if (
+        normalized === '' ||
+        normalized === 'true' ||
+        normalized === 'plaintext-only'
+      ) {
+        return true;
+      }
+    }
+    element = element.parentElement;
+  }
+
+  return false;
+}
+
+function isEligibleText(node: Text, options: PreparedOptions) {
+  if (!node.data) return false;
+  if (hasGeneratedAncestor(node)) return false;
+  if (options.shouldSkipText?.(node) === true) return false;
+
+  const parent = node.parentElement;
+  if (!parent) return false;
+  if (parent.namespaceURI && parent.namespaceURI !== HTML_NAMESPACE) return false;
+  if (contentEditableState(node)) return false;
+
+  let element: Element | null = parent;
+  while (element) {
+    if (options.excludedTags.has(element.tagName.toLowerCase())) return false;
+    if (
+      options.ignoreAttribute &&
+      element.hasAttribute(options.ignoreAttribute)
+    ) {
+      return false;
+    }
+    element = element.parentElement;
+  }
+
+  return true;
+}
+
+function coverElement(document: Document, segment: ScrawlixSegment) {
+  const element = document.createElement('span');
+  element.setAttribute('data-scrawlix-cover', '');
+  element.setAttribute('data-scrawlix-rules', segment.ruleIds.join(','));
+  element.append(document.createTextNode(segment.text));
+  return element;
+}
+
+export function createDomScrawlix(
+  options: DomScrawlixOptions
+): DomScrawlixController {
+  const engine = createScrawlix({
+    rules: options.rules,
+    coverage: options.coverage,
+  });
+  const prepared: PreparedOptions = {
+    excludedTags: new Set(
+      [...DEFAULT_EXCLUDED_TAGS, ...(options.excludeTags ?? [])].map(tag =>
+        tag.toLowerCase()
+      )
+    ),
+    ignoreAttribute: options.ignoreAttribute ?? 'data-scrawlix-ignore',
+    shouldSkipText: options.shouldSkipText,
+  };
+
+  const ownedRoots = new WeakSet<Element>();
+  const originalText = new WeakMap<Element, string>();
+
+  function transformTextNode(node: Text): DomApplyResult {
+    if (!isEligibleText(node, prepared)) return emptyResult();
+
+    const segments = engine.segment(node.data);
+    const coveredSegments = segments.filter(segment => segment.covered).length;
+    if (coveredSegments === 0) return emptyResult();
+
+    const document = node.ownerDocument;
+    const wrapper = document.createElement('span');
+    wrapper.setAttribute('data-scrawlix-dom-root', '');
+
+    for (const segment of segments) {
+      if (segment.covered) {
+        wrapper.append(coverElement(document, segment));
+      } else {
+        wrapper.append(document.createTextNode(segment.text));
+      }
+    }
+
+    ownedRoots.add(wrapper);
+    originalText.set(wrapper, node.data);
+    node.replaceWith(wrapper);
+
+    return { transformedTextNodes: 1, coveredSegments };
+  }
+
+  function apply(root: Node): DomApplyResult {
+    if (root.nodeType === TEXT_NODE) {
+      return transformTextNode(root as Text);
+    }
+
+    if (
+      root.nodeType === ELEMENT_NODE &&
+      (root as Element).hasAttribute('data-scrawlix-dom-root')
+    ) {
+      return emptyResult();
+    }
+
+    const document = ownerDocument(root);
+    if (!document) return emptyResult();
+
+    const walker = document.createTreeWalker(root, SHOW_TEXT);
+    const candidates: Text[] = [];
+    let current = walker.nextNode();
+
+    while (current) {
+      if (current.nodeType === TEXT_NODE && isEligibleText(current as Text, prepared)) {
+        candidates.push(current as Text);
+      }
+      current = walker.nextNode();
+    }
+
+    return candidates.reduce(
+      (result, node) => addResults(result, transformTextNode(node)),
+      emptyResult()
+    );
+  }
+
+  function generatedRootsWithin(root: Node): Element[] {
+    const roots: Element[] = [];
+
+    if (
+      root.nodeType === ELEMENT_NODE &&
+      (root as Element).hasAttribute('data-scrawlix-dom-root')
+    ) {
+      roots.push(root as Element);
+    }
+
+    if ('querySelectorAll' in root) {
+      const queryable = root as Node & ParentNode;
+      roots.push(...queryable.querySelectorAll('[data-scrawlix-dom-root]'));
+    }
+
+    return roots;
+  }
+
+  function restore(root: Node) {
+    let restored = 0;
+
+    for (const wrapper of generatedRootsWithin(root)) {
+      if (!ownedRoots.has(wrapper)) continue;
+      const document = wrapper.ownerDocument;
+      const source = originalText.get(wrapper) ?? wrapper.textContent ?? '';
+      wrapper.replaceWith(document.createTextNode(source));
+      restored += 1;
+    }
+
+    return restored;
+  }
+
+  function observe(
+    root: Node,
+    observeOptions: DomObserveOptions = {}
+  ): DomObservation {
+    const document = ownerDocument(root);
+    const MutationObserverConstructor = document?.defaultView?.MutationObserver;
+    if (!MutationObserverConstructor) {
+      throw new Error('MutationObserver is unavailable for this DOM root.');
+    }
+
+    const pending = new Set<Node>();
+    let scheduled = false;
+
+    const flush = () => {
+      scheduled = false;
+      const queued = [...pending];
+      pending.clear();
+
+      return queued.reduce(
+        (result, node) => addResults(result, apply(node)),
+        emptyResult()
+      );
+    };
+
+    const schedule = () => {
+      if (scheduled) return;
+      scheduled = true;
+      void Promise.resolve().then(() => {
+        if (scheduled) flush();
+      });
+    };
+
+    const observer = new MutationObserverConstructor(records => {
+      for (const record of records) {
+        if (record.type === 'characterData') {
+          pending.add(record.target);
+          continue;
+        }
+
+        for (const added of record.addedNodes) {
+          pending.add(added);
+        }
+      }
+      if (pending.size > 0) schedule();
+    });
+
+    const initialResult =
+      observeOptions.initial === false ? emptyResult() : apply(root);
+
+    observer.observe(root, {
+      subtree: true,
+      childList: true,
+      characterData: true,
+    });
+
+    return {
+      initialResult,
+      flush,
+      disconnect() {
+        scheduled = false;
+        pending.clear();
+        observer.disconnect();
+      },
+    };
+  }
+
+  return { apply, restore, observe };
+}
+
+export default createDomScrawlix;

--- a/packages/dom/src/observation.test.ts
+++ b/packages/dom/src/observation.test.ts
@@ -1,0 +1,32 @@
+/** @vitest-environment jsdom */
+
+import { censorRuleFromWords } from '@scrawlix/core';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createDomScrawlix } from './index';
+
+const rules = [censorRuleFromWords('fuck', ['fuck'])] as const;
+
+function tick() {
+  return new Promise<void>(resolve => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('DOM observation lifecycle', () => {
+  it('disconnects before restoring so disable does not immediately recensor text', async () => {
+    document.body.innerHTML = '<p id="copy">fuck</p>';
+    const controller = createDomScrawlix({ rules, coverage: 'full' });
+    const observation = controller.observe(document.body);
+
+    expect(document.querySelector('[data-scrawlix-dom-root]')).not.toBeNull();
+    expect(observation.restore()).toBe(1);
+    expect(document.querySelector('#copy')?.textContent).toBe('fuck');
+    expect(document.querySelector('[data-scrawlix-dom-root]')).toBeNull();
+
+    await tick();
+
+    expect(document.querySelector('[data-scrawlix-dom-root]')).toBeNull();
+  });
+});

--- a/packages/dom/tsconfig.build.json
+++ b/packages/dom/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "paths": {}
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/dom/tsconfig.json
+++ b/packages/dom/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/smoke-packages.mjs
+++ b/scripts/smoke-packages.mjs
@@ -61,6 +61,7 @@ try {
   const englishTarball = packPackage('packages/en');
   const reactTarball = packPackage('packages/react');
   const rehypeTarball = packPackage('packages/rehype');
+  const domTarball = packPackage('packages/dom');
 
   cpSync(resolve(root, 'fixtures/consumer'), consumerDirectory, {
     recursive: true,
@@ -76,6 +77,7 @@ try {
     '@scrawlix/en': asFileDependency(englishTarball),
     '@scrawlix/react': asFileDependency(reactTarball),
     '@scrawlix/rehype': asFileDependency(rehypeTarball),
+    '@scrawlix/dom': asFileDependency(domTarball),
   };
   packageJson.pnpm = {
     overrides: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
       "@scrawlix/en": ["packages/en/src/index.ts"],
       "@scrawlix/en/corpus": ["packages/en/src/corpus.ts"],
       "@scrawlix/react": ["packages/react/src/index.tsx"],
-      "@scrawlix/rehype": ["packages/rehype/src/index.ts"]
+      "@scrawlix/rehype": ["packages/rehype/src/index.ts"],
+      "@scrawlix/dom": ["packages/dom/src/index.ts"]
     }
   }
 }


### PR DESCRIPTION
Closes #4.
Progresses #5 and #13.

### `@scrawlix/dom`
- walks existing page text with `TreeWalker`
- transforms only text nodes with actual covered ranges
- wraps transformed nodes with controller-owned `data-scrawlix-dom-root` markers
- emits `data-scrawlix-cover` / `data-scrawlix-rules` on covered fragments
- preserves exact source strings in controller-owned weak state for restoration
- is idempotent and skips generated output

### Safe arbitrary-page defaults
- skips code/pre/script/style/template/noscript
- skips form/control-like text including button/select/option/textarea/input
- skips kbd/samp
- skips inherited contenteditable regions while honoring nested `contenteditable="false"` islands
- skips non-HTML namespaces such as SVG
- supports additional excluded tags, `data-scrawlix-ignore`, and `shouldSkipText`

### Dynamic pages
- `observe(root)` applies an optional initial pass, then uses `MutationObserver`
- mutation processing queues only added nodes / changed text delivered by the observer
- regression coverage proves an existing unsafe node stays untouched when observation starts with `{ initial: false }` and a new unsafe node is appended
- `observation.restore()` atomically disconnects, clears pending work, and restores source so disabling a site cannot immediately trigger recensoring

### Package ergonomics
- builds ESM/declarations into `dist`
- joins the workspace package build
- joins the external tarball smoke consumer
- adds `docs/dom.md`, README usage, AGENTS.md invariants, and llms.txt discovery

Presentation and extension preference state remain above this package; `@scrawlix/dom` owns DOM discovery, mutation, and restoration only.