### PR TITLE
Add Witness Protection alias mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added `scrawl`, `bar`, `blur`, `asterisk`, and `grawlix` appearances.
 - Added `hover`, `focus`, `click`, and `never` reveal behavior.
 - Added keyboard reveal handling and a single-source accessibility contract with rendered regressions.
+- Added `AliasText` for stable term-to-alias presentation with longest-match selection and explicit reveal behavior.
 - Added the public CSS subpath export.
 
 ### Markdown
@@ -42,6 +43,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 ### Applications
 
 - Added an interactive editorial proof-sheet demo under `apps/demo`.
+- Added a Witness Protection specimen demonstrating stable aliases for names, companies, and project codenames.
 - Added a Vercel-ready static deployment configuration.
 - Added a Manifest V3 Chromium extension under `apps/extension` with global/site preferences, five appearances, coverage/reveal controls, and local custom terms.
 

--- a/apps/demo/public/llms.txt
+++ b/apps/demo/public/llms.txt
@@ -7,7 +7,7 @@ Source: https://github.com/teamleaderleo/scrawlix
 Packages:
 - @scrawlix/core — language-neutral matching and segmentation
 - @scrawlix/en — English profanity rules, English vowel coverage, regression corpus
-- @scrawlix/react — React renderer and visual/reveal presets
+- @scrawlix/react — React censorship/alias rendering and visual/reveal presets
 - @scrawlix/rehype — HAST/rehype transformer for Markdown-rendered prose
 - @scrawlix/dom — arbitrary-page DOM transformation, restoration, and mutation observation
 
@@ -30,6 +30,25 @@ import '@scrawlix/react/styles.css';
   reveal="hover"
 />
 ```
+
+Canonical stable-alias usage:
+
+```tsx
+import { AliasText } from '@scrawlix/react';
+
+const aliases = [
+  { term: 'Alice Chen', alias: 'Nina Mercer' },
+  { term: 'Project Velvet', alias: 'Project Lantern' },
+];
+
+<AliasText
+  text="Alice Chen approved Project Velvet."
+  aliases={aliases}
+  reveal="never"
+/>
+```
+
+`AliasText` is reversible presentation: the current React contract keeps the original source available for accessibility/reveal. Use a sanitizing export path when source text must be removed from an artifact.
 
 Canonical core usage:
 
@@ -83,9 +102,11 @@ Generic coverage presets: full, tail, middle, inner.
 English-specific helper: englishVowelCoverage.
 React appearances: scrawl, bar, blur, asterisk, grawlix.
 React reveal modes: hover, focus, click, never.
+React stable aliases: AliasText with explicit `{ term, alias }` mappings.
 
 Maintainer guidance: https://github.com/teamleaderleo/scrawlix/blob/main/AGENTS.md
 Language packs: https://github.com/teamleaderleo/scrawlix/blob/main/docs/language-packs.md
+Stable aliases: https://github.com/teamleaderleo/scrawlix/blob/main/docs/aliases.md
 DOM lifecycle: https://github.com/teamleaderleo/scrawlix/blob/main/docs/dom.md
 Extension notes: https://github.com/teamleaderleo/scrawlix/blob/main/apps/extension/README.md
 Release readiness: https://github.com/teamleaderleo/scrawlix/issues/18

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -4,6 +4,7 @@ import {
   englishVowelCoverage,
 } from '@scrawlix/en';
 import {
+  AliasText,
   CensoredText,
   type ScrawlixAppearance,
   type ScrawlixReveal,
@@ -39,6 +40,16 @@ const specimens = [
   'motherfucker',
   'Well, shit. That actually works.',
 ] as const;
+
+const witnessAliases = [
+  { term: 'Alice Chen', alias: 'Nina Mercer' },
+  { term: 'David Goldberg', alias: 'Felix Arden' },
+  { term: 'Acme Widgets', alias: 'Cedar Industries' },
+  { term: 'Project Velvet', alias: 'Project Lantern' },
+] as const;
+
+const witnessText =
+  'Alice Chen asked David Goldberg to send Acme Widgets the Project Velvet proposal. Alice Chen will present Project Velvet on Friday.';
 
 function selectorForCoverage(coverage: CoverageChoice): CoverageSelector {
   return coverage === 'vowel' ? englishVowelCoverage : coverage;
@@ -238,9 +249,35 @@ export function App() {
         </p>
       </section>
 
+      <section className="alias-section" aria-labelledby="alias-title">
+        <div className="section-heading">
+          <p className="eyebrow">04 / witness protection</p>
+          <h2 id="alias-title">Keep the story. Lose the names.</h2>
+          <p>
+            Stable aliases preserve who did what while private names, clients, and
+            codenames stay disguised. Click the paragraph to reveal the source.
+          </p>
+        </div>
+
+        <div className="alias-demo">
+          <p className="alias-output">
+            <AliasText aliases={witnessAliases} reveal="click" text={witnessText} />
+          </p>
+          <div className="alias-key" aria-label="Witness Protection mappings">
+            {witnessAliases.map(entry => (
+              <div key={entry.term}>
+                <span>{entry.term}</span>
+                <span aria-hidden="true">→</span>
+                <strong>{entry.alias}</strong>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
       <section className="code-section" aria-labelledby="code-title">
         <div>
-          <p className="eyebrow">04 / use it</p>
+          <p className="eyebrow">05 / use it</p>
           <h2 id="code-title">Pick the language. Pick the damage.</h2>
           <p>
             Matching rules live in explicit language or custom packs. The core stays

--- a/apps/demo/src/styles.css
+++ b/apps/demo/src/styles.css
@@ -240,6 +240,7 @@ main {
 
 .specimen-section,
 .semantic-section,
+.alias-section,
 .code-section {
   padding: 86px 0;
   border-bottom: 1px solid #171512;
@@ -360,6 +361,55 @@ main {
   margin-top: 28px;
 }
 
+.alias-demo {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(310px, 0.6fr);
+  border: 1px solid #171512;
+  background: #fbf8f0;
+  box-shadow: 9px 9px 0 #171512;
+}
+
+.alias-output {
+  margin: 0;
+  padding: clamp(32px, 5vw, 72px);
+  align-self: center;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(28px, 3.8vw, 56px);
+  line-height: 1.12;
+  letter-spacing: -0.035em;
+}
+
+.alias-output [data-scrawlix-alias] {
+  background: #e7dfcf;
+  text-decoration-thickness: 0.04em;
+}
+
+.alias-key {
+  display: grid;
+  align-content: center;
+  border-left: 1px solid #171512;
+  padding: 24px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.alias-key div {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 10px;
+  padding: 13px 0;
+  border-bottom: 1px solid #cfc5b3;
+}
+
+.alias-key div:last-child {
+  border-bottom: 0;
+}
+
+.alias-key strong {
+  font-weight: 700;
+}
+
 code,
 pre {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
@@ -472,6 +522,15 @@ footer a {
   .semantic-example:last-child {
     border-bottom: 0;
   }
+
+  .alias-demo {
+    grid-template-columns: 1fr;
+  }
+
+  .alias-key {
+    border-top: 1px solid #171512;
+    border-left: 0;
+  }
 }
 
 @media (max-width: 620px) {
@@ -520,6 +579,23 @@ footer a {
 
   .specimen-card:last-child {
     border-bottom: 0;
+  }
+
+  .alias-demo {
+    box-shadow: 5px 5px 0 #171512;
+  }
+
+  .alias-output {
+    padding: 30px 22px;
+    font-size: 32px;
+  }
+
+  .alias-key div {
+    grid-template-columns: 1fr;
+  }
+
+  .alias-key div > span:nth-child(2) {
+    display: none;
   }
 
   footer {

--- a/docs/aliases.md
+++ b/docs/aliases.md
@@ -1,0 +1,51 @@
+# Stable aliases
+
+Scrawlix can disguise explicit names, companies, projects, codenames, and other phrases with readable aliases through `AliasText` from `@scrawlix/react`.
+
+```tsx
+import { AliasText } from '@scrawlix/react';
+
+const aliases = [
+  { term: 'Alice Chen', alias: 'Nina Mercer' },
+  { term: 'Project Velvet', alias: 'Project Lantern' },
+];
+
+<AliasText
+  text="Alice Chen approved Project Velvet. Alice Chen presents Friday."
+  aliases={aliases}
+/>;
+```
+
+Repeated terms receive the same configured alias. Matching is case-insensitive by default, uses Unicode-aware word boundaries, and prefers the longest match when configured phrases overlap at the same source position.
+
+`AliasText` accepts the same reveal vocabulary as `CensoredText`:
+
+```tsx
+<AliasText
+  text={copy}
+  aliases={aliases}
+  reveal="click"
+/>
+```
+
+Alias presentation defaults to `reveal="never"`. `focus`, `click`, and `hover` can expose the source interactively when the surrounding experience calls for it.
+
+For phrases that may sit directly beside other letters, opt into substring matching:
+
+```tsx
+<AliasText
+  text="internalProjectVelvetBuild"
+  aliases={[{ term: 'ProjectVelvet', alias: 'ProjectLantern' }]}
+  boundary="substring"
+/>
+```
+
+## Presentation semantics
+
+`AliasText` follows the current React source-preservation and accessibility contract: it keeps one visually hidden source copy for assistive technology and keeps source substrings available for reveal inside the visual tree. This makes aliases reversible presentation for demos, screen sharing, tutorials, and similar experiences.
+
+Secure/destructive redaction has different output requirements. Track that work separately in #31; use a sanitizing/export pipeline when the original string must be removed from the produced artifact.
+
+## Product language
+
+The demo calls this **Witness Protection**. `AliasText` is the deliberately plain API name: product surfaces can give the behavior more personality without baking that personality into the reusable package.

--- a/fixtures/consumer/src/main.tsx
+++ b/fixtures/consumer/src/main.tsx
@@ -2,7 +2,7 @@ import { createScrawlix } from '@scrawlix/core';
 import { createDomScrawlix } from '@scrawlix/dom';
 import { englishProfanityRules } from '@scrawlix/en';
 import { transformHast } from '@scrawlix/rehype';
-import { CensoredText } from '@scrawlix/react';
+import { AliasText, CensoredText } from '@scrawlix/react';
 import '@scrawlix/react/styles.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
@@ -65,12 +65,20 @@ if (
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <CensoredText
-      appearance="scrawl"
-      coverage="middle"
-      reveal="hover"
-      rules={englishProfanityRules}
-      text="well, fuck"
-    />
+    <p>
+      <CensoredText
+        appearance="scrawl"
+        coverage="middle"
+        reveal="hover"
+        rules={englishProfanityRules}
+        text="well, fuck"
+      />
+    </p>
+    <p>
+      <AliasText
+        aliases={[{ term: 'Project Velvet', alias: 'Project Lantern' }]}
+        text="Project Velvet ships Friday"
+      />
+    </p>
   </React.StrictMode>
 );

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -3,7 +3,7 @@
 import { act, type ReactElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it } from 'vitest';
-import { CensoredText } from './index';
+import { AliasText, CensoredText } from './index';
 
 const rules = [
   {
@@ -156,5 +156,106 @@ describe('CensoredText', () => {
     expect(
       container.querySelector<HTMLElement>('[data-scrawlix-mask]')?.textContent
     ).toBe('@#$%&!');
+  });
+});
+
+describe('AliasText', () => {
+  const aliases = [
+    { term: 'Alice Chen', alias: 'Nina Mercer' },
+    { term: 'Project Velvet', alias: 'Project Lantern' },
+  ] as const;
+
+  it('renders ordinary text directly when no alias matches', () => {
+    const container = render(
+      <AliasText aliases={aliases} text="nothing private here" />
+    );
+
+    expect(container.textContent).toBe('nothing private here');
+    expect(container.querySelector('[data-scrawlix-alias-root]')).toBeNull();
+  });
+
+  it('uses one stable alias for repeated case-insensitive matches', () => {
+    const text =
+      'Alice Chen opened Project Velvet. alice chen closed it. Alice Chen left.';
+    const container = render(<AliasText aliases={aliases} text={text} />);
+    const root = container.querySelector<HTMLElement>('[data-scrawlix-alias-root]')!;
+    const values = [...root.querySelectorAll('[data-scrawlix-alias-value]')].map(
+      node => node.textContent
+    );
+    const sources = [...root.querySelectorAll('[data-scrawlix-source]')].map(
+      node => node.textContent
+    );
+
+    expect(values).toEqual([
+      'Nina Mercer',
+      'Project Lantern',
+      'Nina Mercer',
+      'Nina Mercer',
+    ]);
+    expect(sources).toEqual([
+      'Alice Chen',
+      'Project Velvet',
+      'alice chen',
+      'Alice Chen',
+    ]);
+    expect(root.querySelector('[data-scrawlix-a11y]')?.textContent).toBe(text);
+    expect(root.querySelector('[data-scrawlix-visual]')?.getAttribute('aria-hidden')).toBe(
+      'true'
+    );
+  });
+
+  it('prefers the longest alias when terms begin at the same source position', () => {
+    const container = render(
+      <AliasText
+        aliases={[
+          { term: 'Alice', alias: 'Nina' },
+          { term: 'Alice Chen', alias: 'Mara Vale' },
+        ]}
+        text="Alice Chen called Alice."
+      />
+    );
+    const values = [
+      ...container.querySelectorAll('[data-scrawlix-alias-value]'),
+    ].map(node => node.textContent);
+
+    expect(values).toEqual(['Mara Vale', 'Nina']);
+  });
+
+  it('can require case-sensitive aliases', () => {
+    const container = render(
+      <AliasText
+        aliases={aliases}
+        caseSensitive
+        text="Alice Chen met alice chen."
+      />
+    );
+
+    expect(container.querySelectorAll('[data-scrawlix-alias-value]')).toHaveLength(1);
+    expect(
+      container.querySelector<HTMLElement>('[data-scrawlix-alias-value]')?.textContent
+    ).toBe('Nina Mercer');
+  });
+
+  it('defaults to never reveal and can opt into click reveal', () => {
+    const passive = render(<AliasText aliases={aliases} text="Alice Chen" />);
+    const passiveRoot = passive.querySelector<HTMLElement>(
+      '[data-scrawlix-alias-root]'
+    )!;
+
+    expect(passiveRoot.dataset.reveal).toBe('never');
+    expect(passiveRoot.getAttribute('tabindex')).toBeNull();
+
+    const interactive = render(
+      <AliasText aliases={aliases} reveal="click" text="Alice Chen" />
+    );
+    const interactiveRoot = interactive.querySelector<HTMLElement>(
+      '[data-scrawlix-alias-root]'
+    )!;
+
+    expect(interactiveRoot.tabIndex).toBe(0);
+    act(() =>
+      interactiveRoot.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    );
+    expect(interactiveRoot.dataset.revealed).toBe('true');
   });
 });

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -179,10 +179,10 @@ describe('AliasText', () => {
       'Alice Chen opened Project Velvet. alice chen closed it. Alice Chen left.';
     const container = render(<AliasText aliases={aliases} text={text} />);
     const root = container.querySelector<HTMLElement>('[data-scrawlix-alias-root]')!;
-    const values = [...root.querySelectorAll('[data-scrawlix-alias-value]')].map(
-      node => node.textContent
-    );
-    const sources = [...root.querySelectorAll('[data-scrawlix-source]')].map(
+    const values = Array.from(
+      root.querySelectorAll('[data-scrawlix-alias-value]')
+    ).map(node => node.textContent);
+    const sources = Array.from(root.querySelectorAll('[data-scrawlix-source]')).map(
       node => node.textContent
     );
 
@@ -214,9 +214,9 @@ describe('AliasText', () => {
         text="Alice Chen called Alice."
       />
     );
-    const values = [
-      ...container.querySelectorAll('[data-scrawlix-alias-value]'),
-    ].map(node => node.textContent);
+    const values = Array.from(
+      container.querySelectorAll('[data-scrawlix-alias-value]')
+    ).map(node => node.textContent);
 
     expect(values).toEqual(['Mara Vale', 'Nina']);
   });

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,7 +1,10 @@
 import {
+  censorRuleFromWords,
   createScrawlix,
   type CensorRule,
   type CoverageSelector,
+  type ScrawlixMatch,
+  type WordBoundaryMode,
 } from '@scrawlix/core';
 import { useMemo, useState, type KeyboardEvent } from 'react';
 
@@ -24,6 +27,21 @@ export type CensoredTextProps = {
   title?: string;
 };
 
+export type ScrawlixAlias = {
+  term: string;
+  alias: string;
+};
+
+export type AliasTextProps = {
+  text: string;
+  aliases: readonly ScrawlixAlias[];
+  boundary?: WordBoundaryMode;
+  caseSensitive?: boolean;
+  reveal?: ScrawlixReveal;
+  className?: string;
+  title?: string;
+};
+
 const GRAWLIX = '@#$%&!';
 
 function symbolsFor(text: string, appearance: ScrawlixAppearance) {
@@ -35,6 +53,27 @@ function symbolsFor(text: string, appearance: ScrawlixAppearance) {
       .join('');
   }
   return text;
+}
+
+function useRevealController(reveal: ScrawlixReveal) {
+  const [revealed, setRevealed] = useState(false);
+  const interactive = reveal === 'focus' || reveal === 'click';
+
+  function onKeyDown(event: KeyboardEvent<HTMLSpanElement>) {
+    if (reveal !== 'click') return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      setRevealed(value => !value);
+    }
+  }
+
+  return {
+    interactive,
+    revealed,
+    onClick:
+      reveal === 'click' ? () => setRevealed(value => !value) : undefined,
+    onKeyDown,
+  };
 }
 
 export function CensoredText({
@@ -52,29 +91,19 @@ export function CensoredText({
   );
   const segments = engine.segment(text);
   const hasCoveredText = segments.some(segment => segment.covered);
-  const [revealed, setRevealed] = useState(false);
+  const revealController = useRevealController(reveal);
 
   if (!hasCoveredText) return <>{text}</>;
-
-  const interactive = reveal === 'focus' || reveal === 'click';
-
-  function onKeyDown(event: KeyboardEvent<HTMLSpanElement>) {
-    if (reveal !== 'click') return;
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      setRevealed(value => !value);
-    }
-  }
 
   return (
     <span
       className={className}
       data-scrawlix-root
       data-reveal={reveal}
-      data-revealed={revealed ? 'true' : 'false'}
-      tabIndex={interactive ? 0 : undefined}
-      onClick={reveal === 'click' ? () => setRevealed(value => !value) : undefined}
-      onKeyDown={onKeyDown}
+      data-revealed={revealController.revealed ? 'true' : 'false'}
+      tabIndex={revealController.interactive ? 0 : undefined}
+      onClick={revealController.onClick}
+      onKeyDown={revealController.onKeyDown}
     >
       <span data-scrawlix-a11y>{text}</span>
       <span aria-hidden="true" data-scrawlix-visual>
@@ -104,6 +133,119 @@ export function CensoredText({
               ) : (
                 segment.text
               )}
+            </span>
+          );
+        })}
+      </span>
+    </span>
+  );
+}
+
+type CompiledAlias = {
+  term: string;
+  alias: string;
+  ruleId: string;
+};
+
+function compileAliases(
+  aliases: readonly ScrawlixAlias[],
+  caseSensitive: boolean,
+  boundary: WordBoundaryMode
+) {
+  const seen = new Set<string>();
+  const entries: CompiledAlias[] = [];
+
+  for (const candidate of aliases) {
+    const term = candidate.term.trim();
+    const alias = candidate.alias.trim();
+    if (!term || !alias) continue;
+
+    const key = caseSensitive ? term : term.toLocaleLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    entries.push({
+      term,
+      alias,
+      ruleId: `scrawlix-alias-${entries.length}`,
+    });
+  }
+
+  const aliasByRuleId = new Map(entries.map(entry => [entry.ruleId, entry]));
+  const rules = entries.map(entry =>
+    censorRuleFromWords(entry.ruleId, [entry.term], {
+      boundary,
+      caseSensitive,
+      coverage: 'full',
+    })
+  );
+
+  return {
+    aliasByRuleId,
+    engine: createScrawlix({ rules, coverage: 'full' }),
+  };
+}
+
+function selectAliasMatches(matches: readonly ScrawlixMatch[]) {
+  const selected: ScrawlixMatch[] = [];
+  let cursor = 0;
+
+  for (const match of matches) {
+    if (match.start < cursor) continue;
+    selected.push(match);
+    cursor = match.end;
+  }
+
+  return selected;
+}
+
+export function AliasText({
+  text,
+  aliases,
+  boundary = 'word',
+  caseSensitive = false,
+  reveal = 'never',
+  className = '',
+  title = 'Aliased text',
+}: AliasTextProps) {
+  const compiled = useMemo(
+    () => compileAliases(aliases, caseSensitive, boundary),
+    [aliases, boundary, caseSensitive]
+  );
+  const matches = selectAliasMatches(compiled.engine.find(text));
+  const revealController = useRevealController(reveal);
+
+  if (matches.length === 0) return <>{text}</>;
+
+  let cursor = 0;
+
+  return (
+    <span
+      className={className}
+      data-scrawlix-alias-root
+      data-scrawlix-root
+      data-reveal={reveal}
+      data-revealed={revealController.revealed ? 'true' : 'false'}
+      tabIndex={revealController.interactive ? 0 : undefined}
+      onClick={revealController.onClick}
+      onKeyDown={revealController.onKeyDown}
+    >
+      <span data-scrawlix-a11y>{text}</span>
+      <span aria-hidden="true" data-scrawlix-visual>
+        {matches.map((match, index) => {
+          const before = text.slice(cursor, match.start);
+          const source = text.slice(match.start, match.end);
+          const alias = compiled.aliasByRuleId.get(match.ruleId);
+          cursor = match.end;
+
+          return (
+            <span key={`${match.start}-${match.end}-${match.ruleId}`}>
+              {before}
+              <span data-scrawlix-alias title={title}>
+                <span data-scrawlix-alias-value>{alias?.alias ?? source}</span>
+                <span data-scrawlix-source>{source}</span>
+              </span>
+              {index === matches.length - 1 ? text.slice(cursor) : null}
             </span>
           );
         })}

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -65,6 +65,22 @@
   letter-spacing: -0.04em;
 }
 
+[data-scrawlix-alias] {
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  border-radius: 0.12em;
+  background: color-mix(in srgb, currentColor 8%, transparent);
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  text-decoration-thickness: 0.06em;
+  text-underline-offset: 0.16em;
+  transition: background 140ms ease;
+}
+
+[data-scrawlix-alias-value] {
+  font-style: italic;
+}
+
 [data-scrawlix-source] {
   display: none;
 }
@@ -80,9 +96,18 @@
   user-select: text;
 }
 
+[data-scrawlix-root][data-reveal='hover']:hover [data-scrawlix-alias],
+[data-scrawlix-root][data-reveal='focus']:focus [data-scrawlix-alias],
+[data-scrawlix-root][data-reveal='click'][data-revealed='true'] [data-scrawlix-alias] {
+  background: none;
+}
+
 [data-scrawlix-root][data-reveal='hover']:hover [data-scrawlix-mask],
 [data-scrawlix-root][data-reveal='focus']:focus [data-scrawlix-mask],
-[data-scrawlix-root][data-reveal='click'][data-revealed='true'] [data-scrawlix-mask] {
+[data-scrawlix-root][data-reveal='click'][data-revealed='true'] [data-scrawlix-mask],
+[data-scrawlix-root][data-reveal='hover']:hover [data-scrawlix-alias-value],
+[data-scrawlix-root][data-reveal='focus']:focus [data-scrawlix-alias-value],
+[data-scrawlix-root][data-reveal='click'][data-revealed='true'] [data-scrawlix-alias-value] {
   display: none;
 }
 
@@ -93,7 +118,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  [data-scrawlix-cover] {
+  [data-scrawlix-cover],
+  [data-scrawlix-alias] {
     transition: none;
   }
 }

--- a/tests/browser/browser.spec.ts
+++ b/tests/browser/browser.spec.ts
@@ -26,6 +26,26 @@ test('demo controls drive real rendered coverage and reveal state', async ({ pag
   await proof.click();
   await expect(proof).toHaveAttribute('data-revealed', 'true');
 
+  const aliasProof = page.locator('.alias-output [data-scrawlix-alias-root]');
+  const aliasValues = aliasProof.locator('[data-scrawlix-alias-value]');
+
+  await expect(aliasProof).toBeVisible();
+  await expect(aliasProof).toHaveAttribute('data-reveal', 'click');
+  await expect(aliasValues).toHaveText([
+    'Nina Mercer',
+    'Felix Arden',
+    'Cedar Industries',
+    'Project Lantern',
+    'Nina Mercer',
+    'Project Lantern',
+  ]);
+
+  await aliasProof.click();
+  await expect(aliasProof).toHaveAttribute('data-revealed', 'true');
+  await expect(aliasProof.locator('[data-scrawlix-source]').first()).toHaveText(
+    'Alice Chen'
+  );
+
   await page.setViewportSize({ width: 390, height: 844 });
   const overflow = await page.evaluate(
     () => document.documentElement.scrollWidth - window.innerWidth


### PR DESCRIPTION
## What

Adds a first stable-alias primitive for Scrawlix:

- new `AliasText` React component with explicit `{ term, alias }` mappings
- case-insensitive word matching by default, with `caseSensitive` and `boundary` controls
- longest-match preference for overlapping configured phrases
- stable aliases across repeated occurrences
- `never` reveal by default, plus the existing hover/focus/click reveal vocabulary
- current single-source accessibility/source-preservation contract retained
- dedicated **Witness Protection** demo specimen
- regression coverage and `docs/aliases.md`
- cold-arrival `llms.txt` guidance
- packed-package consumer coverage for the new public export

## Product intent

This proves the screen-share/demo use case without teaching `@scrawlix/core` a new matching concept. Aliases reuse existing core matching and stay a sibling presentation primitive to `CensoredText`.

The implementation is explicitly reversible presentation. Secure/sanitized output semantics remain tracked in #31.

## Validation

CI is green on the current head:

- [x] workspace typecheck
- [x] unit tests
- [x] package + app builds
- [x] real Chromium demo smoke, including stable aliases + click reveal + narrow viewport
- [x] real Chromium extension smoke
- [x] external packed-package consumer smoke importing and rendering `AliasText`

The first CI pass caught a `NodeList`/DOM-lib test compatibility issue; the test now uses `Array.from(...)` and the complete gate passes.

Closes #29