### PR TITLE
Add real Chromium smoke tests for the demo and extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,6 @@ jobs:
       - run: pnpm typecheck
       - run: pnpm test
       - run: pnpm build
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm test:browser
       - run: pnpm smoke:packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
       - run: pnpm typecheck
       - run: pnpm test
       - run: pnpm build
-      - run: pnpm exec playwright install --with-deps chromium
-      - run: pnpm test:browser
+      - name: Install Chromium
+        run: pnpm exec playwright install --with-deps chromium >/dev/null
+      - name: Browser smoke — demo
+        run: pnpm test:browser:demo
+      - name: Browser smoke — extension
+        run: pnpm test:browser:extension
       - run: pnpm smoke:packages

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+**/dist/
+playwright-report/
+test-results/

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "smoke:packages": "node scripts/smoke-packages.mjs",
     "test": "pnpm build:packages && pnpm -r --if-present test",
     "test:browser": "playwright test -c playwright.config.ts",
+    "test:browser:demo": "playwright test -c playwright.config.ts -g \"demo controls\"",
+    "test:browser:extension": "playwright test -c playwright.config.ts -g \"built extension\"",
     "typecheck": "pnpm -r --if-present typecheck"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "dev": "pnpm --filter scrawlix-demo dev",
     "smoke:packages": "node scripts/smoke-packages.mjs",
     "test": "pnpm build:packages && pnpm -r --if-present test",
+    "test:browser": "playwright test -c playwright.config.ts",
     "typecheck": "pnpm -r --if-present typecheck"
   },
   "devDependencies": {
+    "@playwright/test": "^1.57.0",
     "typescript": "^5.2.2",
     "vitest": "^3.2.4"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/browser',
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'line' : 'list',
+  use: {
+    headless: true,
+    trace: 'retain-on-failure',
+  },
+  webServer: [
+    {
+      command:
+        'pnpm --filter scrawlix-demo exec vite preview --host 127.0.0.1 --port 4173',
+      url: 'http://127.0.0.1:4173',
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+    },
+    {
+      command: 'node tests/browser/fixture-server.mjs',
+      url: 'http://127.0.0.1:4174/fixture.html',
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+    },
+  ],
+});

--- a/tests/browser/browser.spec.ts
+++ b/tests/browser/browser.spec.ts
@@ -1,9 +1,7 @@
 import { chromium, expect, test } from '@playwright/test';
-import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 
-const extensionPath = fileURLToPath(
-  new URL('../../apps/extension/dist', import.meta.url)
-);
+const extensionPath = resolve(process.cwd(), 'apps/extension/dist');
 
 test('demo controls drive real rendered coverage and reveal state', async ({ page }) => {
   await page.goto('http://127.0.0.1:4173');

--- a/tests/browser/browser.spec.ts
+++ b/tests/browser/browser.spec.ts
@@ -1,0 +1,87 @@
+import { chromium, expect, test } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+
+const extensionPath = fileURLToPath(
+  new URL('../../apps/extension/dist', import.meta.url)
+);
+
+test('demo controls drive real rendered coverage and reveal state', async ({ page }) => {
+  await page.goto('http://127.0.0.1:4173');
+
+  const proof = page.locator('.proof-output [data-scrawlix-root]');
+  const firstCover = proof.locator('[data-scrawlix-cover]').first();
+
+  await expect(proof).toBeVisible();
+  await expect(firstCover).toHaveAttribute('data-appearance', 'scrawl');
+  await expect(firstCover).toHaveText('uc');
+
+  await page.getByRole('button', { name: 'bar', exact: true }).click();
+  await expect(firstCover).toHaveAttribute('data-appearance', 'bar');
+
+  await page.getByRole('button', { name: 'full', exact: true }).click();
+  await expect(firstCover).toHaveText('fuck');
+
+  await page.getByRole('button', { name: 'click', exact: true }).click();
+  await expect(proof).toHaveAttribute('data-reveal', 'click');
+  await expect(proof).toHaveAttribute('data-revealed', 'false');
+
+  await proof.click();
+  await expect(proof).toHaveAttribute('data-revealed', 'true');
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - window.innerWidth
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
+});
+
+test('built extension transforms initial and dynamic page text in Chromium', async ({}, testInfo) => {
+  const context = await chromium.launchPersistentContext(
+    testInfo.outputPath('extension-profile'),
+    {
+      channel: 'chromium',
+      headless: true,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+      ],
+    }
+  );
+
+  try {
+    const page = context.pages()[0] ?? (await context.newPage());
+    await page.goto('http://127.0.0.1:4174/fixture.html');
+
+    await expect(
+      page.locator('#initial [data-scrawlix-dom-root]')
+    ).toHaveCount(1);
+    await expect(
+      page.locator('#initial [data-scrawlix-cover]')
+    ).toHaveText('uc');
+
+    await expect(page.locator('#code [data-scrawlix-dom-root]')).toHaveCount(0);
+    await expect(page.locator('#editable [data-scrawlix-dom-root]')).toHaveCount(0);
+    await expect(
+      page.locator('#native-button [data-scrawlix-dom-root]')
+    ).toHaveCount(0);
+
+    // Links retain their native semantics even when their text is transformed.
+    await expect(
+      page.locator('#native-link [data-scrawlix-dom-root]')
+    ).toHaveCount(1);
+
+    await page.getByRole('button', { name: 'add dynamic' }).click();
+    await expect(
+      page.locator('#dynamic-copy [data-scrawlix-dom-root]')
+    ).toHaveCount(1);
+    await expect(
+      page.locator('#dynamic-copy [data-scrawlix-cover]')
+    ).toHaveText('uc');
+
+    await page.locator('#native-link').click();
+    await expect(page).toHaveURL('http://127.0.0.1:4174/clicked.html');
+    await expect(page.locator('#clicked')).toHaveText('native link worked');
+  } finally {
+    await context.close();
+  }
+});

--- a/tests/browser/fixture-server.mjs
+++ b/tests/browser/fixture-server.mjs
@@ -1,0 +1,52 @@
+import { createServer } from 'node:http';
+
+const fixture = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Scrawlix extension fixture</title>
+  </head>
+  <body>
+    <main>
+      <p id="initial">well, fuck this</p>
+      <p><code id="code">fuck</code></p>
+      <div id="editable" contenteditable="true">fuck</div>
+      <button id="native-button" type="button">fuck</button>
+      <a id="native-link" href="/clicked.html">fuck</a>
+      <button id="add-dynamic" type="button">add dynamic</button>
+      <section id="dynamic-root"></section>
+    </main>
+    <script>
+      document.querySelector('#add-dynamic').addEventListener('click', () => {
+        const paragraph = document.createElement('p');
+        paragraph.id = 'dynamic-copy';
+        paragraph.textContent = 'dynamic fuck arrived';
+        document.querySelector('#dynamic-root').append(paragraph);
+      });
+    </script>
+  </body>
+</html>`;
+
+const clicked = `<!doctype html><html><body><p id="clicked">native link worked</p></body></html>`;
+
+const server = createServer((request, response) => {
+  const url = new URL(request.url ?? '/', 'http://127.0.0.1:4174');
+  if (url.pathname === '/fixture.html' || url.pathname === '/') {
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    response.end(fixture);
+    return;
+  }
+
+  if (url.pathname === '/clicked.html') {
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    response.end(clicked);
+    return;
+  }
+
+  response.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+  response.end('not found');
+});
+
+server.listen(4174, '127.0.0.1', () => {
+  console.log('Scrawlix browser fixture listening on http://127.0.0.1:4174');
+});


### PR DESCRIPTION
Progresses #23.

### Real-browser demo smoke
- loads the built Vite demo in Chromium
- verifies the proof starts with the `scrawl` appearance and semantic middle coverage
- changes appearance to `bar`
- changes coverage to `full`
- changes reveal to `click` and verifies real rendered toggle state
- checks the narrow 390px viewport for horizontal overflow

### Real-browser extension smoke
- launches Playwright's bundled Chromium with the built MV3 extension in a persistent context
- verifies initial page profanity is transformed by the actual content script
- verifies code, contenteditable, and native button exclusions in-browser
- verifies link text can be transformed while native link navigation still works
- inserts dynamic page content after load and verifies mutation-local Scrawlix transformation
- uses only local deterministic fixture pages

### CI
- adds Playwright Test at the workspace root
- builds the demo and extension before browser tests
- installs bundled Chromium with browser dependencies in CI
- keeps the existing external package-tarball smoke as the final release gate
- adds `.gitignore` entries for dist/dependency/browser-test output

Current Playwright documentation supports extension testing through a persistent Chromium context and the bundled Chromium channel, including headless operation. Screenshot goldens remain separate because Playwright documents that visual baselines should be generated and compared in a consistent OS/browser environment.