### PR TITLE
Harden linguistic rule provenance and Unicode word context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added custom coverage callbacks and per-rule coverage overrides.
 - Added Unicode-aware custom word/phrase rules with explicit `word` and `substring` boundary modes.
 - Added rule-pack composition and caller-safe compiled RegExp handling.
+- Preserve source-pack provenance in composed rules, matches, and coverage callbacks.
+- Reject configured semantic target groups that are unavailable for a produced match instead of silently widening coverage.
+- Treat combining marks, Unicode connector punctuation, ZWNJ, and ZWJ as continuing word context for custom word/phrase boundaries.
 - Added deterministic source-preservation and cursor-state regressions.
 
 ### English pack
@@ -19,6 +22,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added `@scrawlix/en` with explicit English strong-profanity rules.
 - Added English-specific vowel coverage outside the neutral core.
 - Added positive and clean regression corpora, including false-positive traps.
+- Hardened English word edges around combining marks, connector punctuation, ZWNJ, and ZWJ.
 
 ### React
 

--- a/docs/language-packs.md
+++ b/docs/language-packs.md
@@ -33,11 +33,13 @@ const engine = createScrawlix({
 });
 ```
 
+`rulesFromPacks(...)` copies each rule with its source pack id. `find()` exposes that value as `match.packId`, and coverage callbacks receive the same optional `packId`, so composed rules remain traceable even when different packs use the same local rule id. Caller-authored loose rules can continue to omit pack provenance.
+
 Scrawlix deliberately avoids automatic language detection. Applications know more about their content and can choose one pack, several packs, or caller-authored rules.
 
 ## Boundaries
 
-`censorRuleFromWords()` defaults to `boundary: 'word'`, using Unicode letter/number-aware lookarounds. This works well for many whitespace-delimited words and prevents substring false positives such as a short term firing inside a longer ordinary word.
+`censorRuleFromWords()` defaults to `boundary: 'word'`, using Unicode-aware lookarounds. Letters, numbers, combining marks, connector punctuation, ZWNJ, and ZWJ keep a candidate attached to surrounding text. This prevents a boundary from appearing inside many decomposed or connected Unicode sequences while still blocking ordinary substring false positives.
 
 Some scripts and phrase lists need direct substring matching:
 
@@ -63,7 +65,7 @@ const rule = {
 };
 ```
 
-Coverage runs against `core`, while `find()` still reports the full match and both full/target ranges.
+Coverage runs against `core`, while `find()` still reports the full match and both full/target ranges. A declared target group is part of the rule contract: if a produced match cannot resolve that named group, Scrawlix throws a descriptive error instead of widening the target to the full match.
 
 ## Coverage helpers
 

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -10,7 +10,7 @@ import {
 const semanticRule: CensorRule = {
   id: 'semantic-test',
   pattern:
-    /(?<![\p{L}\p{N}_])(?:mother)?(?<core>fuck)(?:ing|ed|er|ers|s)?(?![\p{L}\p{N}_])/giu,
+    /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?:mother)?(?<core>fuck)(?:ing|ed|er|ers|s)?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
   target: { group: 'core' },
 };
 
@@ -55,6 +55,19 @@ describe('Scrawlix core', () => {
     ]);
   });
 
+  it('fails loudly when a configured semantic target group is unavailable', () => {
+    const brokenRule: CensorRule = {
+      id: 'broken-target',
+      pattern: /(?<other>bad)/u,
+      target: { group: 'core' },
+    };
+    const scrawlix = createScrawlix({ rules: [brokenRule] });
+
+    expect(() => scrawlix.find('bad')).toThrow(
+      'Censor rule "broken-target" declares target group "core"'
+    );
+  });
+
   it.each([
     ['full', '[fuck]'],
     ['tail', 'f[uck]'],
@@ -94,6 +107,16 @@ describe('Scrawlix core', () => {
 
     expect(marked(scrawlix.segment('caféteria café CAFÉ.'))).toBe(
       'caféteria [café] [CAFÉ].'
+    );
+  });
+
+  it('keeps marks, connector punctuation, and join controls inside word context', () => {
+    const bad = censorRuleFromWords('bad', ['bad']);
+    const scrawlix = createScrawlix({ rules: [bad], coverage: 'full' });
+    const input = 'bad\u0301 bad\u200Dword bad‿word bad';
+
+    expect(marked(scrawlix.segment(input))).toBe(
+      'bad\u0301 bad\u200Dword bad‿word [bad]'
     );
   });
 
@@ -180,7 +203,7 @@ describe('Scrawlix core', () => {
     expect(marked(scrawlix.segment('fuck'))).toBe('f[uc]k');
   });
 
-  it('combines explicit rule packs', () => {
+  it('combines explicit rule packs and preserves their provenance', () => {
     const privatePack = {
       id: 'private',
       rules: [censorRuleFromWords('private', ['Velvet'])],
@@ -197,6 +220,38 @@ describe('Scrawlix core', () => {
     expect(marked(scrawlix.segment('Velvet and Rosebud'))).toBe(
       '[Velvet] and [Rosebud]'
     );
+    expect(
+      scrawlix.find('Velvet and Rosebud').map(match => ({
+        packId: match.packId,
+        ruleId: match.ruleId,
+        text: match.text,
+      }))
+    ).toEqual([
+      { packId: 'private', ruleId: 'private', text: 'Velvet' },
+      { packId: 'spoiler', ruleId: 'spoiler', text: 'Rosebud' },
+    ]);
+  });
+
+  it('distinguishes duplicate rule ids from different packs in find results', () => {
+    const firstPack = {
+      id: 'alpha',
+      rules: [censorRuleFromWords('shared', ['Velvet'])],
+    };
+    const secondPack = {
+      id: 'beta',
+      rules: [censorRuleFromWords('shared', ['Velvet'])],
+    };
+    const scrawlix = createScrawlix({
+      rules: rulesFromPacks(firstPack, secondPack),
+      coverage: 'full',
+    });
+
+    expect(
+      scrawlix.find('Velvet').map(match => [match.packId, match.ruleId])
+    ).toEqual([
+      ['alpha', 'shared'],
+      ['beta', 'shared'],
+    ]);
   });
 
   it('preserves core segmentation invariants across deterministic fuzz cases', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export type RelativeRange = {
 
 export type CoverageContext = {
   ruleId: string;
+  packId?: string;
   matchText: string;
   targetText: string;
   matchStart: number;
@@ -28,6 +29,8 @@ export type CensorRule = {
   pattern: RegExp;
   target?: CensorTarget;
   coverage?: CoverageSelector;
+  /** Pack provenance attached by rulesFromPacks(). */
+  packId?: string;
 };
 
 export type CensorRulePack = {
@@ -40,6 +43,7 @@ export type WordBoundaryMode = 'word' | 'substring';
 
 export type ScrawlixMatch = {
   ruleId: string;
+  packId?: string;
   text: string;
   start: number;
   end: number;
@@ -83,6 +87,13 @@ const graphemeSegmenter =
   typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
     ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
     : null;
+
+/**
+ * Characters that should keep a custom-word match attached to surrounding text.
+ * Marks and join controls matter here because a boundary inside an extended
+ * grapheme cluster can otherwise turn decomposed/connected text into a false hit.
+ */
+const wordContextClass = '\\p{L}\\p{N}\\p{M}\\p{Pc}\\u200C\\u200D';
 
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -188,6 +199,10 @@ function sanitizeRanges(
     .sort((left, right) => left.start - right.start || left.end - right.end);
 }
 
+function ruleIdentity(rule: CompiledRule) {
+  return rule.packId ? `${rule.packId}:${rule.id}` : rule.id;
+}
+
 function resolveTargetRange(match: RegExpExecArray, rule: CompiledRule) {
   const fullStart = match.index;
   const fullEnd = match.index + match[0].length;
@@ -198,7 +213,9 @@ function resolveTargetRange(match: RegExpExecArray, rule: CompiledRule) {
 
   const groupRange = match.indices?.groups?.[rule.target.group];
   if (!groupRange) {
-    return { start: fullStart, end: fullEnd };
+    throw new Error(
+      `Censor rule "${ruleIdentity(rule)}" declares target group "${rule.target.group}", but that group was unavailable for match "${match[0]}".`
+    );
   }
 
   return { start: groupRange[0], end: groupRange[1] };
@@ -222,6 +239,7 @@ function scan(text: string, rules: readonly CompiledRule[]): ScannedMatch[] {
         rule,
         match: {
           ruleId: rule.id,
+          ...(rule.packId ? { packId: rule.packId } : {}),
           text: rawMatch[0],
           start: rawMatch.index,
           end: rawMatch.index + rawMatch[0].length,
@@ -239,6 +257,7 @@ function scan(text: string, rules: readonly CompiledRule[]): ScannedMatch[] {
     (left, right) =>
       left.match.start - right.match.start ||
       right.match.end - left.match.end ||
+      (left.match.packId ?? '').localeCompare(right.match.packId ?? '') ||
       left.match.ruleId.localeCompare(right.match.ruleId)
   );
 
@@ -255,6 +274,7 @@ function collectCoveredRanges(
     const { match, rule } = scanned;
     const context: CoverageContext = {
       ruleId: match.ruleId,
+      ...(match.packId ? { packId: match.packId } : {}),
       matchText: match.text,
       targetText: match.targetText,
       matchStart: match.start,
@@ -364,7 +384,7 @@ export function censorRuleFromWords(
   const source = `(?:${alternatives.join('|')})`;
   const boundedSource =
     boundary === 'word'
-      ? `(?<![\\p{L}\\p{N}_])${source}(?![\\p{L}\\p{N}_])`
+      ? `(?<![${wordContextClass}])${source}(?![${wordContextClass}])`
       : source;
 
   return {
@@ -377,7 +397,12 @@ export function censorRuleFromWords(
 export function rulesFromPacks(
   ...packs: readonly CensorRulePack[]
 ): CensorRule[] {
-  return packs.flatMap(pack => pack.rules);
+  return packs.flatMap(pack =>
+    pack.rules.map(rule => ({
+      ...rule,
+      packId: pack.id,
+    }))
+  );
 }
 
 export function createScrawlix({

--- a/packages/en/src/corpus.ts
+++ b/packages/en/src/corpus.ts
@@ -80,5 +80,8 @@ export const englishCleanCorpus: readonly EnglishCorpusCase[] = [
   { id: 'shitake', text: 'shitake mushrooms', matches: [] },
   { id: 'classhole', text: 'classhole', matches: [] },
   { id: 'motherfuckerish', text: 'motherfuckerish', matches: [] },
+  { id: 'fuck-combining-mark-continuation', text: 'fuck\u0301', matches: [] },
+  { id: 'shit-connector-continuation', text: 'shit‿word', matches: [] },
+  { id: 'cunt-join-control-continuation', text: 'cunt\u200Dword', matches: [] },
   { id: 'ordinary-prose', text: 'a perfectly ordinary sentence', matches: [] },
 ] as const;

--- a/packages/en/src/index.ts
+++ b/packages/en/src/index.ts
@@ -47,31 +47,31 @@ export const englishProfanityRules: readonly CensorRule[] = [
   {
     id: 'fuck',
     pattern:
-      /(?<![\p{L}\p{N}_])(?:mother)?(?<core>fuck)(?:ing|ed|er|ers|s)?(?![\p{L}\p{N}_])/giu,
+      /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?:mother)?(?<core>fuck)(?:ing|ed|er|ers|s)?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
     target: { group: 'core' },
   },
   {
     id: 'shit',
     pattern:
-      /(?<![\p{L}\p{N}_])(?:bull)?(?<core>shit)(?:ting|ted|ter|ters|s|ty)?(?![\p{L}\p{N}_])/giu,
+      /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?:bull)?(?<core>shit)(?:ting|ted|ter|ters|s|ty)?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
     target: { group: 'core' },
   },
   {
     id: 'bitch',
     pattern:
-      /(?<![\p{L}\p{N}_])(?<core>bitch)(?:es|ing|ed|y)?(?![\p{L}\p{N}_])/giu,
+      /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?<core>bitch)(?:es|ing|ed|y)?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
     target: { group: 'core' },
   },
   {
     id: 'asshole',
     pattern:
-      /(?<![\p{L}\p{N}_])(?<core>asshole)s?(?![\p{L}\p{N}_])/giu,
+      /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?<core>asshole)s?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
     target: { group: 'core' },
   },
   {
     id: 'cunt',
     pattern:
-      /(?<![\p{L}\p{N}_])(?<core>cunt)s?(?![\p{L}\p{N}_])/giu,
+      /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?<core>cunt)s?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
     target: { group: 'core' },
   },
 ] as const;


### PR DESCRIPTION
## Summary
First Cobalt implementation slice from the language-pack review.

- preserve pack provenance through `rulesFromPacks()` and `find()`
- expose `packId` to coverage callbacks
- make configured semantic target groups fail loudly when a produced match cannot resolve them
- treat combining marks, Unicode connector punctuation, ZWNJ, and ZWJ as continuing word context in custom-word matching
- apply the same word-edge hardening to the bundled English profanity rules
- add regressions for duplicate rule ids across packs and Unicode boundary traps

## Why
Two silent behaviors were dangerous for future language packs: flattening away pack identity and broadening a malformed semantic target to the whole regex match. The previous word-context guard also allowed boundaries before combining marks/join controls, which can create hits inside connected Unicode text.

## Scope
This is deliberately a small first slice. Canonical NFC/NFD equivalence, complete grapheme-safe matching/source maps, richer locale segmentation, and obfuscated profiles remain tracked separately.

Closes #40
Progress on #35
Related: #33, #36, #38