### PR TITLE
Fix zero-width Unicode regex progress

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -161,6 +161,25 @@ describe('Scrawlix core', () => {
     expect(third).toEqual(first);
   });
 
+  it('advances zero-width Unicode matches across astral characters', () => {
+    const scrawlix = createScrawlix({
+      rules: [{ id: 'mixed', pattern: /(?=🔥)|a/u }],
+      coverage: 'full',
+    });
+
+    expect(scrawlix.find('🔥a')).toEqual([
+      {
+        ruleId: 'mixed',
+        text: 'a',
+        start: 2,
+        end: 3,
+        targetText: 'a',
+        targetStart: 2,
+        targetEnd: 3,
+      },
+    ]);
+  });
+
   it('merges overlapping covered ranges and keeps contributing rule ids', () => {
     const scrawlix = createScrawlix({
       rules: [semanticRule, { id: 'whole', pattern: /motherfucker/gi }],

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,19 @@ function compilePattern(pattern: RegExp) {
   return new RegExp(pattern.source, [...flags].join(''));
 }
 
+function advanceStringIndex(value: string, index: number, unicode: boolean) {
+  if (!unicode) return index + 1;
+  if (index + 1 >= value.length) return index + 1;
+
+  const first = value.charCodeAt(index);
+  if (first < 0xd800 || first > 0xdbff) return index + 1;
+
+  const second = value.charCodeAt(index + 1);
+  if (second < 0xdc00 || second > 0xdfff) return index + 1;
+
+  return index + 2;
+}
+
 function graphemeRanges(value: string): RelativeRange[] {
   if (!value) return [];
 
@@ -230,7 +243,9 @@ function scan(text: string, rules: readonly CompiledRule[]): ScannedMatch[] {
 
     while ((rawMatch = rule.pattern.exec(text)) !== null) {
       if (!rawMatch[0]) {
-        rule.pattern.lastIndex = rawMatch.index + 1;
+        const unicode =
+          rule.pattern.flags.includes('u') || rule.pattern.flags.includes('v');
+        rule.pattern.lastIndex = advanceStringIndex(text, rawMatch.index, unicode);
         continue;
       }
 


### PR DESCRIPTION
## What changed

- add an ECMAScript-style Unicode-aware string-index advance helper for manually advancing empty regex matches
- advance over an astral surrogate pair as one Unicode code point when the compiled rule uses `u` or `v`
- add a regression where a zero-width lookahead before `🔥` must progress far enough to find a later non-empty match

## Why

The previous `rawMatch.index + 1` logic could place `lastIndex` inside a surrogate pair. Under Unicode regex semantics, the next execution can snap back to the same code-point boundary and produce the same zero-width match forever, locking the JS thread.

Closes #53.