### PR TITLE
Exercise extension storage and site policy in Chromium

### DIFF
--- a/tests/browser/browser.spec.ts
+++ b/tests/browser/browser.spec.ts
@@ -172,7 +172,7 @@ test('built extension restores, persists, overrides sites, and recompiles custom
     await reopened.locator('#custom-words').press('Tab');
     await expect(reopened.locator('#save-status')).toHaveText('saved');
     await expect(custom.locator('[data-scrawlix-dom-root]')).toHaveCount(1);
-    await expect(custom.locator('[data-scrawlix-cover]')).toHaveText('thb');
+    await expect(custom.locator('[data-scrawlix-cover]')).toHaveText('othb');
 
     // Explicit site off wins over global/custom state and restores exact source again.
     await reopened.evaluate(async () => {

--- a/tests/browser/browser.spec.ts
+++ b/tests/browser/browser.spec.ts
@@ -1,7 +1,56 @@
-import { chromium, expect, test } from '@playwright/test';
+import { chromium, expect, test, type BrowserContext, type TestInfo } from '@playwright/test';
+import { createHash } from 'node:crypto';
+import { realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const extensionPath = resolve(process.cwd(), 'apps/extension/dist');
+
+function unpackedExtensionId(path: string) {
+  let normalized = realpathSync(path);
+  let bytes: Buffer;
+
+  if (process.platform === 'win32') {
+    if (/^[a-z]:/.test(normalized)) {
+      normalized = `${normalized[0]!.toUpperCase()}${normalized.slice(1)}`;
+    }
+    bytes = Buffer.from(normalized, 'utf16le');
+  } else {
+    bytes = Buffer.from(normalized, 'utf8');
+  }
+
+  const hex = createHash('sha256').update(bytes).digest('hex').slice(0, 32);
+  return Array.from(hex, digit =>
+    String.fromCharCode('a'.charCodeAt(0) + Number.parseInt(digit, 16))
+  ).join('');
+}
+
+async function launchExtensionContext(testInfo: TestInfo) {
+  return chromium.launchPersistentContext(
+    testInfo.outputPath('extension-profile'),
+    {
+      channel: 'chromium',
+      headless: true,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+      ],
+    }
+  );
+}
+
+async function openFixture(context: BrowserContext) {
+  const page = context.pages()[0] ?? (await context.newPage());
+  await page.goto('http://127.0.0.1:4174/fixture.html');
+  return page;
+}
+
+async function openPopup(context: BrowserContext) {
+  const popup = await context.newPage();
+  const extensionId = unpackedExtensionId(extensionPath);
+  await popup.goto(`chrome-extension://${extensionId}/popup.html`);
+  await expect(popup.locator('#enabled')).toBeVisible();
+  return popup;
+}
 
 test('demo controls drive real rendered coverage and reveal state', async ({ page }) => {
   await page.goto('http://127.0.0.1:4173');
@@ -34,21 +83,10 @@ test('demo controls drive real rendered coverage and reveal state', async ({ pag
 });
 
 test('built extension transforms initial and dynamic page text in Chromium', async ({}, testInfo) => {
-  const context = await chromium.launchPersistentContext(
-    testInfo.outputPath('extension-profile'),
-    {
-      channel: 'chromium',
-      headless: true,
-      args: [
-        `--disable-extensions-except=${extensionPath}`,
-        `--load-extension=${extensionPath}`,
-      ],
-    }
-  );
+  const context = await launchExtensionContext(testInfo);
 
   try {
-    const page = context.pages()[0] ?? (await context.newPage());
-    await page.goto('http://127.0.0.1:4174/fixture.html');
+    const page = await openFixture(context);
 
     await expect(
       page.locator('#initial [data-scrawlix-dom-root]')
@@ -79,6 +117,82 @@ test('built extension transforms initial and dynamic page text in Chromium', asy
     await page.locator('#native-link').click();
     await expect(page).toHaveURL('http://127.0.0.1:4174/clicked.html');
     await expect(page.locator('#clicked')).toHaveText('native link worked');
+  } finally {
+    await context.close();
+  }
+});
+
+test('built extension restores, persists, overrides sites, and recompiles custom words', async ({}, testInfo) => {
+  const context = await launchExtensionContext(testInfo);
+
+  try {
+    const page = await openFixture(context);
+    const initial = page.locator('#initial');
+    const custom = page.locator('#custom-copy');
+
+    await expect(initial.locator('[data-scrawlix-dom-root]')).toHaveCount(1);
+    await expect(custom.locator('[data-scrawlix-dom-root]')).toHaveCount(0);
+
+    const popup = await openPopup(context);
+    await expect(popup.locator('#enabled')).toBeChecked();
+
+    // Global off goes through the real popup UI and restores source immediately.
+    await popup.locator('#enabled').uncheck();
+    await expect(initial.locator('[data-scrawlix-dom-root]')).toHaveCount(0);
+    await expect(initial).toHaveText('well, fuck this');
+
+    await popup.close();
+    const reopened = await openPopup(context);
+    await expect(reopened.locator('#enabled')).not.toBeChecked();
+
+    // A persisted per-host override can turn this hostname back on while global is off.
+    await reopened.evaluate(async () => {
+      const key = 'scrawlixSettings';
+      const stored = await chrome.storage.sync.get(key);
+      const settings = stored[key];
+      await chrome.storage.sync.set({
+        [key]: {
+          ...settings,
+          enabled: false,
+          siteOverrides: { '127.0.0.1': 'on' },
+        },
+      });
+    });
+
+    await expect(initial.locator('[data-scrawlix-dom-root]')).toHaveCount(1);
+
+    // Presentation changes also restart through storage and reach the generated roots.
+    await reopened.locator('#appearance').selectOption('grawlix');
+    await expect(
+      initial.locator('[data-scrawlix-dom-root]')
+    ).toHaveAttribute('data-scrawlix-appearance', 'grawlix');
+
+    // Custom phrases are saved locally and compiled into the next controller session.
+    await reopened.locator('#custom-words').fill('Mothbit');
+    await reopened.locator('#custom-words').press('Tab');
+    await expect(reopened.locator('#save-status')).toHaveText('saved');
+    await expect(custom.locator('[data-scrawlix-dom-root]')).toHaveCount(1);
+    await expect(custom.locator('[data-scrawlix-cover]')).toHaveText('thb');
+
+    // Explicit site off wins over global/custom state and restores exact source again.
+    await reopened.evaluate(async () => {
+      const key = 'scrawlixSettings';
+      const stored = await chrome.storage.sync.get(key);
+      const settings = stored[key];
+      await chrome.storage.sync.set({
+        [key]: {
+          ...settings,
+          siteOverrides: { '127.0.0.1': 'off' },
+        },
+      });
+    });
+
+    await expect(initial.locator('[data-scrawlix-dom-root]')).toHaveCount(0);
+    await expect(custom.locator('[data-scrawlix-dom-root]')).toHaveCount(0);
+    await expect(initial).toHaveText('well, fuck this');
+    await expect(custom).toHaveText(
+      'Mothbit stays visible until it joins the custom list.'
+    );
   } finally {
     await context.close();
   }

--- a/tests/browser/fixture-server.mjs
+++ b/tests/browser/fixture-server.mjs
@@ -9,6 +9,7 @@ const fixture = `<!doctype html>
   <body>
     <main>
       <p id="initial">well, fuck this</p>
+      <p id="custom-copy">Mothbit stays visible until it joins the custom list.</p>
       <p><code id="code">fuck</code></p>
       <div id="editable" contenteditable="true">fuck</div>
       <button id="native-button" type="button">fuck</button>


### PR DESCRIPTION
Progresses #23.

### Real extension state lifecycle
- extends the deterministic browser fixture with a custom-term candidate (`Mothbit`)
- computes the unpacked Chromium extension ID from the exact loaded extension path, matching Chromium's path-hash behavior for unpacked extensions
- opens the real built popup without adding a production background/service worker

### Storage/popup E2E
- global off through the actual popup checkbox restores exact source immediately
- reopening the popup proves the global setting persisted in `chrome.storage.sync`
- a real per-host `127.0.0.1: on` override forces the site back on while global remains off
- changing the popup appearance to `grawlix` restarts the page session and reaches generated DOM roots
- entering `Mothbit` through the popup custom-word textarea persists locally and recompiles the active controller
- the custom word receives generic middle coverage (`othb`)
- an explicit per-host `off` override wins over global/custom state and restores exact built-in + custom source text again

This keeps the shipped extension service-worker-free; extension ID discovery exists only in the Playwright harness. The test uses the same built MV3 artifact CI already exercises.