### PR TITLE
Expand and unify censor appearance rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ Scrawlix is in pre-release development. Until the first package version is chose
 ### React
 
 - Added `@scrawlix/react` and `CensoredText`.
-- Added `scrawl`, `bar`, `blur`, `asterisk`, and `grawlix` appearances.
+- Added `scrawl`, `bar`, `blur`, `whiteout`, `mosaic`, `asterisk`, and `grawlix` appearances.
 - Added `hover`, `focus`, `click`, and `never` reveal behavior.
 - Added keyboard reveal handling and a single-source accessibility contract with rendered regressions.
+- Standardized namespaced presentation attributes and kept symbol-mask source text in-flow across reveal states.
+- Added grapheme-aware asterisk/grawlix masks and configurable appearance CSS custom properties.
 - Added the public CSS subpath export.
 
 ### Markdown
@@ -43,10 +45,12 @@ Scrawlix is in pre-release development. Until the first package version is chose
 
 - Added an interactive editorial proof-sheet demo under `apps/demo`.
 - Added a Vercel-ready static deployment configuration.
-- Added a Manifest V3 Chromium extension under `apps/extension` with global/site preferences, five appearances, coverage/reveal controls, and local custom terms.
+- Added a Manifest V3 Chromium extension under `apps/extension` with global/site preferences, seven appearances, coverage/reveal controls, and local custom terms.
+- Aligned React and extension presentation attributes and appearance CSS behavior.
 
 ### Developer experience
 
 - Added compiled ESM/declaration artifacts for public packages.
 - Added an external tarball consumer smoke test as a CI release gate.
 - Added `AGENTS.md`, `llms.txt`, language-pack docs, DOM lifecycle docs, extension docs, and the first-release runbook.
+- Extended browser smoke coverage for the shared presentation contract and reveal-width stability.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Scrawlix separates the interesting parts of censorship so they can be mixed deli
 - **appearance** — how should the covered part look?
 - **reveal** — when, if ever, should the original text show through?
 
-That means the same word can become `████`, `f███`, `f██k`, `f█ck`, `f**k`, a blur, an inked-over scrawl, or a grawlix — while callers keep control of the underlying source text.
+That means the same word can become `████`, `f███`, `f██k`, `f█ck`, `f**k`, a blur, an inked-over scrawl, correction-fluid whiteout, a pixel mosaic, or a grawlix — while callers keep control of the underlying source text.
 
 Scrawlix began as a censor/reveal primitive in [Scrapbook](https://github.com/teamleaderleo/scrapbook). The standalone project turns that experiment into a small language-neutral engine with rule packs and adapters for React, Markdown, arbitrary DOMs, and a browser extension built from the same pieces.
 
@@ -47,9 +47,11 @@ import '@scrawlix/react/styles.css';
 />;
 ```
 
-Current appearances: `scrawl`, `bar`, `blur`, `asterisk`, and `grawlix`.
+Current appearances: `scrawl`, `bar`, `blur`, `whiteout`, `mosaic`, `asterisk`, and `grawlix`.
 
 Current reveal modes: `hover`, `focus`, `click`, and `never`.
+
+The renderer exposes a namespaced presentation contract through `data-scrawlix-root`, `data-scrawlix-appearance`, `data-scrawlix-reveal`, `data-scrawlix-revealed`, `data-scrawlix-cover`, `data-scrawlix-rules`, and optional `data-scrawlix-mask` attributes. Preset styling can be tuned with CSS custom properties including `--scrawlix-ink`, `--scrawlix-surface`, `--scrawlix-bar-height`, `--scrawlix-blur-radius`, and `--scrawlix-mosaic-cell`.
 
 ## Markdown / rehype
 
@@ -120,7 +122,7 @@ The popup currently supports:
 
 - a global on/off switch
 - per-host **follow global / always on / always off** behavior
-- all five appearances
+- all seven appearances
 - all generic coverage modes plus English vowel coverage
 - hover / focus / click / never reveal
 - local custom words and phrases
@@ -171,7 +173,7 @@ pnpm install
 pnpm dev
 ```
 
-The demo includes an editable live proof, coverage and reveal controls, a five-style specimen sheet, semantic-match examples, and a live component snippet.
+The demo includes an editable live proof, coverage and reveal controls, a seven-style specimen sheet, semantic-match examples, and a live component snippet.
 
 ### Vercel
 
@@ -209,6 +211,9 @@ pnpm smoke:packages
 - [Language packs](https://github.com/teamleaderleo/scrawlix/issues/12)
 - [Human and agent adoption ergonomics](https://github.com/teamleaderleo/scrawlix/issues/13)
 - [First public release readiness](https://github.com/teamleaderleo/scrawlix/issues/18)
+- [Appearance DOM/CSS contract](https://github.com/teamleaderleo/scrawlix/issues/26)
+- [Per-match reveal metadata](https://github.com/teamleaderleo/scrawlix/issues/27)
+- [Demo X-ray and specimen lab](https://github.com/teamleaderleo/scrawlix/issues/28)
 
 ## Status
 

--- a/apps/demo/public/llms.txt
+++ b/apps/demo/public/llms.txt
@@ -77,11 +77,13 @@ The rehype adapter emits spans with `data-scrawlix-cover` and `data-scrawlix-rul
 
 The DOM adapter transforms only matching text nodes, marks controller output with `data-scrawlix-dom-root`, skips editable/form/code/non-HTML regions by default, observes only mutation roots delivered by MutationObserver, and can restore exact controller-owned source strings.
 
+React and the extension share namespaced presentation metadata: `data-scrawlix-root`, `data-scrawlix-appearance`, `data-scrawlix-reveal`, `data-scrawlix-revealed`, `data-scrawlix-cover`, `data-scrawlix-rules`, and optional `data-scrawlix-mask`.
+
 Core is deliberately language-neutral. Select language/rule packs explicitly. Custom names, spoilers, and phrases can be supplied with `censorRuleFromWords()`.
 
 Generic coverage presets: full, tail, middle, inner.
 English-specific helper: englishVowelCoverage.
-React appearances: scrawl, bar, blur, asterisk, grawlix.
+React appearances: scrawl, bar, blur, whiteout, mosaic, asterisk, grawlix.
 React reveal modes: hover, focus, click, never.
 
 Maintainer guidance: https://github.com/teamleaderleo/scrawlix/blob/main/AGENTS.md

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -14,6 +14,8 @@ const appearances: readonly ScrawlixAppearance[] = [
   'scrawl',
   'bar',
   'blur',
+  'whiteout',
+  'mosaic',
   'asterisk',
   'grawlix',
 ];
@@ -177,7 +179,7 @@ export function App() {
       <section className="specimen-section" aria-labelledby="specimen-title">
         <div className="section-heading">
           <p className="eyebrow">02 / specimen sheet</p>
-          <h2 id="specimen-title">Five ways to lose your fucking vowels.</h2>
+          <h2 id="specimen-title">Seven ways to damage the same word.</h2>
           <p>
             Same matcher. Same coverage rule. Different presentation. Swap the visual
             treatment without teaching your text parser anything new.

--- a/apps/demo/src/styles.css
+++ b/apps/demo/src/styles.css
@@ -24,6 +24,10 @@ body {
   background-size: 100% 28px;
 }
 
+[data-scrawlix-root] {
+  --scrawlix-surface: #fffdf7;
+}
+
 button,
 textarea {
   font: inherit;
@@ -276,7 +280,7 @@ main {
 
 .specimen-grid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(7, minmax(0, 1fr));
   border: 1px solid #171512;
 }
 
@@ -459,6 +463,16 @@ footer a {
     border-bottom: 1px solid #171512;
   }
 
+  .specimen-card:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .specimen-card:last-child {
+    grid-column: 1 / -1;
+    border-right: 0;
+    border-bottom: 0;
+  }
+
   .semantic-grid {
     grid-template-columns: 1fr;
   }
@@ -513,7 +527,9 @@ footer a {
   }
 
   .specimen-card,
+  .specimen-card:nth-child(2n),
   .specimen-card:last-child {
+    grid-column: auto;
     border-right: 0;
     border-bottom: 1px solid #171512;
   }
@@ -528,5 +544,11 @@ footer a {
 
   footer span:nth-child(2) {
     display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
   }
 }

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -61,15 +61,21 @@ The DOM adapter watches mutation roots rather than rescanning the document after
 
 ## Presentation
 
-`content.css` implements the extension's five appearances:
+`content.css` implements the extension's seven appearances:
 
 - scrawl
 - bar
 - blur
+- whiteout
+- mosaic
 - asterisk
 - grawlix
 
-Asterisk/grawlix masks are presentation metadata on generated cover spans. The source substring remains the actual DOM text underneath.
+Generated page wrappers keep their `data-scrawlix-dom-root` ownership marker and also receive the shared `data-scrawlix-root`, `data-scrawlix-appearance`, `data-scrawlix-reveal`, and `data-scrawlix-revealed` presentation attributes used by the React adapter.
+
+Asterisk/grawlix masks live in `data-scrawlix-mask` metadata on generated cover spans. The exact covered substring remains the in-flow DOM text underneath, so reveal preserves its layout width. Symbol counts follow Unicode grapheme clusters when `Intl.Segmenter` is available.
+
+Appearance CSS can be tuned per page with `--scrawlix-ink`, `--scrawlix-surface`, `--scrawlix-bar-height`, `--scrawlix-blur-radius`, and `--scrawlix-mosaic-cell`.
 
 Hover is the default reveal mode. Focus/click reveal makes a generated wrapper keyboard-focusable only when the wrapper is outside links, buttons, inputs, and other native interactive controls. Scrawlix avoids stealing those controls' interaction semantics.
 

--- a/apps/extension/popup.html
+++ b/apps/extension/popup.html
@@ -41,6 +41,8 @@
             <option value="scrawl">scrawl</option>
             <option value="bar">bar</option>
             <option value="blur">blur</option>
+            <option value="whiteout">whiteout</option>
+            <option value="mosaic">mosaic</option>
             <option value="asterisk">asterisk</option>
             <option value="grawlix">grawlix</option>
           </select>

--- a/apps/extension/src/config.test.ts
+++ b/apps/extension/src/config.test.ts
@@ -30,6 +30,20 @@ describe('extension settings', () => {
     });
   });
 
+  it('accepts the full appearance set', () => {
+    for (const appearance of [
+      'scrawl',
+      'bar',
+      'blur',
+      'whiteout',
+      'mosaic',
+      'asterisk',
+      'grawlix',
+    ] as const) {
+      expect(normalizeSettings({ appearance }).appearance).toBe(appearance);
+    }
+  });
+
   it('lets explicit site modes override the global switch', () => {
     const disabled = { ...DEFAULT_SETTINGS, enabled: false };
     const forcedOn = setSiteMode(disabled, 'example.com', 'on');
@@ -62,7 +76,9 @@ describe('extension settings', () => {
   it('generates symbol masks without rewriting source text', () => {
     expect(maskFor('fuck', 'asterisk')).toBe('****');
     expect(maskFor('abcdef', 'grawlix')).toBe('@#$%&!');
-    expect(maskFor('🔥x', 'asterisk')).toBe('**');
+    expect(maskFor('👩🏽‍💻x', 'asterisk')).toBe('**');
     expect(maskFor('fuck', 'bar')).toBe('');
+    expect(maskFor('fuck', 'whiteout')).toBe('');
+    expect(maskFor('fuck', 'mosaic')).toBe('');
   });
 });

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -5,6 +5,8 @@ export type ExtensionAppearance =
   | 'scrawl'
   | 'bar'
   | 'blur'
+  | 'whiteout'
+  | 'mosaic'
   | 'asterisk'
   | 'grawlix';
 
@@ -35,6 +37,8 @@ const APPEARANCES = new Set<ExtensionAppearance>([
   'scrawl',
   'bar',
   'blur',
+  'whiteout',
+  'mosaic',
   'asterisk',
   'grawlix',
 ]);
@@ -46,9 +50,18 @@ const COVERAGES = new Set<ExtensionCoverage>([
   'vowel',
 ]);
 const REVEALS = new Set<ExtensionReveal>(['hover', 'focus', 'click', 'never']);
+const graphemeSegmenter =
+  typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
+    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    : null;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function graphemeCount(text: string) {
+  if (graphemeSegmenter) return [...graphemeSegmenter.segment(text)].length;
+  return Array.from(text).length;
 }
 
 export function normalizeSettings(value: unknown): SyncSettings {
@@ -132,7 +145,7 @@ export function coverageSelector(coverage: ExtensionCoverage): CoverageSelector 
 }
 
 export function maskFor(text: string, appearance: ExtensionAppearance) {
-  const length = Array.from(text).length;
+  const length = graphemeCount(text);
   if (appearance === 'asterisk') return '*'.repeat(length);
   if (appearance === 'grawlix') {
     const symbols = '@#$%&!';

--- a/apps/extension/src/content.css
+++ b/apps/extension/src/content.css
@@ -72,34 +72,52 @@
 
 [data-scrawlix-root][data-scrawlix-appearance='mosaic'] [data-scrawlix-cover] {
   -webkit-text-fill-color: transparent;
-  background:
+  background-color: var(--scrawlix-soft-ink);
+  background-image:
     linear-gradient(
-        90deg,
-        var(--scrawlix-ink) 0 24%,
-        transparent 24% 42%,
-        var(--scrawlix-fuzzy-ink) 42% 67%,
-        transparent 67% 78%,
-        var(--scrawlix-ink) 78% 100%
+      90deg,
+      var(--scrawlix-ink) 0 22%,
+      var(--scrawlix-fuzzy-ink) 22% 52%,
+      var(--scrawlix-ink) 52% 73%,
+      var(--scrawlix-soft-ink) 73% 100%
+    ),
+    linear-gradient(
+      90deg,
+      var(--scrawlix-fuzzy-ink) 0 18%,
+      var(--scrawlix-ink) 18% 47%,
+      var(--scrawlix-soft-ink) 47% 69%,
+      var(--scrawlix-ink) 69% 100%
+    ),
+    linear-gradient(
+      90deg,
+      var(--scrawlix-ink) 0 31%,
+      var(--scrawlix-soft-ink) 31% 48%,
+      var(--scrawlix-ink) 48% 78%,
+      var(--scrawlix-fuzzy-ink) 78% 100%
+    );
+  background-position:
+    0 0.03em,
+    var(--scrawlix-mosaic-cell) calc(var(--scrawlix-mosaic-cell) + 0.03em),
+    0 calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) + 0.03em
+      );
+  background-size:
+    calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+          var(--scrawlix-mosaic-cell)
       )
-      0 0 /
-      calc(
-          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
-            var(--scrawlix-mosaic-cell)
-        )
       var(--scrawlix-mosaic-cell),
-    linear-gradient(
-        90deg,
-        var(--scrawlix-soft-ink) 0 31%,
-        var(--scrawlix-ink) 31% 55%,
-        var(--scrawlix-fuzzy-ink) 55% 77%,
-        var(--scrawlix-ink) 77% 100%
+    calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell)
       )
-      var(--scrawlix-mosaic-cell) var(--scrawlix-mosaic-cell) /
-      calc(
-          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
-            var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell)
-        )
+      var(--scrawlix-mosaic-cell),
+    calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+          var(--scrawlix-mosaic-cell)
+      )
       var(--scrawlix-mosaic-cell);
+  background-repeat: repeat-x;
   border-radius: 0.035em;
 }
 

--- a/apps/extension/src/content.css
+++ b/apps/extension/src/content.css
@@ -1,87 +1,128 @@
-[data-scrawlix-dom-root] {
-  --scrawlix-soft-ink: color-mix(in srgb, currentColor 24%, transparent);
-  --scrawlix-fuzzy-ink: color-mix(in srgb, currentColor 58%, transparent);
+[data-scrawlix-root] {
+  --scrawlix-ink: currentColor;
+  --scrawlix-soft-ink: color-mix(in srgb, var(--scrawlix-ink) 24%, transparent);
+  --scrawlix-fuzzy-ink: color-mix(in srgb, var(--scrawlix-ink) 58%, transparent);
+  --scrawlix-surface: Canvas;
+  --scrawlix-bar-height: 0.72em;
+  --scrawlix-blur-radius: 0.17em;
+  --scrawlix-mosaic-cell: 0.3em;
 }
 
-[data-scrawlix-dom-root]:focus-visible {
+[data-scrawlix-root]:focus-visible {
   outline: 1px solid currentColor;
-  outline-offset: 0.15em;
+  outline-offset: 0.2em;
   border-radius: 0.12em;
 }
 
-[data-scrawlix-dom-root] [data-scrawlix-cover] {
+[data-scrawlix-cover] {
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
+  display: inline;
   position: relative;
   transition:
     filter 140ms ease,
     background 140ms ease,
+    box-shadow 140ms ease,
     text-shadow 140ms ease,
     -webkit-text-fill-color 140ms ease;
 }
 
-[data-scrawlix-dom-root][data-scrawlix-appearance='scrawl'] [data-scrawlix-cover] {
+[data-scrawlix-root][data-scrawlix-appearance='scrawl'] [data-scrawlix-cover] {
   -webkit-text-fill-color: transparent;
-  background: repeating-linear-gradient(
-    -13deg,
-    var(--scrawlix-soft-ink) 0 0.08em,
-    transparent 0.08em 0.18em
-  );
-  border-radius: 0.18em;
-  padding-inline: 0.04em;
-  text-shadow: 0 0 0.34em var(--scrawlix-fuzzy-ink);
+  background:
+    repeating-linear-gradient(
+      -13deg,
+      var(--scrawlix-soft-ink) 0 0.07em,
+      transparent 0.07em 0.16em
+    ),
+    repeating-linear-gradient(
+      9deg,
+      transparent 0 0.09em,
+      var(--scrawlix-fuzzy-ink) 0.09em 0.13em,
+      transparent 0.13em 0.23em
+    );
+  border-radius: 0.16em;
+  text-shadow: 0 0 0.3em var(--scrawlix-fuzzy-ink);
 }
 
-[data-scrawlix-dom-root][data-scrawlix-appearance='bar'] [data-scrawlix-cover] {
+[data-scrawlix-root][data-scrawlix-appearance='bar'] [data-scrawlix-cover] {
   -webkit-text-fill-color: transparent;
-  background: linear-gradient(currentColor, currentColor) center / 100% 0.72em no-repeat;
+  background: linear-gradient(var(--scrawlix-ink), var(--scrawlix-ink)) center / 100%
+    var(--scrawlix-bar-height) no-repeat;
   border-radius: 0.06em;
 }
 
-[data-scrawlix-dom-root][data-scrawlix-appearance='blur'] [data-scrawlix-cover] {
-  filter: blur(0.17em);
+[data-scrawlix-root][data-scrawlix-appearance='blur'] [data-scrawlix-cover] {
+  filter: blur(var(--scrawlix-blur-radius));
   user-select: none;
 }
 
-[data-scrawlix-dom-root] [data-scrawlix-cover][data-scrawlix-mask] {
-  display: inline-block;
-  position: relative;
+[data-scrawlix-root][data-scrawlix-appearance='whiteout'] [data-scrawlix-cover] {
+  -webkit-text-fill-color: transparent;
+  background: linear-gradient(var(--scrawlix-surface), var(--scrawlix-surface)) center / 100%
+    0.94em no-repeat;
+  border-radius: 0.04em;
+  box-shadow:
+    inset 0 0.055em color-mix(in srgb, var(--scrawlix-ink) 10%, transparent),
+    inset 0 -0.055em color-mix(in srgb, var(--scrawlix-ink) 7%, transparent);
+}
+
+[data-scrawlix-root][data-scrawlix-appearance='mosaic'] [data-scrawlix-cover] {
+  -webkit-text-fill-color: transparent;
+  background: repeating-conic-gradient(
+      from 45deg,
+      var(--scrawlix-ink) 0 25%,
+      var(--scrawlix-soft-ink) 0 50%
+    )
+    center / var(--scrawlix-mosaic-cell) var(--scrawlix-mosaic-cell);
+  border-radius: 0.04em;
+}
+
+[data-scrawlix-cover][data-scrawlix-mask] {
   -webkit-text-fill-color: transparent;
 }
 
-[data-scrawlix-dom-root] [data-scrawlix-cover][data-scrawlix-mask]::after {
+[data-scrawlix-cover][data-scrawlix-mask]::after {
   content: attr(data-scrawlix-mask);
   position: absolute;
-  inset: 0;
-  color: currentColor;
-  -webkit-text-fill-color: currentColor;
+  inset-inline-start: 0;
+  top: 0.02em;
+  color: var(--scrawlix-ink);
+  -webkit-text-fill-color: var(--scrawlix-ink);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 0.92em;
   font-weight: 700;
   letter-spacing: -0.04em;
+  line-height: inherit;
   pointer-events: none;
   white-space: pre;
+  transition: opacity 140ms ease;
 }
 
-[data-scrawlix-dom-root][data-scrawlix-reveal='hover']:hover [data-scrawlix-cover],
-[data-scrawlix-dom-root][data-scrawlix-reveal='focus']:focus [data-scrawlix-cover],
-[data-scrawlix-dom-root][data-scrawlix-reveal='click'][data-scrawlix-revealed='true'] [data-scrawlix-cover] {
+[data-scrawlix-root][data-scrawlix-reveal='hover']:hover [data-scrawlix-cover],
+[data-scrawlix-root][data-scrawlix-reveal='focus']:focus [data-scrawlix-cover],
+[data-scrawlix-root][data-scrawlix-reveal='click'][data-scrawlix-revealed='true']
+  [data-scrawlix-cover] {
   -webkit-text-fill-color: currentColor;
-  background: none;
+  background: transparent;
+  box-shadow: none;
   filter: none;
-  padding-inline: 0;
   text-shadow: none;
   user-select: text;
 }
 
-[data-scrawlix-dom-root][data-scrawlix-reveal='hover']:hover [data-scrawlix-cover][data-scrawlix-mask]::after,
-[data-scrawlix-dom-root][data-scrawlix-reveal='focus']:focus [data-scrawlix-cover][data-scrawlix-mask]::after,
-[data-scrawlix-dom-root][data-scrawlix-reveal='click'][data-scrawlix-revealed='true'] [data-scrawlix-cover][data-scrawlix-mask]::after {
+[data-scrawlix-root][data-scrawlix-reveal='hover']:hover
+  [data-scrawlix-cover][data-scrawlix-mask]::after,
+[data-scrawlix-root][data-scrawlix-reveal='focus']:focus
+  [data-scrawlix-cover][data-scrawlix-mask]::after,
+[data-scrawlix-root][data-scrawlix-reveal='click'][data-scrawlix-revealed='true']
+  [data-scrawlix-cover][data-scrawlix-mask]::after {
   opacity: 0;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  [data-scrawlix-dom-root] [data-scrawlix-cover] {
+  [data-scrawlix-cover],
+  [data-scrawlix-cover][data-scrawlix-mask]::after {
     transition: none;
   }
 }

--- a/apps/extension/src/content.css
+++ b/apps/extension/src/content.css
@@ -14,7 +14,7 @@
   border-radius: 0.12em;
 }
 
-[data-scrawlix-cover] {
+[data-scrawlix-root] [data-scrawlix-cover] {
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
   display: inline;
@@ -78,11 +78,11 @@
   border-radius: 0.04em;
 }
 
-[data-scrawlix-cover][data-scrawlix-mask] {
+[data-scrawlix-root] [data-scrawlix-cover][data-scrawlix-mask] {
   -webkit-text-fill-color: transparent;
 }
 
-[data-scrawlix-cover][data-scrawlix-mask]::after {
+[data-scrawlix-root] [data-scrawlix-cover][data-scrawlix-mask]::after {
   content: attr(data-scrawlix-mask);
   position: absolute;
   inset-inline-start: 0;
@@ -121,8 +121,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  [data-scrawlix-cover],
-  [data-scrawlix-cover][data-scrawlix-mask]::after {
+  [data-scrawlix-root] [data-scrawlix-cover],
+  [data-scrawlix-root] [data-scrawlix-cover][data-scrawlix-mask]::after {
     transition: none;
   }
 }

--- a/apps/extension/src/content.css
+++ b/apps/extension/src/content.css
@@ -31,18 +31,20 @@
   -webkit-text-fill-color: transparent;
   background:
     repeating-linear-gradient(
-      -13deg,
-      var(--scrawlix-soft-ink) 0 0.07em,
-      transparent 0.07em 0.16em
+      -11deg,
+      color-mix(in srgb, var(--scrawlix-ink) 74%, transparent) 0 0.055em,
+      transparent 0.055em 0.12em,
+      color-mix(in srgb, var(--scrawlix-ink) 46%, transparent) 0.12em 0.18em,
+      transparent 0.18em 0.23em
     ),
     repeating-linear-gradient(
-      9deg,
-      transparent 0 0.09em,
-      var(--scrawlix-fuzzy-ink) 0.09em 0.13em,
-      transparent 0.13em 0.23em
+      7deg,
+      transparent 0 0.075em,
+      color-mix(in srgb, var(--scrawlix-ink) 84%, transparent) 0.075em 0.105em,
+      transparent 0.105em 0.17em
     );
-  border-radius: 0.16em;
-  text-shadow: 0 0 0.3em var(--scrawlix-fuzzy-ink);
+  border-radius: 0.1em;
+  text-shadow: 0 0 0.16em color-mix(in srgb, var(--scrawlix-ink) 46%, transparent);
 }
 
 [data-scrawlix-root][data-scrawlix-appearance='bar'] [data-scrawlix-cover] {
@@ -63,19 +65,42 @@
     0.94em no-repeat;
   border-radius: 0.04em;
   box-shadow:
-    inset 0 0.055em color-mix(in srgb, var(--scrawlix-ink) 10%, transparent),
-    inset 0 -0.055em color-mix(in srgb, var(--scrawlix-ink) 7%, transparent);
+    inset 0 0.055em color-mix(in srgb, var(--scrawlix-ink) 12%, transparent),
+    inset 0 -0.055em color-mix(in srgb, var(--scrawlix-ink) 8%, transparent),
+    0 0.045em 0.09em color-mix(in srgb, var(--scrawlix-ink) 12%, transparent);
 }
 
 [data-scrawlix-root][data-scrawlix-appearance='mosaic'] [data-scrawlix-cover] {
   -webkit-text-fill-color: transparent;
-  background: repeating-conic-gradient(
-      from 45deg,
-      var(--scrawlix-ink) 0 25%,
-      var(--scrawlix-soft-ink) 0 50%
-    )
-    center / var(--scrawlix-mosaic-cell) var(--scrawlix-mosaic-cell);
-  border-radius: 0.04em;
+  background:
+    linear-gradient(
+        90deg,
+        var(--scrawlix-ink) 0 24%,
+        transparent 24% 42%,
+        var(--scrawlix-fuzzy-ink) 42% 67%,
+        transparent 67% 78%,
+        var(--scrawlix-ink) 78% 100%
+      )
+      0 0 /
+      calc(
+          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+            var(--scrawlix-mosaic-cell)
+        )
+      var(--scrawlix-mosaic-cell),
+    linear-gradient(
+        90deg,
+        var(--scrawlix-soft-ink) 0 31%,
+        var(--scrawlix-ink) 31% 55%,
+        var(--scrawlix-fuzzy-ink) 55% 77%,
+        var(--scrawlix-ink) 77% 100%
+      )
+      var(--scrawlix-mosaic-cell) var(--scrawlix-mosaic-cell) /
+      calc(
+          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+            var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell)
+        )
+      var(--scrawlix-mosaic-cell);
+  border-radius: 0.035em;
 }
 
 [data-scrawlix-root] [data-scrawlix-cover][data-scrawlix-mask] {

--- a/apps/extension/src/content.ts
+++ b/apps/extension/src/content.ts
@@ -29,6 +29,7 @@ function canOwnInteraction(root: HTMLElement) {
 }
 
 function decorateGeneratedRoot(root: HTMLElement, settings: SyncSettings) {
+  root.setAttribute('data-scrawlix-root', '');
   root.dataset.scrawlixAppearance = settings.appearance;
   root.dataset.scrawlixReveal = settings.reveal;
   root.dataset.scrawlixRevealed = 'false';

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -57,12 +57,12 @@ describe('CensoredText', () => {
     const covers = visual.querySelectorAll('[data-scrawlix-cover]');
 
     expect(root.getAttribute('aria-label')).toBeNull();
+    expect(root.dataset.scrawlixAppearance).toBe('bar');
     expect(accessible.textContent).toBe(text);
     expect(accessible.getAttribute('aria-hidden')).toBeNull();
     expect(visual.getAttribute('aria-hidden')).toBe('true');
     expect(covers).toHaveLength(1);
-    expect(covers[0]?.getAttribute('data-rules')).toBe('fuck');
-    expect(covers[0]?.getAttribute('data-appearance')).toBe('bar');
+    expect(covers[0]?.getAttribute('data-scrawlix-rules')).toBe('fuck');
   });
 
   it('keeps hover and never reveal passive in the tab order', () => {
@@ -73,8 +73,8 @@ describe('CensoredText', () => {
       const root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
 
       expect(root.getAttribute('tabindex')).toBeNull();
-      expect(root.dataset.reveal).toBe(reveal);
-      expect(root.dataset.revealed).toBe('false');
+      expect(root.dataset.scrawlixReveal).toBe(reveal);
+      expect(root.dataset.scrawlixRevealed).toBe('false');
     }
   });
 
@@ -86,7 +86,7 @@ describe('CensoredText', () => {
 
     expect(root.tabIndex).toBe(0);
     act(() => root.dispatchEvent(new MouseEvent('click', { bubbles: true })));
-    expect(root.dataset.revealed).toBe('false');
+    expect(root.dataset.scrawlixRevealed).toBe('false');
   });
 
   it('toggles click reveal with pointer activation', () => {
@@ -96,13 +96,13 @@ describe('CensoredText', () => {
     const root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
 
     expect(root.tabIndex).toBe(0);
-    expect(root.dataset.revealed).toBe('false');
+    expect(root.dataset.scrawlixRevealed).toBe('false');
 
     act(() => root.dispatchEvent(new MouseEvent('click', { bubbles: true })));
-    expect(root.dataset.revealed).toBe('true');
+    expect(root.dataset.scrawlixRevealed).toBe('true');
 
     act(() => root.dispatchEvent(new MouseEvent('click', { bubbles: true })));
-    expect(root.dataset.revealed).toBe('false');
+    expect(root.dataset.scrawlixRevealed).toBe('false');
   });
 
   it.each(['Enter', ' '])('toggles click reveal with %j', key => {
@@ -121,10 +121,10 @@ describe('CensoredText', () => {
       )
     );
 
-    expect(root.dataset.revealed).toBe('true');
+    expect(root.dataset.scrawlixRevealed).toBe('true');
   });
 
-  it('renders symbol masks while retaining the exact covered source substring', () => {
+  it('paints symbol masks over the exact covered source substring', () => {
     const container = render(
       <CensoredText
         appearance="asterisk"
@@ -135,11 +135,9 @@ describe('CensoredText', () => {
     );
 
     const cover = container.querySelector<HTMLElement>('[data-scrawlix-cover]')!;
-    const mask = cover.querySelector<HTMLElement>('[data-scrawlix-mask]')!;
-    const source = cover.querySelector<HTMLElement>('[data-scrawlix-source]')!;
 
-    expect(mask.textContent).toBe('**');
-    expect(source.textContent).toBe('uc');
+    expect(cover.dataset.scrawlixMask).toBe('**');
+    expect(cover.textContent).toBe('uc');
   });
 
   it('cycles grawlix symbols by covered grapheme count', () => {
@@ -154,7 +152,24 @@ describe('CensoredText', () => {
     );
 
     expect(
-      container.querySelector<HTMLElement>('[data-scrawlix-mask]')?.textContent
+      container.querySelector<HTMLElement>('[data-scrawlix-cover]')?.dataset
+        .scrawlixMask
     ).toBe('@#$%&!');
+  });
+
+  it('treats emoji sequences as single grapheme clusters in symbol masks', () => {
+    const fullRule = [{ id: 'emoji', pattern: /👩🏽‍💻x/gu }] as const;
+    const container = render(
+      <CensoredText
+        appearance="asterisk"
+        coverage="full"
+        rules={fullRule}
+        text="👩🏽‍💻x"
+      />
+    );
+
+    const cover = container.querySelector<HTMLElement>('[data-scrawlix-cover]')!;
+    expect(cover.dataset.scrawlixMask).toBe('**');
+    expect(cover.textContent).toBe('👩🏽‍💻x');
   });
 });

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -9,6 +9,8 @@ export type ScrawlixAppearance =
   | 'scrawl'
   | 'bar'
   | 'blur'
+  | 'whiteout'
+  | 'mosaic'
   | 'asterisk'
   | 'grawlix';
 
@@ -25,16 +27,27 @@ export type CensoredTextProps = {
 };
 
 const GRAWLIX = '@#$%&!';
+const graphemeSegmenter =
+  typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
+    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    : null;
 
-function symbolsFor(text: string, appearance: ScrawlixAppearance) {
-  const characters = Array.from(text);
-  if (appearance === 'asterisk') return characters.map(() => '*').join('');
+function graphemesFor(text: string) {
+  if (graphemeSegmenter) {
+    return [...graphemeSegmenter.segment(text)].map(part => part.segment);
+  }
+  return Array.from(text);
+}
+
+function maskFor(text: string, appearance: ScrawlixAppearance) {
+  const graphemes = graphemesFor(text);
+  if (appearance === 'asterisk') return graphemes.map(() => '*').join('');
   if (appearance === 'grawlix') {
-    return characters
+    return graphemes
       .map((_, index) => GRAWLIX[index % GRAWLIX.length])
       .join('');
   }
-  return text;
+  return '';
 }
 
 export function CensoredText({
@@ -70,8 +83,9 @@ export function CensoredText({
     <span
       className={className}
       data-scrawlix-root
-      data-reveal={reveal}
-      data-revealed={revealed ? 'true' : 'false'}
+      data-scrawlix-appearance={appearance}
+      data-scrawlix-reveal={reveal}
+      data-scrawlix-revealed={revealed ? 'true' : 'false'}
       tabIndex={interactive ? 0 : undefined}
       onClick={reveal === 'click' ? () => setRevealed(value => !value) : undefined}
       onKeyDown={onKeyDown}
@@ -83,27 +97,17 @@ export function CensoredText({
             return <span key={`${index}-${segment.text}`}>{segment.text}</span>;
           }
 
-          const symbolAppearance =
-            appearance === 'asterisk' || appearance === 'grawlix';
+          const mask = maskFor(segment.text, appearance);
 
           return (
             <span
               data-scrawlix-cover
-              data-appearance={appearance}
-              data-rules={segment.ruleIds.join(',')}
+              data-scrawlix-mask={mask || undefined}
+              data-scrawlix-rules={segment.ruleIds.join(',')}
               key={`${index}-${segment.text}`}
               title={title}
             >
-              {symbolAppearance ? (
-                <>
-                  <span data-scrawlix-mask>
-                    {symbolsFor(segment.text, appearance)}
-                  </span>
-                  <span data-scrawlix-source>{segment.text}</span>
-                </>
-              ) : (
-                segment.text
-              )}
+              {segment.text}
             </span>
           );
         })}

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1,6 +1,11 @@
 [data-scrawlix-root] {
-  --scrawlix-soft-ink: color-mix(in srgb, currentColor 24%, transparent);
-  --scrawlix-fuzzy-ink: color-mix(in srgb, currentColor 58%, transparent);
+  --scrawlix-ink: currentColor;
+  --scrawlix-soft-ink: color-mix(in srgb, var(--scrawlix-ink) 24%, transparent);
+  --scrawlix-fuzzy-ink: color-mix(in srgb, var(--scrawlix-ink) 58%, transparent);
+  --scrawlix-surface: Canvas;
+  --scrawlix-bar-height: 0.72em;
+  --scrawlix-blur-radius: 0.17em;
+  --scrawlix-mosaic-cell: 0.3em;
 }
 
 [data-scrawlix-a11y] {
@@ -30,70 +35,107 @@
   transition:
     filter 140ms ease,
     background 140ms ease,
+    box-shadow 140ms ease,
     text-shadow 140ms ease,
     -webkit-text-fill-color 140ms ease;
 }
 
-[data-scrawlix-cover][data-appearance='scrawl'] {
+[data-scrawlix-root][data-scrawlix-appearance='scrawl'] [data-scrawlix-cover] {
   -webkit-text-fill-color: transparent;
-  background: repeating-linear-gradient(
-    -13deg,
-    var(--scrawlix-soft-ink) 0 0.08em,
-    transparent 0.08em 0.18em
-  );
-  border-radius: 0.18em;
-  padding-inline: 0.04em;
-  text-shadow: 0 0 0.34em var(--scrawlix-fuzzy-ink);
+  background:
+    repeating-linear-gradient(
+      -13deg,
+      var(--scrawlix-soft-ink) 0 0.07em,
+      transparent 0.07em 0.16em
+    ),
+    repeating-linear-gradient(
+      9deg,
+      transparent 0 0.09em,
+      var(--scrawlix-fuzzy-ink) 0.09em 0.13em,
+      transparent 0.13em 0.23em
+    );
+  border-radius: 0.16em;
+  text-shadow: 0 0 0.3em var(--scrawlix-fuzzy-ink);
 }
 
-[data-scrawlix-cover][data-appearance='bar'] {
+[data-scrawlix-root][data-scrawlix-appearance='bar'] [data-scrawlix-cover] {
   -webkit-text-fill-color: transparent;
-  background: linear-gradient(currentColor, currentColor) center / 100% 0.72em no-repeat;
+  background: linear-gradient(var(--scrawlix-ink), var(--scrawlix-ink)) center / 100%
+    var(--scrawlix-bar-height) no-repeat;
   border-radius: 0.06em;
 }
 
-[data-scrawlix-cover][data-appearance='blur'] {
-  filter: blur(0.17em);
+[data-scrawlix-root][data-scrawlix-appearance='blur'] [data-scrawlix-cover] {
+  filter: blur(var(--scrawlix-blur-radius));
   user-select: none;
 }
 
-[data-scrawlix-cover][data-appearance='asterisk'],
-[data-scrawlix-cover][data-appearance='grawlix'] {
+[data-scrawlix-root][data-scrawlix-appearance='whiteout'] [data-scrawlix-cover] {
+  -webkit-text-fill-color: transparent;
+  background: linear-gradient(var(--scrawlix-surface), var(--scrawlix-surface)) center / 100%
+    0.94em no-repeat;
+  border-radius: 0.04em;
+  box-shadow:
+    inset 0 0.055em color-mix(in srgb, var(--scrawlix-ink) 10%, transparent),
+    inset 0 -0.055em color-mix(in srgb, var(--scrawlix-ink) 7%, transparent);
+}
+
+[data-scrawlix-root][data-scrawlix-appearance='mosaic'] [data-scrawlix-cover] {
+  -webkit-text-fill-color: transparent;
+  background: repeating-conic-gradient(
+      from 45deg,
+      var(--scrawlix-ink) 0 25%,
+      var(--scrawlix-soft-ink) 0 50%
+    )
+    center / var(--scrawlix-mosaic-cell) var(--scrawlix-mosaic-cell);
+  border-radius: 0.04em;
+}
+
+[data-scrawlix-cover][data-scrawlix-mask] {
+  -webkit-text-fill-color: transparent;
+}
+
+[data-scrawlix-cover][data-scrawlix-mask]::after {
+  content: attr(data-scrawlix-mask);
+  position: absolute;
+  inset-inline-start: 0;
+  top: 0.02em;
+  color: var(--scrawlix-ink);
+  -webkit-text-fill-color: var(--scrawlix-ink);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 0.92em;
   font-weight: 700;
   letter-spacing: -0.04em;
+  line-height: inherit;
+  pointer-events: none;
+  white-space: pre;
+  transition: opacity 140ms ease;
 }
 
-[data-scrawlix-source] {
-  display: none;
-}
-
-[data-scrawlix-root][data-reveal='hover']:hover [data-scrawlix-cover],
-[data-scrawlix-root][data-reveal='focus']:focus [data-scrawlix-cover],
-[data-scrawlix-root][data-reveal='click'][data-revealed='true'] [data-scrawlix-cover] {
+[data-scrawlix-root][data-scrawlix-reveal='hover']:hover [data-scrawlix-cover],
+[data-scrawlix-root][data-scrawlix-reveal='focus']:focus [data-scrawlix-cover],
+[data-scrawlix-root][data-scrawlix-reveal='click'][data-scrawlix-revealed='true']
+  [data-scrawlix-cover] {
   -webkit-text-fill-color: currentColor;
-  background: none;
+  background: transparent;
+  box-shadow: none;
   filter: none;
-  padding-inline: 0;
   text-shadow: none;
   user-select: text;
 }
 
-[data-scrawlix-root][data-reveal='hover']:hover [data-scrawlix-mask],
-[data-scrawlix-root][data-reveal='focus']:focus [data-scrawlix-mask],
-[data-scrawlix-root][data-reveal='click'][data-revealed='true'] [data-scrawlix-mask] {
-  display: none;
-}
-
-[data-scrawlix-root][data-reveal='hover']:hover [data-scrawlix-source],
-[data-scrawlix-root][data-reveal='focus']:focus [data-scrawlix-source],
-[data-scrawlix-root][data-reveal='click'][data-revealed='true'] [data-scrawlix-source] {
-  display: inline;
+[data-scrawlix-root][data-scrawlix-reveal='hover']:hover
+  [data-scrawlix-cover][data-scrawlix-mask]::after,
+[data-scrawlix-root][data-scrawlix-reveal='focus']:focus
+  [data-scrawlix-cover][data-scrawlix-mask]::after,
+[data-scrawlix-root][data-scrawlix-reveal='click'][data-scrawlix-revealed='true']
+  [data-scrawlix-cover][data-scrawlix-mask]::after {
+  opacity: 0;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  [data-scrawlix-cover] {
+  [data-scrawlix-cover],
+  [data-scrawlix-cover][data-scrawlix-mask]::after {
     transition: none;
   }
 }

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -27,7 +27,7 @@
   border-radius: 0.12em;
 }
 
-[data-scrawlix-cover] {
+[data-scrawlix-root] [data-scrawlix-cover] {
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
   display: inline;
@@ -91,11 +91,11 @@
   border-radius: 0.04em;
 }
 
-[data-scrawlix-cover][data-scrawlix-mask] {
+[data-scrawlix-root] [data-scrawlix-cover][data-scrawlix-mask] {
   -webkit-text-fill-color: transparent;
 }
 
-[data-scrawlix-cover][data-scrawlix-mask]::after {
+[data-scrawlix-root] [data-scrawlix-cover][data-scrawlix-mask]::after {
   content: attr(data-scrawlix-mask);
   position: absolute;
   inset-inline-start: 0;
@@ -134,8 +134,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  [data-scrawlix-cover],
-  [data-scrawlix-cover][data-scrawlix-mask]::after {
+  [data-scrawlix-root] [data-scrawlix-cover],
+  [data-scrawlix-root] [data-scrawlix-cover][data-scrawlix-mask]::after {
     transition: none;
   }
 }

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -85,34 +85,52 @@
 
 [data-scrawlix-root][data-scrawlix-appearance='mosaic'] [data-scrawlix-cover] {
   -webkit-text-fill-color: transparent;
-  background:
+  background-color: var(--scrawlix-soft-ink);
+  background-image:
     linear-gradient(
-        90deg,
-        var(--scrawlix-ink) 0 24%,
-        transparent 24% 42%,
-        var(--scrawlix-fuzzy-ink) 42% 67%,
-        transparent 67% 78%,
-        var(--scrawlix-ink) 78% 100%
+      90deg,
+      var(--scrawlix-ink) 0 22%,
+      var(--scrawlix-fuzzy-ink) 22% 52%,
+      var(--scrawlix-ink) 52% 73%,
+      var(--scrawlix-soft-ink) 73% 100%
+    ),
+    linear-gradient(
+      90deg,
+      var(--scrawlix-fuzzy-ink) 0 18%,
+      var(--scrawlix-ink) 18% 47%,
+      var(--scrawlix-soft-ink) 47% 69%,
+      var(--scrawlix-ink) 69% 100%
+    ),
+    linear-gradient(
+      90deg,
+      var(--scrawlix-ink) 0 31%,
+      var(--scrawlix-soft-ink) 31% 48%,
+      var(--scrawlix-ink) 48% 78%,
+      var(--scrawlix-fuzzy-ink) 78% 100%
+    );
+  background-position:
+    0 0.03em,
+    var(--scrawlix-mosaic-cell) calc(var(--scrawlix-mosaic-cell) + 0.03em),
+    0 calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) + 0.03em
+      );
+  background-size:
+    calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+          var(--scrawlix-mosaic-cell)
       )
-      0 0 /
-      calc(
-          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
-            var(--scrawlix-mosaic-cell)
-        )
       var(--scrawlix-mosaic-cell),
-    linear-gradient(
-        90deg,
-        var(--scrawlix-soft-ink) 0 31%,
-        var(--scrawlix-ink) 31% 55%,
-        var(--scrawlix-fuzzy-ink) 55% 77%,
-        var(--scrawlix-ink) 77% 100%
+    calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell)
       )
-      var(--scrawlix-mosaic-cell) var(--scrawlix-mosaic-cell) /
-      calc(
-          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
-            var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell)
-        )
+      var(--scrawlix-mosaic-cell),
+    calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+          var(--scrawlix-mosaic-cell)
+      )
       var(--scrawlix-mosaic-cell);
+  background-repeat: repeat-x;
   border-radius: 0.035em;
 }
 

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -44,18 +44,20 @@
   -webkit-text-fill-color: transparent;
   background:
     repeating-linear-gradient(
-      -13deg,
-      var(--scrawlix-soft-ink) 0 0.07em,
-      transparent 0.07em 0.16em
+      -11deg,
+      color-mix(in srgb, var(--scrawlix-ink) 74%, transparent) 0 0.055em,
+      transparent 0.055em 0.12em,
+      color-mix(in srgb, var(--scrawlix-ink) 46%, transparent) 0.12em 0.18em,
+      transparent 0.18em 0.23em
     ),
     repeating-linear-gradient(
-      9deg,
-      transparent 0 0.09em,
-      var(--scrawlix-fuzzy-ink) 0.09em 0.13em,
-      transparent 0.13em 0.23em
+      7deg,
+      transparent 0 0.075em,
+      color-mix(in srgb, var(--scrawlix-ink) 84%, transparent) 0.075em 0.105em,
+      transparent 0.105em 0.17em
     );
-  border-radius: 0.16em;
-  text-shadow: 0 0 0.3em var(--scrawlix-fuzzy-ink);
+  border-radius: 0.1em;
+  text-shadow: 0 0 0.16em color-mix(in srgb, var(--scrawlix-ink) 46%, transparent);
 }
 
 [data-scrawlix-root][data-scrawlix-appearance='bar'] [data-scrawlix-cover] {
@@ -76,19 +78,42 @@
     0.94em no-repeat;
   border-radius: 0.04em;
   box-shadow:
-    inset 0 0.055em color-mix(in srgb, var(--scrawlix-ink) 10%, transparent),
-    inset 0 -0.055em color-mix(in srgb, var(--scrawlix-ink) 7%, transparent);
+    inset 0 0.055em color-mix(in srgb, var(--scrawlix-ink) 12%, transparent),
+    inset 0 -0.055em color-mix(in srgb, var(--scrawlix-ink) 8%, transparent),
+    0 0.045em 0.09em color-mix(in srgb, var(--scrawlix-ink) 12%, transparent);
 }
 
 [data-scrawlix-root][data-scrawlix-appearance='mosaic'] [data-scrawlix-cover] {
   -webkit-text-fill-color: transparent;
-  background: repeating-conic-gradient(
-      from 45deg,
-      var(--scrawlix-ink) 0 25%,
-      var(--scrawlix-soft-ink) 0 50%
-    )
-    center / var(--scrawlix-mosaic-cell) var(--scrawlix-mosaic-cell);
-  border-radius: 0.04em;
+  background:
+    linear-gradient(
+        90deg,
+        var(--scrawlix-ink) 0 24%,
+        transparent 24% 42%,
+        var(--scrawlix-fuzzy-ink) 42% 67%,
+        transparent 67% 78%,
+        var(--scrawlix-ink) 78% 100%
+      )
+      0 0 /
+      calc(
+          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+            var(--scrawlix-mosaic-cell)
+        )
+      var(--scrawlix-mosaic-cell),
+    linear-gradient(
+        90deg,
+        var(--scrawlix-soft-ink) 0 31%,
+        var(--scrawlix-ink) 31% 55%,
+        var(--scrawlix-fuzzy-ink) 55% 77%,
+        var(--scrawlix-ink) 77% 100%
+      )
+      var(--scrawlix-mosaic-cell) var(--scrawlix-mosaic-cell) /
+      calc(
+          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+            var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell)
+        )
+      var(--scrawlix-mosaic-cell);
+  border-radius: 0.035em;
 }
 
 [data-scrawlix-root] [data-scrawlix-cover][data-scrawlix-mask] {

--- a/tests/browser/browser.spec.ts
+++ b/tests/browser/browser.spec.ts
@@ -10,21 +10,33 @@ test('demo controls drive real rendered coverage and reveal state', async ({ pag
   const firstCover = proof.locator('[data-scrawlix-cover]').first();
 
   await expect(proof).toBeVisible();
-  await expect(firstCover).toHaveAttribute('data-appearance', 'scrawl');
+  await expect(proof).toHaveAttribute('data-scrawlix-appearance', 'scrawl');
   await expect(firstCover).toHaveText('uc');
 
   await page.getByRole('button', { name: 'bar', exact: true }).click();
-  await expect(firstCover).toHaveAttribute('data-appearance', 'bar');
+  await expect(proof).toHaveAttribute('data-scrawlix-appearance', 'bar');
 
   await page.getByRole('button', { name: 'full', exact: true }).click();
   await expect(firstCover).toHaveText('fuck');
 
-  await page.getByRole('button', { name: 'click', exact: true }).click();
-  await expect(proof).toHaveAttribute('data-reveal', 'click');
-  await expect(proof).toHaveAttribute('data-revealed', 'false');
+  for (const appearance of ['whiteout', 'mosaic', 'asterisk'] as const) {
+    await page.getByRole('button', { name: appearance, exact: true }).click();
+    await expect(proof).toHaveAttribute('data-scrawlix-appearance', appearance);
+  }
 
+  await page.getByRole('button', { name: 'click', exact: true }).click();
+  await expect(proof).toHaveAttribute('data-scrawlix-reveal', 'click');
+  await expect(proof).toHaveAttribute('data-scrawlix-revealed', 'false');
+
+  const beforeRevealBox = await firstCover.boundingBox();
   await proof.click();
-  await expect(proof).toHaveAttribute('data-revealed', 'true');
+  await expect(proof).toHaveAttribute('data-scrawlix-revealed', 'true');
+  const afterRevealBox = await firstCover.boundingBox();
+
+  if (!beforeRevealBox || !afterRevealBox) {
+    throw new Error('Expected the first covered segment to have a layout box.');
+  }
+  expect(Math.abs(beforeRevealBox.width - afterRevealBox.width)).toBeLessThan(0.5);
 
   await page.setViewportSize({ width: 390, height: 844 });
   const overflow = await page.evaluate(
@@ -50,9 +62,10 @@ test('built extension transforms initial and dynamic page text in Chromium', asy
     const page = context.pages()[0] ?? (await context.newPage());
     await page.goto('http://127.0.0.1:4174/fixture.html');
 
-    await expect(
-      page.locator('#initial [data-scrawlix-dom-root]')
-    ).toHaveCount(1);
+    const initialRoot = page.locator('#initial [data-scrawlix-dom-root]');
+    await expect(initialRoot).toHaveCount(1);
+    await expect(initialRoot).toHaveAttribute('data-scrawlix-root', '');
+    await expect(initialRoot).toHaveAttribute('data-scrawlix-appearance', 'scrawl');
     await expect(
       page.locator('#initial [data-scrawlix-cover]')
     ).toHaveText('uc');


### PR DESCRIPTION
## Summary

- standardize React and extension presentation metadata around `data-scrawlix-*`
- keep asterisk/grawlix source text in-flow and paint symbol masks as an overlay, preserving width across reveal
- count symbol masks by grapheme cluster when `Intl.Segmenter` is available
- add `whiteout` and `mosaic` appearances across React, demo, extension settings, and docs
- give `scrawl` a denser two-direction ink treatment and expose appearance CSS custom properties
- remove scrawl reveal padding drift
- expand the demo to a seven-treatment specimen sheet with cleaner tablet borders and reduced-motion scrolling
- extend unit/browser regressions for the new contract and reveal-width stability

## Presentation contract

React and extension-rendered roots now share:

- `data-scrawlix-root`
- `data-scrawlix-appearance`
- `data-scrawlix-reveal`
- `data-scrawlix-revealed`
- `data-scrawlix-cover`
- `data-scrawlix-rules`
- optional `data-scrawlix-mask`

The extension keeps `data-scrawlix-dom-root` separately for DOM-controller ownership/restoration.

## CSS knobs

- `--scrawlix-ink`
- `--scrawlix-surface`
- `--scrawlix-bar-height`
- `--scrawlix-blur-radius`
- `--scrawlix-mosaic-cell`

## Compatibility

This intentionally changes React's pre-release presentation attribute names (`data-appearance`, `data-reveal`, `data-revealed`, `data-rules`) to the namespaced contract before the first public package release.

Closes #26
Related: #23, #27, #28