### PR TITLE
Clarify extension pause state and reconcile settings incrementally

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,9 +95,9 @@ Presentation remains above the DOM adapter. Keep black bars, blur, grawlix masks
 
 `apps/extension` owns `chrome.storage`, hostname overrides, popup UI, manifest permissions, and injected presentation. Do not move those concerns into reusable packages.
 
-Small global preferences belong in `storage.sync`; custom terms currently live in `storage.local`. Host overrides are sparse tri-state policy: absence means inherit, explicit values are `on` or `off`.
+Small global preferences belong in `storage.sync`; custom terms currently live in `storage.local`. Host overrides are sparse tri-state policy: absence means inherit, explicit values are `on` or `off`. The master pause is independent from the default site-enabled policy and must win over every host override.
 
-A storage change restarts the page session through `DomObservation.restore()` before a new controller starts. Preserve that atomic restore/reconfigure sequence.
+Storage changes should perform the minimum page work. Policy changes that leave the current page's effective state unchanged are no-ops; appearance/reveal changes may redecorate owned roots in place. When coverage or custom terms require a new controller, use `DomObservation.restore()` before the replacement controller starts so teardown/reconfigure remains atomic and exact source text returns first.
 
 Extension reveal interaction must avoid stealing native page controls. Generated roots inside links, buttons, inputs, or similar controls stay outside the extension's own focus/click-toggle path.
 

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -31,7 +31,8 @@ To try it locally in Chromium:
 
 Small preferences live in `chrome.storage.sync`:
 
-- global enabled state
+- master paused state
+- default site enabled state
 - appearance
 - coverage
 - reveal mode
@@ -39,23 +40,27 @@ Small preferences live in `chrome.storage.sync`:
 
 Custom words and phrases live in `chrome.storage.local`. They can grow independently of the small synced preference object and stay local to the browser profile.
 
+The popup separates the master state from site policy. **Active** means site policy is allowed to apply; pausing Scrawlix disables it everywhere until the user resumes it. The default-site setting controls hosts without an explicit override.
+
 The popup exposes a tri-state site mode:
 
-- **follow global** — no hostname entry is stored
-- **always on** — hostname explicitly overrides the global switch
-- **always off** — hostname explicitly overrides the global switch
+- **default** — no hostname entry is stored; use the default-site setting
+- **always on** — hostname explicitly overrides the default-site setting
+- **always off** — hostname explicitly overrides the default-site setting
 
-Storage changes are observed by the content script. A preference change tears down the current DOM observation with `observation.restore()`, restoring exact source text before a new configured session begins.
+The master pause always wins over site policy, including an **always on** hostname.
+
+Storage changes are observed by the content script and reconciled with the minimum page work. Appearance/reveal changes redecorate existing Scrawlix roots in place. Policy changes that leave the current page's effective enabled state unchanged are page no-ops. Coverage or custom-term changes restore exact source text with `observation.restore()` before a newly configured controller starts.
 
 ## Page lifecycle
 
 The content script:
 
 1. loads the English pack plus one compiled custom-word rule when custom terms exist
-2. creates one `@scrawlix/dom` controller for the current settings
+2. creates one `@scrawlix/dom` controller for the current settings when the page is effectively enabled
 3. observes `document.body`
 4. decorates only Scrawlix-generated roots with extension presentation metadata
-5. listens for storage changes and restarts atomically
+5. listens for storage changes and chooses among no-op, redecorate, stop, start, or atomic controller restart
 
 The DOM adapter watches mutation roots rather than rescanning the document after every page update.
 
@@ -95,4 +100,4 @@ Broad HTTP/HTTPS host access is a meaningful permission and should remain explic
 - `popup.html` exists
 - every JS/CSS/popup path referenced by the manifest exists in `dist`
 
-Pure preference/mask behavior is covered by `src/config.test.ts`; broader extension/browser E2E coverage can grow after the first unpacked build is exercised manually.
+Pure preference/mask behavior is covered by `src/config.test.ts`. The workspace browser smoke suite loads the built MV3 extension in real Chromium and covers initial/dynamic transformation plus key native-page exclusions; storage/popup policy E2E coverage continues under the browser-hardening work.

--- a/apps/extension/popup.html
+++ b/apps/extension/popup.html
@@ -11,10 +11,11 @@
         <div>
           <p class="wordmark">scrawlix<span aria-hidden="true">*</span></p>
           <p class="tagline">programmable censorship</p>
+          <span id="settings-status" class="save-status" aria-live="polite"></span>
         </div>
         <label class="switch-row compact">
-          <span>global</span>
-          <input id="enabled" type="checkbox" />
+          <span>active</span>
+          <input id="active" type="checkbox" />
         </label>
       </header>
 
@@ -27,7 +28,7 @@
         <label>
           <span class="sr-only">Site mode</span>
           <select id="site-mode">
-            <option value="inherit">follow global</option>
+            <option value="inherit">default</option>
             <option value="on">always on</option>
             <option value="off">always off</option>
           </select>
@@ -36,7 +37,15 @@
 
       <section class="settings-grid" aria-label="Censor treatment">
         <label>
-          <span>appearance</span>
+          <span>default sites</span>
+          <select id="default-enabled">
+            <option value="on">on</option>
+            <option value="off">off</option>
+          </select>
+        </label>
+
+        <label>
+          <span>censor style</span>
           <select id="appearance">
             <option value="scrawl">scrawl</option>
             <option value="bar">bar</option>
@@ -47,13 +56,13 @@
         </label>
 
         <label>
-          <span>coverage</span>
+          <span>how much to hide</span>
           <select id="coverage">
             <option value="middle">middle</option>
-            <option value="vowel">vowel</option>
-            <option value="inner">inner</option>
-            <option value="tail">tail</option>
-            <option value="full">full</option>
+            <option value="vowel">vowels</option>
+            <option value="inner">inner letters</option>
+            <option value="tail">after first letter</option>
+            <option value="full">whole word</option>
           </select>
         </label>
 
@@ -63,7 +72,7 @@
             <option value="hover">hover</option>
             <option value="focus">focus</option>
             <option value="click">click</option>
-            <option value="never">never</option>
+            <option value="never">hidden</option>
           </select>
         </label>
       </section>
@@ -74,7 +83,7 @@
             <p class="eyebrow">your list</p>
             <h2 id="custom-heading">Custom words & phrases</h2>
           </div>
-          <span id="save-status" aria-live="polite"></span>
+          <span id="save-status" class="save-status" aria-live="polite"></span>
         </div>
         <textarea
           id="custom-words"

--- a/apps/extension/src/config.test.ts
+++ b/apps/extension/src/config.test.ts
@@ -6,14 +6,24 @@ import {
   maskFor,
   normalizeCustomWords,
   normalizeSettings,
+  sessionActionFor,
   setSiteMode,
   siteModeFor,
+  type ExtensionStateSnapshot,
 } from './config';
+
+function state(
+  settings = DEFAULT_SETTINGS,
+  customWords: readonly string[] = []
+): ExtensionStateSnapshot {
+  return { settings, customWords };
+}
 
 describe('extension settings', () => {
   it('normalizes invalid stored values to safe defaults', () => {
     expect(
       normalizeSettings({
+        paused: 'no',
         enabled: 'yes',
         appearance: 'paint',
         coverage: 'random',
@@ -30,7 +40,26 @@ describe('extension settings', () => {
     });
   });
 
-  it('lets explicit site modes override the global switch', () => {
+  it('migrates stored settings without a paused field as unpaused', () => {
+    expect(
+      normalizeSettings({
+        enabled: false,
+        appearance: 'bar',
+        coverage: 'full',
+        reveal: 'never',
+        siteOverrides: { 'example.com': 'on' },
+      })
+    ).toEqual({
+      paused: false,
+      enabled: false,
+      appearance: 'bar',
+      coverage: 'full',
+      reveal: 'never',
+      siteOverrides: { 'example.com': 'on' },
+    });
+  });
+
+  it('lets explicit site modes override the default site policy', () => {
     const disabled = { ...DEFAULT_SETTINGS, enabled: false };
     const forcedOn = setSiteMode(disabled, 'example.com', 'on');
     expect(siteModeFor(forcedOn, 'example.com')).toBe('on');
@@ -38,6 +67,16 @@ describe('extension settings', () => {
 
     const forcedOff = setSiteMode(DEFAULT_SETTINGS, 'example.com', 'off');
     expect(effectiveEnabled(forcedOff, 'example.com')).toBe(false);
+  });
+
+  it('lets the master pause beat a forced-on hostname', () => {
+    const forcedOn = setSiteMode(
+      { ...DEFAULT_SETTINGS, paused: true, enabled: false },
+      'example.com',
+      'on'
+    );
+
+    expect(effectiveEnabled(forcedOn, 'example.com')).toBe(false);
   });
 
   it('removes a site override when mode returns to inherit', () => {
@@ -52,6 +91,57 @@ describe('extension settings', () => {
     expect(
       normalizeCustomWords([' Velvet ', 'velvet', '', 42, 'Mothbit', 'MOTHBIT'])
     ).toEqual(['Velvet', 'Mothbit']);
+  });
+
+  it('plans the minimum page-session work for settings changes', () => {
+    const hostname = 'example.com';
+    const base = state();
+
+    expect(sessionActionFor(null, base, hostname, false)).toBe('start');
+    expect(sessionActionFor(base, base, hostname, true)).toBe('none');
+
+    expect(
+      sessionActionFor(
+        base,
+        state({ ...DEFAULT_SETTINGS, appearance: 'blur' }),
+        hostname,
+        true
+      )
+    ).toBe('decorate');
+
+    expect(
+      sessionActionFor(
+        base,
+        state({ ...DEFAULT_SETTINGS, coverage: 'full' }),
+        hostname,
+        true
+      )
+    ).toBe('restart');
+
+    expect(sessionActionFor(base, state(DEFAULT_SETTINGS, ['Mothbit']), hostname, true)).toBe(
+      'restart'
+    );
+  });
+
+  it('does no page work when unrelated policy changes leave this host unchanged', () => {
+    const hostname = 'example.com';
+    const forcedOn = setSiteMode({ ...DEFAULT_SETTINGS, enabled: false }, hostname, 'on');
+    const unrelatedOverride = setSiteMode(forcedOn, 'elsewhere.test', 'off');
+    const changedDefault = { ...forcedOn, enabled: true };
+
+    expect(sessionActionFor(state(forcedOn), state(unrelatedOverride), hostname, true)).toBe(
+      'none'
+    );
+    expect(sessionActionFor(state(forcedOn), state(changedDefault), hostname, true)).toBe('none');
+  });
+
+  it('stops for pause and starts again after unpausing', () => {
+    const hostname = 'example.com';
+    const active = state(setSiteMode(DEFAULT_SETTINGS, hostname, 'on'));
+    const paused = state({ ...active.settings, paused: true });
+
+    expect(sessionActionFor(active, paused, hostname, true)).toBe('stop');
+    expect(sessionActionFor(paused, active, hostname, false)).toBe('start');
   });
 
   it('maps the vowel setting to the English coverage helper', () => {

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -13,6 +13,9 @@ export type ExtensionReveal = 'hover' | 'focus' | 'click' | 'never';
 export type SiteMode = 'inherit' | 'on' | 'off';
 
 export type SyncSettings = {
+  /** True master pause. When paused, no site override can enable Scrawlix. */
+  paused: boolean;
+  /** Default site policy used when a hostname has no explicit override. */
   enabled: boolean;
   appearance: ExtensionAppearance;
   coverage: ExtensionCoverage;
@@ -20,10 +23,18 @@ export type SyncSettings = {
   siteOverrides: Record<string, Exclude<SiteMode, 'inherit'>>;
 };
 
+export type ExtensionStateSnapshot = {
+  settings: SyncSettings;
+  customWords: readonly string[];
+};
+
+export type SessionAction = 'none' | 'start' | 'stop' | 'restart' | 'decorate';
+
 export const SYNC_SETTINGS_KEY = 'scrawlixSettings';
 export const CUSTOM_WORDS_KEY = 'scrawlixCustomWords';
 
 export const DEFAULT_SETTINGS: SyncSettings = {
+  paused: false,
   enabled: true,
   appearance: 'scrawl',
   coverage: 'middle',
@@ -66,6 +77,7 @@ export function normalizeSettings(value: unknown): SyncSettings {
   }
 
   return {
+    paused: typeof value.paused === 'boolean' ? value.paused : DEFAULT_SETTINGS.paused,
     enabled: typeof value.enabled === 'boolean' ? value.enabled : DEFAULT_SETTINGS.enabled,
     appearance: APPEARANCES.has(value.appearance as ExtensionAppearance)
       ? (value.appearance as ExtensionAppearance)
@@ -104,6 +116,8 @@ export function siteModeFor(settings: SyncSettings, hostname: string): SiteMode 
 }
 
 export function effectiveEnabled(settings: SyncSettings, hostname: string) {
+  if (settings.paused) return false;
+
   const mode = siteModeFor(settings, hostname);
   if (mode === 'on') return true;
   if (mode === 'off') return false;
@@ -125,6 +139,38 @@ export function setSiteMode(
   }
 
   return { ...settings, siteOverrides };
+}
+
+function sameWords(left: readonly string[], right: readonly string[]) {
+  return left.length === right.length && left.every((word, index) => word === right[index]);
+}
+
+export function sessionActionFor(
+  previous: ExtensionStateSnapshot | null,
+  next: ExtensionStateSnapshot,
+  hostname: string,
+  hasSession: boolean
+): SessionAction {
+  const nextEnabled = effectiveEnabled(next.settings, hostname);
+  if (!nextEnabled) return hasSession ? 'stop' : 'none';
+  if (!hasSession) return 'start';
+  if (!previous) return 'restart';
+
+  if (
+    previous.settings.coverage !== next.settings.coverage ||
+    !sameWords(previous.customWords, next.customWords)
+  ) {
+    return 'restart';
+  }
+
+  if (
+    previous.settings.appearance !== next.settings.appearance ||
+    previous.settings.reveal !== next.settings.reveal
+  ) {
+    return 'decorate';
+  }
+
+  return 'none';
 }
 
 export function coverageSelector(coverage: ExtensionCoverage): CoverageSelector {

--- a/apps/extension/src/content.ts
+++ b/apps/extension/src/content.ts
@@ -5,8 +5,9 @@ import {
   CUSTOM_WORDS_KEY,
   SYNC_SETTINGS_KEY,
   coverageSelector,
-  effectiveEnabled,
   maskFor,
+  sessionActionFor,
+  type ExtensionStateSnapshot,
   type SyncSettings,
 } from './config';
 import { loadExtensionState } from './storage';
@@ -16,7 +17,7 @@ const INTERACTIVE_ANCESTOR =
 
 let observation: DomObservation | null = null;
 let presentationObserver: MutationObserver | null = null;
-let activeSettings: SyncSettings | null = null;
+let activeState: ExtensionStateSnapshot | null = null;
 let restartGeneration = 0;
 
 function customRule(customWords: readonly string[]): CensorRule[] {
@@ -29,9 +30,13 @@ function canOwnInteraction(root: HTMLElement) {
 }
 
 function decorateGeneratedRoot(root: HTMLElement, settings: SyncSettings) {
+  const previousReveal = root.dataset.scrawlixReveal;
+
   root.dataset.scrawlixAppearance = settings.appearance;
   root.dataset.scrawlixReveal = settings.reveal;
-  root.dataset.scrawlixRevealed = 'false';
+  if (previousReveal !== settings.reveal || root.dataset.scrawlixRevealed === undefined) {
+    root.dataset.scrawlixRevealed = 'false';
+  }
 
   const interactiveReveal = settings.reveal === 'focus' || settings.reveal === 'click';
   if (interactiveReveal && canOwnInteraction(root)) {
@@ -63,8 +68,11 @@ function decorateSubtree(node: Node, settings: SyncSettings) {
   }
 }
 
-function startPresentationObserver(settings: SyncSettings) {
+function startPresentationObserver() {
   const observer = new MutationObserver(records => {
+    const settings = activeState?.settings;
+    if (!settings) return;
+
     for (const record of records) {
       for (const added of Array.from(record.addedNodes)) {
         decorateSubtree(added, settings);
@@ -81,28 +89,52 @@ function stopCurrentSession() {
   presentationObserver = null;
   observation?.restore();
   observation = null;
-  activeSettings = null;
 }
 
-async function restart() {
-  const generation = ++restartGeneration;
-  const state = await loadExtensionState();
-  if (generation !== restartGeneration) return;
-
-  stopCurrentSession();
-
-  const hostname = location.hostname.toLowerCase();
-  if (!document.body || !effectiveEnabled(state.settings, hostname)) return;
-
+function startSession(state: ExtensionStateSnapshot) {
   const controller = createDomScrawlix({
     rules: [...englishProfanityRules, ...customRule(state.customWords)],
     coverage: coverageSelector(state.settings.coverage),
   });
 
-  activeSettings = state.settings;
   observation = controller.observe(document.body);
   decorateSubtree(document.body, state.settings);
-  startPresentationObserver(state.settings);
+  startPresentationObserver();
+}
+
+async function reconcile() {
+  const generation = ++restartGeneration;
+  const state = await loadExtensionState();
+  if (generation !== restartGeneration) return;
+
+  const previous = activeState;
+  const hostname = location.hostname.toLowerCase();
+  const action = sessionActionFor(previous, state, hostname, observation !== null);
+  activeState = state;
+
+  if (!document.body) return;
+
+  switch (action) {
+    case 'stop':
+      stopCurrentSession();
+      return;
+
+    case 'start':
+      startSession(state);
+      return;
+
+    case 'restart':
+      stopCurrentSession();
+      startSession(state);
+      return;
+
+    case 'decorate':
+      decorateSubtree(document.body, state.settings);
+      return;
+
+    case 'none':
+      return;
+  }
 }
 
 function clickRootFromEvent(event: Event) {
@@ -138,14 +170,12 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
   const relevantLocal =
     areaName === 'local' && Object.prototype.hasOwnProperty.call(changes, CUSTOM_WORDS_KEY);
 
-  if (relevantSync || relevantLocal) void restart();
+  if (relevantSync || relevantLocal) void reconcile();
 });
 
 function startWhenReady() {
-  if (document.body) void restart();
-  else window.addEventListener('DOMContentLoaded', () => void restart(), { once: true });
+  if (document.body) void reconcile();
+  else window.addEventListener('DOMContentLoaded', () => void reconcile(), { once: true });
 }
 
 startWhenReady();
-
-void activeSettings;

--- a/apps/extension/src/popup.css
+++ b/apps/extension/src/popup.css
@@ -68,7 +68,7 @@ footer {
 footer,
 .switch-row span,
 .settings-grid label > span,
-#save-status {
+.save-status {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
@@ -78,6 +78,19 @@ footer,
   text-transform: uppercase;
   letter-spacing: 0.11em;
   opacity: 0.62;
+}
+
+.save-status {
+  display: inline-block;
+  min-height: 1em;
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.6;
+}
+
+#settings-status {
+  margin-top: 4px;
 }
 
 .switch-row {
@@ -168,8 +181,8 @@ textarea:focus {
 
 .settings-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px 8px;
   padding: 14px 0;
 }
 
@@ -200,11 +213,7 @@ textarea:focus {
 
 #save-status {
   min-width: 60px;
-  font-size: 8px;
   text-align: right;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  opacity: 0.6;
 }
 
 textarea {

--- a/apps/extension/src/popup.ts
+++ b/apps/extension/src/popup.ts
@@ -12,6 +12,7 @@ import {
 } from './config';
 import {
   loadExtensionState,
+  loadSettings,
   saveCustomWords,
   saveSettings,
 } from './storage';
@@ -22,7 +23,8 @@ function required<T extends HTMLElement>(id: string): T {
   return element as T;
 }
 
-const enabledInput = required<HTMLInputElement>('enabled');
+const activeInput = required<HTMLInputElement>('active');
+const defaultEnabledSelect = required<HTMLSelectElement>('default-enabled');
 const siteModeSelect = required<HTMLSelectElement>('site-mode');
 const appearanceSelect = required<HTMLSelectElement>('appearance');
 const coverageSelect = required<HTMLSelectElement>('coverage');
@@ -30,11 +32,13 @@ const revealSelect = required<HTMLSelectElement>('reveal');
 const customWordsInput = required<HTMLTextAreaElement>('custom-words');
 const siteHeading = required<HTMLHeadingElement>('site-heading');
 const effectiveStatus = required<HTMLParagraphElement>('effective-status');
+const settingsStatus = required<HTMLSpanElement>('settings-status');
 const saveStatus = required<HTMLSpanElement>('save-status');
 
 let settings: SyncSettings;
 let hostname: string | null = null;
 let wordSaveTimer: number | null = null;
+let settingsSaveQueue = Promise.resolve();
 
 async function currentHostname() {
   const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -54,6 +58,7 @@ function renderEffectiveStatus() {
   if (!hostname) {
     siteHeading.textContent = 'This page is unavailable';
     effectiveStatus.textContent = 'Scrawlix runs on ordinary HTTP and HTTPS pages.';
+    effectiveStatus.dataset.enabled = 'false';
     siteModeSelect.disabled = true;
     return;
   }
@@ -62,12 +67,17 @@ function renderEffectiveStatus() {
   siteModeSelect.disabled = false;
   siteModeSelect.value = siteModeFor(settings, hostname);
   const enabledHere = effectiveEnabled(settings, hostname);
-  effectiveStatus.textContent = enabledHere ? 'censoring is on here' : 'censoring is off here';
+  if (settings.paused) {
+    effectiveStatus.textContent = 'paused everywhere';
+  } else {
+    effectiveStatus.textContent = enabledHere ? 'censoring is on here' : 'censoring is off here';
+  }
   effectiveStatus.dataset.enabled = enabledHere ? 'true' : 'false';
 }
 
 function renderSettings() {
-  enabledInput.checked = settings.enabled;
+  activeInput.checked = !settings.paused;
+  defaultEnabledSelect.value = settings.enabled ? 'on' : 'off';
   appearanceSelect.value = settings.appearance;
   coverageSelect.value = settings.coverage;
   revealSelect.value = settings.reveal;
@@ -77,7 +87,26 @@ function renderSettings() {
 async function persistSettings(next: SyncSettings) {
   settings = next;
   renderSettings();
-  await saveSettings(settings);
+  settingsStatus.textContent = 'saving…';
+
+  const queued = settingsSaveQueue
+    .catch(() => undefined)
+    .then(async () => {
+      try {
+        await saveSettings(next);
+        if (settings === next) settingsStatus.textContent = 'saved';
+      } catch {
+        if (settings === next) {
+          settings = await loadSettings();
+          renderSettings();
+          settingsStatus.textContent = 'save failed';
+        }
+        throw new Error('Failed to save Scrawlix settings.');
+      }
+    });
+
+  settingsSaveQueue = queued.catch(() => undefined);
+  await queued.catch(() => undefined);
 }
 
 function wordsFromTextarea() {
@@ -105,8 +134,12 @@ function scheduleWordSave() {
   wordSaveTimer = window.setTimeout(() => void persistWords(), 250);
 }
 
-enabledInput.addEventListener('change', () => {
-  void persistSettings({ ...settings, enabled: enabledInput.checked });
+activeInput.addEventListener('change', () => {
+  void persistSettings({ ...settings, paused: !activeInput.checked });
+});
+
+defaultEnabledSelect.addEventListener('change', () => {
+  void persistSettings({ ...settings, enabled: defaultEnabledSelect.value === 'on' });
 });
 
 siteModeSelect.addEventListener('change', () => {


### PR DESCRIPTION
## What changed

- add a true master `paused` state that always wins over hostname overrides
- keep the existing `enabled` field as the default-site policy so existing installs migrate cleanly
- replace unconditional content-script restarts with a pure reconciliation plan:
  - stop when the current site becomes disabled
  - start when it becomes enabled
  - restart only for coverage/custom-term changes
  - redecorate in place for appearance/reveal changes
  - do nothing for unrelated host-policy/default changes that leave the current site unchanged
- preserve click-revealed state across appearance-only updates
- relabel the popup around **Active**, **Default sites**, **Censor style**, and **How much to hide**
- serialize compact-settings writes and recover the popup from storage write failures
- add unit coverage for migration, master-pause precedence, minimal reconciliation, and the forced-on-host/default-policy edge case
- update extension docs and maintainer invariants to describe incremental reconciliation

## Validation

CI is green on the final head:

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Chromium demo smoke
- Chromium extension smoke
- `pnpm smoke:packages`

Progresses #48 and the browser-hardening umbrella #23.

Follow-up work remains in #50 (permissions/privacy) and #51 (popup/options/reveal UX).