### PR TITLE
Build the first Scrawlix browser extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,11 @@ A change in one layer should rarely require logic in another.
 - `packages/rehype` — HAST/rehype transformer for syntax-tree prose
 - `packages/dom` — arbitrary-page text-node transformation, restoration, and mutation observation
 - `apps/demo` — public interactive proof sheet and integration consumer
+- `apps/extension` — Manifest V3 application: browser state, popup UI, and injected presentation
 - `fixtures/consumer` — external packed-package smoke consumer
 - `docs` — design and extension guidance
 
-Planned application work is tracked in GitHub issues for the browser extension and Scrapbook adoption.
+Scrapbook adoption remains tracked separately as a real-consumer integration.
 
 ## Commands
 
@@ -38,7 +39,7 @@ pnpm build
 pnpm smoke:packages
 ```
 
-The demo build is part of the workspace build and acts as an integration check across core, language packs, and React. The package smoke test installs packed tarballs into a consumer outside the workspace dependency graph.
+The demo and extension builds are part of the workspace build. The package smoke test installs packed tarballs into a consumer outside the workspace dependency graph.
 
 ## Invariants
 
@@ -90,6 +91,18 @@ Restoration is controller-owned. A controller records exact source strings for r
 
 Presentation remains above the DOM adapter. Keep black bars, blur, grawlix masks, site preferences, and extension UI out of `@scrawlix/dom`.
 
+### Keep browser-extension state in the application
+
+`apps/extension` owns `chrome.storage`, hostname overrides, popup UI, manifest permissions, and injected presentation. Do not move those concerns into reusable packages.
+
+Small global preferences belong in `storage.sync`; custom terms currently live in `storage.local`. Host overrides are sparse tri-state policy: absence means inherit, explicit values are `on` or `off`.
+
+A storage change restarts the page session through `DomObservation.restore()` before a new controller starts. Preserve that atomic restore/reconfigure sequence.
+
+Extension reveal interaction must avoid stealing native page controls. Generated roots inside links, buttons, inputs, or similar controls stay outside the extension's own focus/click-toggle path.
+
+Broad HTTP/HTTPS host access is a deliberate development choice for persistent automatic per-site behavior. Treat permission minimization as a store-release requirement and document any permission change alongside its UX tradeoff.
+
 ### Add corpus cases for learned linguistic behavior
 
 When a bug or rule change teaches a durable positive or false-positive example, add it to the relevant pack corpus. Prefer data cases over one-off matcher test code.
@@ -112,6 +125,7 @@ When a bug or rule change teaches a durable positive or false-positive example, 
 4. Add the appearance to the demo specimen sheet.
 5. Preserve reveal modes and reduced-motion behavior.
 6. Extend rendered regressions for any new DOM contract or interaction.
+7. If the extension should expose the same appearance, update its local presentation union/CSS and test its mask semantics separately.
 
 ## Adding a coverage behavior
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Scrawlix separates the interesting parts of censorship so they can be mixed deli
 
 That means the same word can become `████`, `f███`, `f██k`, `f█ck`, `f**k`, a blur, an inked-over scrawl, or a grawlix — while callers keep control of the underlying source text.
 
-Scrawlix began as a censor/reveal primitive in [Scrapbook](https://github.com/teamleaderleo/scrapbook). The standalone project turns that experiment into a small language-neutral engine with rule packs and adapters for React, Markdown, the DOM, and eventually a browser extension.
+Scrawlix began as a censor/reveal primitive in [Scrapbook](https://github.com/teamleaderleo/scrapbook). The standalone project turns that experiment into a small language-neutral engine with rule packs and adapters for React, Markdown, arbitrary DOMs, and a browser extension built from the same pieces.
 
 ## Quick start
 
@@ -104,6 +104,30 @@ observation.restore();
 ```
 
 That disconnects observation, clears pending work, and restores the controller-owned source strings. Form/editable/code-like regions, non-HTML namespaces, and generated output are skipped by default. See `docs/dom.md` for exclusion and lifecycle details.
+
+## Browser extension
+
+The unpacked Manifest V3 extension lives in `apps/extension`. It is a thin application around `@scrawlix/dom` and `@scrawlix/en`: page matching/restoration stays in the packages, while browser storage, per-host preferences, injected presentation, and popup UI stay in the extension.
+
+```sh
+pnpm install
+pnpm build
+```
+
+Then load `apps/extension/dist` as an unpacked extension in a Chromium browser.
+
+The popup currently supports:
+
+- a global on/off switch
+- per-host **follow global / always on / always off** behavior
+- all five appearances
+- all generic coverage modes plus English vowel coverage
+- hover / focus / click / never reveal
+- local custom words and phrases
+
+Small preferences and sparse hostname overrides use `chrome.storage.sync`; custom terms use `chrome.storage.local`. A settings change restores the current page's source text before starting the newly configured observation session.
+
+The development manifest runs automatically on HTTP/HTTPS pages so per-site behavior survives navigation. That broad host access is intentionally called out as a store-release review item; see `apps/extension/README.md` for the permission, privacy, build, and lifecycle notes.
 
 ## Custom words and phrases
 

--- a/apps/demo/public/llms.txt
+++ b/apps/demo/public/llms.txt
@@ -11,6 +11,10 @@ Packages:
 - @scrawlix/rehype — HAST/rehype transformer for Markdown-rendered prose
 - @scrawlix/dom — arbitrary-page DOM transformation, restoration, and mutation observation
 
+Applications:
+- apps/demo — interactive proof-sheet demo
+- apps/extension — Manifest V3 browser extension built on @scrawlix/dom
+
 Canonical React usage:
 
 ```tsx
@@ -67,6 +71,8 @@ const observation = controller.observe(document.body);
 observation.restore();
 ```
 
+The browser extension keeps browser state outside reusable packages. Global treatment settings + sparse hostname overrides use chrome.storage.sync; custom terms use chrome.storage.local. Storage changes restore the old DOM session before a newly configured observation begins. Build it with `pnpm build`, then load `apps/extension/dist` as an unpacked Chromium extension.
+
 The rehype adapter emits spans with `data-scrawlix-cover` and `data-scrawlix-rules`, preserves the original text as text content, and skips code/pre/script/style/textarea by default.
 
 The DOM adapter transforms only matching text nodes, marks controller output with `data-scrawlix-dom-root`, skips editable/form/code/non-HTML regions by default, observes only mutation roots delivered by MutationObserver, and can restore exact controller-owned source strings.
@@ -81,4 +87,5 @@ React reveal modes: hover, focus, click, never.
 Maintainer guidance: https://github.com/teamleaderleo/scrawlix/blob/main/AGENTS.md
 Language packs: https://github.com/teamleaderleo/scrawlix/blob/main/docs/language-packs.md
 DOM lifecycle: https://github.com/teamleaderleo/scrawlix/blob/main/docs/dom.md
+Extension notes: https://github.com/teamleaderleo/scrawlix/blob/main/apps/extension/README.md
 Release readiness: https://github.com/teamleaderleo/scrawlix/issues/18

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -1,0 +1,98 @@
+# Scrawlix browser extension
+
+The extension is the first application built on `@scrawlix/dom`. It owns browser preference state and presentation; matching and arbitrary-page mutation remain reusable packages.
+
+## Build
+
+From the repository root:
+
+```sh
+pnpm install
+pnpm build
+```
+
+Or build only the extension after the publishable Scrawlix packages have been built:
+
+```sh
+pnpm build:packages
+pnpm --filter scrawlix-extension build
+```
+
+The unpacked extension is emitted to `apps/extension/dist`.
+
+To try it locally in Chromium:
+
+1. open the browser's Extensions page
+2. enable Developer mode
+3. choose **Load unpacked**
+4. select `apps/extension/dist`
+
+## Preferences
+
+Small preferences live in `chrome.storage.sync`:
+
+- global enabled state
+- appearance
+- coverage
+- reveal mode
+- sparse hostname overrides (`on` / `off`)
+
+Custom words and phrases live in `chrome.storage.local`. They can grow independently of the small synced preference object and stay local to the browser profile.
+
+The popup exposes a tri-state site mode:
+
+- **follow global** — no hostname entry is stored
+- **always on** — hostname explicitly overrides the global switch
+- **always off** — hostname explicitly overrides the global switch
+
+Storage changes are observed by the content script. A preference change tears down the current DOM observation with `observation.restore()`, restoring exact source text before a new configured session begins.
+
+## Page lifecycle
+
+The content script:
+
+1. loads the English pack plus one compiled custom-word rule when custom terms exist
+2. creates one `@scrawlix/dom` controller for the current settings
+3. observes `document.body`
+4. decorates only Scrawlix-generated roots with extension presentation metadata
+5. listens for storage changes and restarts atomically
+
+The DOM adapter watches mutation roots rather than rescanning the document after every page update.
+
+## Presentation
+
+`content.css` implements the extension's five appearances:
+
+- scrawl
+- bar
+- blur
+- asterisk
+- grawlix
+
+Asterisk/grawlix masks are presentation metadata on generated cover spans. The source substring remains the actual DOM text underneath.
+
+Hover is the default reveal mode. Focus/click reveal makes a generated wrapper keyboard-focusable only when the wrapper is outside links, buttons, inputs, and other native interactive controls. Scrawlix avoids stealing those controls' interaction semantics.
+
+## Permissions
+
+The development manifest requests:
+
+- `storage` — persist preferences
+- `activeTab` — let the popup identify the current HTTP/HTTPS hostname after the user opens it
+- host access to HTTP and HTTPS pages — run the content script automatically on pages where Scrawlix may be enabled
+
+The extension has no background service worker and sends no browsing or page text to a server. Matching happens inside the page's content-script context using bundled Scrawlix packages.
+
+Broad HTTP/HTTPS host access is a meaningful permission and should remain explicit in store-facing documentation. Before a store release, revisit whether optional host permissions or another activation model would deliver the desired persistent per-site behavior with a gentler permission prompt.
+
+## Build validation
+
+`pnpm --filter scrawlix-extension build` validates that:
+
+- the manifest is MV3
+- `content.js` exists
+- `content.css` exists
+- `popup.html` exists
+- every JS/CSS/popup path referenced by the manifest exists in `dist`
+
+Pure preference/mask behavior is covered by `src/config.test.ts`; broader extension/browser E2E coverage can grow after the first unpacked build is exercised manually.

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "Scrawlix",
+  "description": "Programmable censorship for the web.",
+  "version": "0.0.0",
+  "permissions": ["storage", "activeTab"],
+  "host_permissions": ["http://*/*", "https://*/*"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Scrawlix"
+  },
+  "content_scripts": [
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "js": ["content.js"],
+      "css": ["content.css"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "scrawlix-extension",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && vite build -c vite.content.config.ts && vite build -c vite.popup.config.ts && node ../../scripts/copy-file.mjs manifest.json dist/manifest.json && node ../../scripts/copy-file.mjs src/content.css dist/content.css && node scripts/validate-build.mjs",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@scrawlix/core": "workspace:*",
+    "@scrawlix/dom": "workspace:*",
+    "@scrawlix/en": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/chrome": "^0.2.7",
+    "@types/node": "^24.6.2",
+    "vite": "^7.1.7"
+  }
+}

--- a/apps/extension/popup.html
+++ b/apps/extension/popup.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Scrawlix</title>
+  </head>
+  <body>
+    <main class="popup-shell">
+      <header class="masthead">
+        <div>
+          <p class="wordmark">scrawlix<span aria-hidden="true">*</span></p>
+          <p class="tagline">programmable censorship</p>
+        </div>
+        <label class="switch-row compact">
+          <span>global</span>
+          <input id="enabled" type="checkbox" />
+        </label>
+      </header>
+
+      <section class="site-card" aria-labelledby="site-heading">
+        <div>
+          <p class="eyebrow">this site</p>
+          <h1 id="site-heading">Loading…</h1>
+          <p id="effective-status" class="status-line"></p>
+        </div>
+        <label>
+          <span class="sr-only">Site mode</span>
+          <select id="site-mode">
+            <option value="inherit">follow global</option>
+            <option value="on">always on</option>
+            <option value="off">always off</option>
+          </select>
+        </label>
+      </section>
+
+      <section class="settings-grid" aria-label="Censor treatment">
+        <label>
+          <span>appearance</span>
+          <select id="appearance">
+            <option value="scrawl">scrawl</option>
+            <option value="bar">bar</option>
+            <option value="blur">blur</option>
+            <option value="asterisk">asterisk</option>
+            <option value="grawlix">grawlix</option>
+          </select>
+        </label>
+
+        <label>
+          <span>coverage</span>
+          <select id="coverage">
+            <option value="middle">middle</option>
+            <option value="vowel">vowel</option>
+            <option value="inner">inner</option>
+            <option value="tail">tail</option>
+            <option value="full">full</option>
+          </select>
+        </label>
+
+        <label>
+          <span>reveal</span>
+          <select id="reveal">
+            <option value="hover">hover</option>
+            <option value="focus">focus</option>
+            <option value="click">click</option>
+            <option value="never">never</option>
+          </select>
+        </label>
+      </section>
+
+      <section class="custom-words" aria-labelledby="custom-heading">
+        <div class="section-label">
+          <div>
+            <p class="eyebrow">your list</p>
+            <h2 id="custom-heading">Custom words & phrases</h2>
+          </div>
+          <span id="save-status" aria-live="polite"></span>
+        </div>
+        <textarea
+          id="custom-words"
+          rows="5"
+          placeholder="Project Velvet&#10;Mothbit&#10;spoiler phrase"
+          spellcheck="false"
+        ></textarea>
+        <p class="hint">One per line. Saved locally in this browser.</p>
+      </section>
+
+      <footer>
+        <span>Scrawlix dev build</span>
+        <a href="https://github.com/teamleaderleo/scrawlix" target="_blank" rel="noreferrer">source ↗</a>
+      </footer>
+    </main>
+
+    <script type="module" src="/src/popup.ts"></script>
+  </body>
+</html>

--- a/apps/extension/scripts/validate-build.mjs
+++ b/apps/extension/scripts/validate-build.mjs
@@ -1,0 +1,32 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const dist = resolve(process.cwd(), 'dist');
+const manifestPath = resolve(dist, 'manifest.json');
+
+for (const file of ['manifest.json', 'content.js', 'content.css', 'popup.html']) {
+  if (!existsSync(resolve(dist, file))) {
+    throw new Error(`Extension build is missing ${file}.`);
+  }
+}
+
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+if (manifest.manifest_version !== 3) {
+  throw new Error('Extension manifest must use Manifest V3.');
+}
+
+const referenced = [
+  manifest.action?.default_popup,
+  ...(manifest.content_scripts ?? []).flatMap(entry => [
+    ...(entry.js ?? []),
+    ...(entry.css ?? []),
+  ]),
+].filter(Boolean);
+
+for (const file of referenced) {
+  if (!existsSync(resolve(dist, file))) {
+    throw new Error(`Manifest references missing build file ${file}.`);
+  }
+}
+
+console.log('Scrawlix extension build validated.');

--- a/apps/extension/src/config.test.ts
+++ b/apps/extension/src/config.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_SETTINGS,
+  coverageSelector,
+  effectiveEnabled,
+  maskFor,
+  normalizeCustomWords,
+  normalizeSettings,
+  setSiteMode,
+  siteModeFor,
+} from './config';
+
+describe('extension settings', () => {
+  it('normalizes invalid stored values to safe defaults', () => {
+    expect(
+      normalizeSettings({
+        enabled: 'yes',
+        appearance: 'paint',
+        coverage: 'random',
+        reveal: 'sometimes',
+        siteOverrides: {
+          'Example.COM': 'off',
+          'bad.example': 'inherit',
+          '': 'on',
+        },
+      })
+    ).toEqual({
+      ...DEFAULT_SETTINGS,
+      siteOverrides: { 'example.com': 'off' },
+    });
+  });
+
+  it('lets explicit site modes override the global switch', () => {
+    const disabled = { ...DEFAULT_SETTINGS, enabled: false };
+    const forcedOn = setSiteMode(disabled, 'example.com', 'on');
+    expect(siteModeFor(forcedOn, 'example.com')).toBe('on');
+    expect(effectiveEnabled(forcedOn, 'example.com')).toBe(true);
+
+    const forcedOff = setSiteMode(DEFAULT_SETTINGS, 'example.com', 'off');
+    expect(effectiveEnabled(forcedOff, 'example.com')).toBe(false);
+  });
+
+  it('removes a site override when mode returns to inherit', () => {
+    const withOverride = setSiteMode(DEFAULT_SETTINGS, 'Example.COM', 'off');
+    const inherited = setSiteMode(withOverride, 'example.com', 'inherit');
+
+    expect(inherited.siteOverrides).toEqual({});
+    expect(siteModeFor(inherited, 'example.com')).toBe('inherit');
+  });
+
+  it('deduplicates and trims custom words case-insensitively', () => {
+    expect(
+      normalizeCustomWords([' Velvet ', 'velvet', '', 42, 'Mothbit', 'MOTHBIT'])
+    ).toEqual(['Velvet', 'Mothbit']);
+  });
+
+  it('maps the vowel setting to the English coverage helper', () => {
+    expect(typeof coverageSelector('vowel')).toBe('function');
+    expect(coverageSelector('middle')).toBe('middle');
+  });
+
+  it('generates symbol masks without rewriting source text', () => {
+    expect(maskFor('fuck', 'asterisk')).toBe('****');
+    expect(maskFor('abcdef', 'grawlix')).toBe('@#$%&!');
+    expect(maskFor('🔥x', 'asterisk')).toBe('**');
+    expect(maskFor('fuck', 'bar')).toBe('');
+  });
+});

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -1,0 +1,142 @@
+import type { CoverageSelector } from '@scrawlix/core';
+import { englishVowelCoverage } from '@scrawlix/en';
+
+export type ExtensionAppearance =
+  | 'scrawl'
+  | 'bar'
+  | 'blur'
+  | 'asterisk'
+  | 'grawlix';
+
+export type ExtensionCoverage = 'full' | 'tail' | 'middle' | 'inner' | 'vowel';
+export type ExtensionReveal = 'hover' | 'focus' | 'click' | 'never';
+export type SiteMode = 'inherit' | 'on' | 'off';
+
+export type SyncSettings = {
+  enabled: boolean;
+  appearance: ExtensionAppearance;
+  coverage: ExtensionCoverage;
+  reveal: ExtensionReveal;
+  siteOverrides: Record<string, Exclude<SiteMode, 'inherit'>>;
+};
+
+export const SYNC_SETTINGS_KEY = 'scrawlixSettings';
+export const CUSTOM_WORDS_KEY = 'scrawlixCustomWords';
+
+export const DEFAULT_SETTINGS: SyncSettings = {
+  enabled: true,
+  appearance: 'scrawl',
+  coverage: 'middle',
+  reveal: 'hover',
+  siteOverrides: {},
+};
+
+const APPEARANCES = new Set<ExtensionAppearance>([
+  'scrawl',
+  'bar',
+  'blur',
+  'asterisk',
+  'grawlix',
+]);
+const COVERAGES = new Set<ExtensionCoverage>([
+  'full',
+  'tail',
+  'middle',
+  'inner',
+  'vowel',
+]);
+const REVEALS = new Set<ExtensionReveal>(['hover', 'focus', 'click', 'never']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function normalizeSettings(value: unknown): SyncSettings {
+  if (!isRecord(value)) return { ...DEFAULT_SETTINGS, siteOverrides: {} };
+
+  const siteOverrides: SyncSettings['siteOverrides'] = {};
+  if (isRecord(value.siteOverrides)) {
+    for (const [hostname, mode] of Object.entries(value.siteOverrides)) {
+      const normalizedHostname = hostname.trim().toLowerCase();
+      if (!normalizedHostname) continue;
+      if (mode === 'on' || mode === 'off') {
+        siteOverrides[normalizedHostname] = mode;
+      }
+    }
+  }
+
+  return {
+    enabled: typeof value.enabled === 'boolean' ? value.enabled : DEFAULT_SETTINGS.enabled,
+    appearance: APPEARANCES.has(value.appearance as ExtensionAppearance)
+      ? (value.appearance as ExtensionAppearance)
+      : DEFAULT_SETTINGS.appearance,
+    coverage: COVERAGES.has(value.coverage as ExtensionCoverage)
+      ? (value.coverage as ExtensionCoverage)
+      : DEFAULT_SETTINGS.coverage,
+    reveal: REVEALS.has(value.reveal as ExtensionReveal)
+      ? (value.reveal as ExtensionReveal)
+      : DEFAULT_SETTINGS.reveal,
+    siteOverrides,
+  };
+}
+
+export function normalizeCustomWords(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+
+  const seen = new Set<string>();
+  const words: string[] = [];
+
+  for (const item of value) {
+    if (typeof item !== 'string') continue;
+    const word = item.trim();
+    if (!word) continue;
+    const key = word.toLocaleLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    words.push(word);
+  }
+
+  return words;
+}
+
+export function siteModeFor(settings: SyncSettings, hostname: string): SiteMode {
+  return settings.siteOverrides[hostname.toLowerCase()] ?? 'inherit';
+}
+
+export function effectiveEnabled(settings: SyncSettings, hostname: string) {
+  const mode = siteModeFor(settings, hostname);
+  if (mode === 'on') return true;
+  if (mode === 'off') return false;
+  return settings.enabled;
+}
+
+export function setSiteMode(
+  settings: SyncSettings,
+  hostname: string,
+  mode: SiteMode
+): SyncSettings {
+  const normalizedHostname = hostname.trim().toLowerCase();
+  const siteOverrides = { ...settings.siteOverrides };
+
+  if (!normalizedHostname || mode === 'inherit') {
+    delete siteOverrides[normalizedHostname];
+  } else {
+    siteOverrides[normalizedHostname] = mode;
+  }
+
+  return { ...settings, siteOverrides };
+}
+
+export function coverageSelector(coverage: ExtensionCoverage): CoverageSelector {
+  return coverage === 'vowel' ? englishVowelCoverage : coverage;
+}
+
+export function maskFor(text: string, appearance: ExtensionAppearance) {
+  const length = Array.from(text).length;
+  if (appearance === 'asterisk') return '*'.repeat(length);
+  if (appearance === 'grawlix') {
+    const symbols = '@#$%&!';
+    return Array.from({ length }, (_, index) => symbols[index % symbols.length]).join('');
+  }
+  return '';
+}

--- a/apps/extension/src/content.css
+++ b/apps/extension/src/content.css
@@ -1,0 +1,87 @@
+[data-scrawlix-dom-root] {
+  --scrawlix-soft-ink: color-mix(in srgb, currentColor 24%, transparent);
+  --scrawlix-fuzzy-ink: color-mix(in srgb, currentColor 58%, transparent);
+}
+
+[data-scrawlix-dom-root]:focus-visible {
+  outline: 1px solid currentColor;
+  outline-offset: 0.15em;
+  border-radius: 0.12em;
+}
+
+[data-scrawlix-dom-root] [data-scrawlix-cover] {
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  position: relative;
+  transition:
+    filter 140ms ease,
+    background 140ms ease,
+    text-shadow 140ms ease,
+    -webkit-text-fill-color 140ms ease;
+}
+
+[data-scrawlix-dom-root][data-scrawlix-appearance='scrawl'] [data-scrawlix-cover] {
+  -webkit-text-fill-color: transparent;
+  background: repeating-linear-gradient(
+    -13deg,
+    var(--scrawlix-soft-ink) 0 0.08em,
+    transparent 0.08em 0.18em
+  );
+  border-radius: 0.18em;
+  padding-inline: 0.04em;
+  text-shadow: 0 0 0.34em var(--scrawlix-fuzzy-ink);
+}
+
+[data-scrawlix-dom-root][data-scrawlix-appearance='bar'] [data-scrawlix-cover] {
+  -webkit-text-fill-color: transparent;
+  background: linear-gradient(currentColor, currentColor) center / 100% 0.72em no-repeat;
+  border-radius: 0.06em;
+}
+
+[data-scrawlix-dom-root][data-scrawlix-appearance='blur'] [data-scrawlix-cover] {
+  filter: blur(0.17em);
+  user-select: none;
+}
+
+[data-scrawlix-dom-root] [data-scrawlix-cover][data-scrawlix-mask] {
+  display: inline-block;
+  position: relative;
+  -webkit-text-fill-color: transparent;
+}
+
+[data-scrawlix-dom-root] [data-scrawlix-cover][data-scrawlix-mask]::after {
+  content: attr(data-scrawlix-mask);
+  position: absolute;
+  inset: 0;
+  color: currentColor;
+  -webkit-text-fill-color: currentColor;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.92em;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  pointer-events: none;
+  white-space: pre;
+}
+
+[data-scrawlix-dom-root][data-scrawlix-reveal='hover']:hover [data-scrawlix-cover],
+[data-scrawlix-dom-root][data-scrawlix-reveal='focus']:focus [data-scrawlix-cover],
+[data-scrawlix-dom-root][data-scrawlix-reveal='click'][data-scrawlix-revealed='true'] [data-scrawlix-cover] {
+  -webkit-text-fill-color: currentColor;
+  background: none;
+  filter: none;
+  padding-inline: 0;
+  text-shadow: none;
+  user-select: text;
+}
+
+[data-scrawlix-dom-root][data-scrawlix-reveal='hover']:hover [data-scrawlix-cover][data-scrawlix-mask]::after,
+[data-scrawlix-dom-root][data-scrawlix-reveal='focus']:focus [data-scrawlix-cover][data-scrawlix-mask]::after,
+[data-scrawlix-dom-root][data-scrawlix-reveal='click'][data-scrawlix-revealed='true'] [data-scrawlix-cover][data-scrawlix-mask]::after {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-scrawlix-dom-root] [data-scrawlix-cover] {
+    transition: none;
+  }
+}

--- a/apps/extension/src/content.ts
+++ b/apps/extension/src/content.ts
@@ -1,0 +1,151 @@
+import { censorRuleFromWords, type CensorRule } from '@scrawlix/core';
+import { createDomScrawlix, type DomObservation } from '@scrawlix/dom';
+import { englishProfanityRules } from '@scrawlix/en';
+import {
+  CUSTOM_WORDS_KEY,
+  SYNC_SETTINGS_KEY,
+  coverageSelector,
+  effectiveEnabled,
+  maskFor,
+  type SyncSettings,
+} from './config';
+import { loadExtensionState } from './storage';
+
+const INTERACTIVE_ANCESTOR =
+  'a,button,input,select,textarea,summary,[role="button"],[role="link"]';
+
+let observation: DomObservation | null = null;
+let presentationObserver: MutationObserver | null = null;
+let activeSettings: SyncSettings | null = null;
+let restartGeneration = 0;
+
+function customRule(customWords: readonly string[]): CensorRule[] {
+  if (customWords.length === 0) return [];
+  return [censorRuleFromWords('custom', customWords)];
+}
+
+function canOwnInteraction(root: HTMLElement) {
+  return root.closest(INTERACTIVE_ANCESTOR) === null;
+}
+
+function decorateGeneratedRoot(root: HTMLElement, settings: SyncSettings) {
+  root.dataset.scrawlixAppearance = settings.appearance;
+  root.dataset.scrawlixReveal = settings.reveal;
+  root.dataset.scrawlixRevealed = 'false';
+
+  const interactiveReveal = settings.reveal === 'focus' || settings.reveal === 'click';
+  if (interactiveReveal && canOwnInteraction(root)) {
+    root.tabIndex = 0;
+  } else {
+    root.removeAttribute('tabindex');
+  }
+
+  for (const cover of Array.from(
+    root.querySelectorAll<HTMLElement>('[data-scrawlix-cover]')
+  )) {
+    const mask = maskFor(cover.textContent ?? '', settings.appearance);
+    if (mask) cover.dataset.scrawlixMask = mask;
+    else delete cover.dataset.scrawlixMask;
+  }
+}
+
+function decorateSubtree(node: Node, settings: SyncSettings) {
+  if (!(node instanceof Element)) return;
+
+  if (node.matches('[data-scrawlix-dom-root]')) {
+    decorateGeneratedRoot(node as HTMLElement, settings);
+  }
+
+  for (const root of Array.from(
+    node.querySelectorAll<HTMLElement>('[data-scrawlix-dom-root]')
+  )) {
+    decorateGeneratedRoot(root, settings);
+  }
+}
+
+function startPresentationObserver(settings: SyncSettings) {
+  const observer = new MutationObserver(records => {
+    for (const record of records) {
+      for (const added of Array.from(record.addedNodes)) {
+        decorateSubtree(added, settings);
+      }
+    }
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+  presentationObserver = observer;
+}
+
+function stopCurrentSession() {
+  presentationObserver?.disconnect();
+  presentationObserver = null;
+  observation?.restore();
+  observation = null;
+  activeSettings = null;
+}
+
+async function restart() {
+  const generation = ++restartGeneration;
+  const state = await loadExtensionState();
+  if (generation !== restartGeneration) return;
+
+  stopCurrentSession();
+
+  const hostname = location.hostname.toLowerCase();
+  if (!document.body || !effectiveEnabled(state.settings, hostname)) return;
+
+  const controller = createDomScrawlix({
+    rules: [...englishProfanityRules, ...customRule(state.customWords)],
+    coverage: coverageSelector(state.settings.coverage),
+  });
+
+  activeSettings = state.settings;
+  observation = controller.observe(document.body);
+  decorateSubtree(document.body, state.settings);
+  startPresentationObserver(state.settings);
+}
+
+function clickRootFromEvent(event: Event) {
+  const target = event.target;
+  if (!(target instanceof Element)) return null;
+  const root = target.closest<HTMLElement>(
+    '[data-scrawlix-dom-root][data-scrawlix-reveal="click"]'
+  );
+  if (!root || root.tabIndex !== 0) return null;
+  return root;
+}
+
+document.addEventListener('click', event => {
+  const root = clickRootFromEvent(event);
+  if (!root) return;
+  root.dataset.scrawlixRevealed =
+    root.dataset.scrawlixRevealed === 'true' ? 'false' : 'true';
+});
+
+document.addEventListener('keydown', event => {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  const root = clickRootFromEvent(event);
+  if (!root) return;
+
+  event.preventDefault();
+  root.dataset.scrawlixRevealed =
+    root.dataset.scrawlixRevealed === 'true' ? 'false' : 'true';
+});
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  const relevantSync =
+    areaName === 'sync' && Object.prototype.hasOwnProperty.call(changes, SYNC_SETTINGS_KEY);
+  const relevantLocal =
+    areaName === 'local' && Object.prototype.hasOwnProperty.call(changes, CUSTOM_WORDS_KEY);
+
+  if (relevantSync || relevantLocal) void restart();
+});
+
+function startWhenReady() {
+  if (document.body) void restart();
+  else window.addEventListener('DOMContentLoaded', () => void restart(), { once: true });
+}
+
+startWhenReady();
+
+void activeSettings;

--- a/apps/extension/src/popup.css
+++ b/apps/extension/src/popup.css
@@ -1,0 +1,250 @@
+:root {
+  color: #171510;
+  background: #f2eddf;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 340px;
+  background:
+    linear-gradient(rgba(23, 21, 16, 0.035) 1px, transparent 1px) 0 0 / 100% 24px,
+    #f2eddf;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+.popup-shell {
+  width: 340px;
+  padding: 14px;
+}
+
+.masthead,
+.site-card,
+.settings-grid,
+.custom-words,
+footer {
+  border-top: 1px solid #171510;
+}
+
+.masthead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 0 14px;
+  border-top-width: 3px;
+}
+
+.wordmark {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 0.9;
+  letter-spacing: -0.05em;
+}
+
+.wordmark span {
+  display: inline-block;
+  margin-left: 1px;
+  transform: rotate(-10deg);
+}
+
+.tagline,
+.eyebrow,
+.status-line,
+.hint,
+footer,
+.switch-row span,
+.settings-grid label > span,
+#save-status {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.tagline {
+  margin: 6px 0 0;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.11em;
+  opacity: 0.62;
+}
+
+.switch-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.switch-row span {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.switch-row input {
+  width: 17px;
+  height: 17px;
+  accent-color: #171510;
+}
+
+.site-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 120px;
+  align-items: end;
+  gap: 14px;
+  padding: 14px 0;
+}
+
+.eyebrow {
+  margin: 0 0 4px;
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.13em;
+  opacity: 0.55;
+}
+
+.site-card h1,
+.custom-words h2 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-weight: 600;
+  letter-spacing: -0.035em;
+}
+
+.site-card h1 {
+  overflow: hidden;
+  font-size: 18px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-line {
+  margin: 5px 0 0;
+  font-size: 9px;
+  opacity: 0.7;
+}
+
+.status-line[data-enabled='true']::before {
+  content: '● ';
+}
+
+.status-line[data-enabled='false']::before {
+  content: '○ ';
+}
+
+select,
+textarea {
+  width: 100%;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.28);
+  border: 1px solid rgba(23, 21, 16, 0.42);
+  border-radius: 0;
+  outline: none;
+}
+
+select {
+  min-height: 34px;
+  padding: 6px 8px;
+  font-size: 11px;
+}
+
+select:focus,
+textarea:focus {
+  border-color: #171510;
+  box-shadow: 0 0 0 1px #171510;
+}
+
+.settings-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  padding: 14px 0;
+}
+
+.settings-grid label > span {
+  display: block;
+  margin-bottom: 5px;
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.custom-words {
+  padding: 14px 0;
+}
+
+.section-label {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 9px;
+}
+
+.custom-words h2 {
+  font-size: 16px;
+}
+
+#save-status {
+  min-width: 60px;
+  font-size: 8px;
+  text-align: right;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.6;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 88px;
+  padding: 9px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.hint {
+  margin: 5px 0 0;
+  font-size: 8px;
+  opacity: 0.58;
+}
+
+footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 10px;
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  opacity: 0.65;
+}
+
+footer a {
+  color: inherit;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/apps/extension/src/popup.ts
+++ b/apps/extension/src/popup.ts
@@ -1,0 +1,155 @@
+import './popup.css';
+import {
+  effectiveEnabled,
+  normalizeCustomWords,
+  setSiteMode,
+  siteModeFor,
+  type ExtensionAppearance,
+  type ExtensionCoverage,
+  type ExtensionReveal,
+  type SiteMode,
+  type SyncSettings,
+} from './config';
+import {
+  loadExtensionState,
+  saveCustomWords,
+  saveSettings,
+} from './storage';
+
+function required<T extends HTMLElement>(id: string): T {
+  const element = document.getElementById(id);
+  if (!element) throw new Error(`Missing popup element #${id}`);
+  return element as T;
+}
+
+const enabledInput = required<HTMLInputElement>('enabled');
+const siteModeSelect = required<HTMLSelectElement>('site-mode');
+const appearanceSelect = required<HTMLSelectElement>('appearance');
+const coverageSelect = required<HTMLSelectElement>('coverage');
+const revealSelect = required<HTMLSelectElement>('reveal');
+const customWordsInput = required<HTMLTextAreaElement>('custom-words');
+const siteHeading = required<HTMLHeadingElement>('site-heading');
+const effectiveStatus = required<HTMLParagraphElement>('effective-status');
+const saveStatus = required<HTMLSpanElement>('save-status');
+
+let settings: SyncSettings;
+let hostname: string | null = null;
+let wordSaveTimer: number | null = null;
+
+async function currentHostname() {
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+  const url = tabs[0]?.url;
+  if (!url) return null;
+
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return parsed.hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function renderEffectiveStatus() {
+  if (!hostname) {
+    siteHeading.textContent = 'This page is unavailable';
+    effectiveStatus.textContent = 'Scrawlix runs on ordinary HTTP and HTTPS pages.';
+    siteModeSelect.disabled = true;
+    return;
+  }
+
+  siteHeading.textContent = hostname;
+  siteModeSelect.disabled = false;
+  siteModeSelect.value = siteModeFor(settings, hostname);
+  const enabledHere = effectiveEnabled(settings, hostname);
+  effectiveStatus.textContent = enabledHere ? 'censoring is on here' : 'censoring is off here';
+  effectiveStatus.dataset.enabled = enabledHere ? 'true' : 'false';
+}
+
+function renderSettings() {
+  enabledInput.checked = settings.enabled;
+  appearanceSelect.value = settings.appearance;
+  coverageSelect.value = settings.coverage;
+  revealSelect.value = settings.reveal;
+  renderEffectiveStatus();
+}
+
+async function persistSettings(next: SyncSettings) {
+  settings = next;
+  renderSettings();
+  await saveSettings(settings);
+}
+
+function wordsFromTextarea() {
+  return normalizeCustomWords(customWordsInput.value.split('\n'));
+}
+
+async function persistWords() {
+  if (wordSaveTimer !== null) {
+    window.clearTimeout(wordSaveTimer);
+    wordSaveTimer = null;
+  }
+
+  saveStatus.textContent = 'saving…';
+  try {
+    await saveCustomWords(wordsFromTextarea());
+    saveStatus.textContent = 'saved';
+  } catch {
+    saveStatus.textContent = 'save failed';
+  }
+}
+
+function scheduleWordSave() {
+  if (wordSaveTimer !== null) window.clearTimeout(wordSaveTimer);
+  saveStatus.textContent = 'editing';
+  wordSaveTimer = window.setTimeout(() => void persistWords(), 250);
+}
+
+enabledInput.addEventListener('change', () => {
+  void persistSettings({ ...settings, enabled: enabledInput.checked });
+});
+
+siteModeSelect.addEventListener('change', () => {
+  if (!hostname) return;
+  void persistSettings(
+    setSiteMode(settings, hostname, siteModeSelect.value as SiteMode)
+  );
+});
+
+appearanceSelect.addEventListener('change', () => {
+  void persistSettings({
+    ...settings,
+    appearance: appearanceSelect.value as ExtensionAppearance,
+  });
+});
+
+coverageSelect.addEventListener('change', () => {
+  void persistSettings({
+    ...settings,
+    coverage: coverageSelect.value as ExtensionCoverage,
+  });
+});
+
+revealSelect.addEventListener('change', () => {
+  void persistSettings({
+    ...settings,
+    reveal: revealSelect.value as ExtensionReveal,
+  });
+});
+
+customWordsInput.addEventListener('input', scheduleWordSave);
+customWordsInput.addEventListener('change', () => void persistWords());
+
+async function initialize() {
+  const [state, activeHostname] = await Promise.all([
+    loadExtensionState(),
+    currentHostname(),
+  ]);
+
+  settings = state.settings;
+  hostname = activeHostname;
+  customWordsInput.value = state.customWords.join('\n');
+  renderSettings();
+}
+
+void initialize();

--- a/apps/extension/src/storage.ts
+++ b/apps/extension/src/storage.ts
@@ -1,0 +1,36 @@
+import {
+  CUSTOM_WORDS_KEY,
+  SYNC_SETTINGS_KEY,
+  normalizeCustomWords,
+  normalizeSettings,
+  type SyncSettings,
+} from './config';
+
+export async function loadSettings(): Promise<SyncSettings> {
+  const stored = await chrome.storage.sync.get(SYNC_SETTINGS_KEY);
+  return normalizeSettings(stored[SYNC_SETTINGS_KEY]);
+}
+
+export async function saveSettings(settings: SyncSettings) {
+  await chrome.storage.sync.set({ [SYNC_SETTINGS_KEY]: settings });
+}
+
+export async function loadCustomWords(): Promise<string[]> {
+  const stored = await chrome.storage.local.get(CUSTOM_WORDS_KEY);
+  return normalizeCustomWords(stored[CUSTOM_WORDS_KEY]);
+}
+
+export async function saveCustomWords(words: readonly string[]) {
+  await chrome.storage.local.set({
+    [CUSTOM_WORDS_KEY]: normalizeCustomWords(words),
+  });
+}
+
+export async function loadExtensionState() {
+  const [settings, customWords] = await Promise.all([
+    loadSettings(),
+    loadCustomWords(),
+  ]);
+
+  return { settings, customWords };
+}

--- a/apps/extension/tsconfig.json
+++ b/apps/extension/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["chrome", "node"]
+  },
+  "include": ["src/**/*.ts", "vite.*.config.ts", "scripts/**/*.mjs"]
+}

--- a/apps/extension/vite.content.config.ts
+++ b/apps/extension/vite.content.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    emptyOutDir: true,
+    outDir: 'dist',
+    sourcemap: true,
+    minify: false,
+    lib: {
+      entry: fileURLToPath(new URL('./src/content.ts', import.meta.url)),
+      name: 'ScrawlixContent',
+      formats: ['iife'],
+      fileName: () => 'content.js',
+    },
+  },
+});

--- a/apps/extension/vite.popup.config.ts
+++ b/apps/extension/vite.popup.config.ts
@@ -1,0 +1,13 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    outDir: 'dist',
+    sourcemap: true,
+    rollupOptions: {
+      input: fileURLToPath(new URL('./popup.html', import.meta.url)),
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "scrawlix-workspace",
   "private": true,
   "scripts": {
-    "build": "pnpm build:packages && pnpm --filter scrawlix-demo build",
+    "build": "pnpm build:packages && pnpm --filter scrawlix-demo build && pnpm --filter scrawlix-extension build",
     "build:packages": "pnpm --filter @scrawlix/core build && pnpm --filter @scrawlix/en build && pnpm --filter @scrawlix/react build && pnpm --filter @scrawlix/rehype build && pnpm --filter @scrawlix/dom build",
     "dev": "pnpm --filter scrawlix-demo dev",
     "smoke:packages": "node scripts/smoke-packages.mjs",


### PR DESCRIPTION
Closes #5.
Progresses #13 and #18.

### Manifest V3 application
- adds `apps/extension` with a bundled content script and small popup
- no background service worker
- validates emitted manifest/popup/content JS/CSS paths after every build
- joins workspace typecheck/tests/build

### Settings model
- global enabled state
- tri-state per-host mode: inherit / always on / always off
- appearance: scrawl / bar / blur / asterisk / grawlix
- coverage: middle / vowel / inner / tail / full
- reveal: hover / focus / click / never
- custom words and phrases
- small preferences in `chrome.storage.sync`
- custom terms in `chrome.storage.local`
- normalization/deduplication regression tests

### Content script
- uses `@scrawlix/dom` + `@scrawlix/en`; no duplicate matcher
- compiles custom terms into one additional rule
- storage changes atomically restore the current DOM session before starting a new configuration
- decorates only Scrawlix-generated DOM roots
- presentation uses source-preserving data attributes/pseudo-element masks
- avoids claiming click/focus interaction inside native links/buttons/inputs
- dynamic page handling stays mutation-local through the DOM package

### Popup
- ink/proof-sheet styling consistent with the demo
- global toggle, hostname override, treatment controls, custom-term editor
- current hostname/effective-state display

### Permissions
The development manifest uses `storage`, `activeTab`, and automatic content-script host access for HTTP/HTTPS pages so persistent per-site behavior survives navigation. The extension sends no page text or browsing data to a server. `apps/extension/README.md` explicitly treats permission minimization/optional-host alternatives as a store-release review item.