### PR TITLE
Add a source-ranged custom matcher escape hatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added custom coverage callbacks and per-rule coverage overrides.
 - Added Unicode-aware custom word/phrase rules with explicit `word` and `substring` boundary modes.
 - Added rule-pack composition and caller-safe compiled RegExp handling.
+- Added a custom matcher escape hatch that can return exact original-source match/target ranges for pack-owned normalization, segmentation, or other matching algorithms.
+- Validate custom matcher ranges instead of silently clamping malformed source offsets.
 - Preserve source-pack provenance in composed rules, matches, and coverage callbacks.
 - Reject configured semantic target groups that are unavailable for a produced match instead of silently widening coverage.
 - Treat combining marks, Unicode connector punctuation, ZWNJ, and ZWJ as continuing word context for custom word/phrase boundaries.

--- a/docs/language-packs.md
+++ b/docs/language-packs.md
@@ -55,7 +55,7 @@ Future packs may need richer tokenization than either mode. Add that capability 
 
 ## Semantic targets
 
-A rule can match a larger inflection or compound while identifying the semantic core with a named capture group:
+A regex rule can match a larger inflection or compound while identifying the semantic core with a named capture group:
 
 ```ts
 const rule = {
@@ -66,6 +66,37 @@ const rule = {
 ```
 
 Coverage runs against `core`, while `find()` still reports the full match and both full/target ranges. A declared target group is part of the rule contract: if a produced match cannot resolve that named group, Scrawlix throws a descriptive error instead of widening the target to the full match.
+
+## Custom matcher escape hatch
+
+Regex remains the compact path for ordinary rules. A pack that needs normalization, locale-specific segmentation, a trie, or another matching algorithm can provide a custom matcher instead:
+
+```ts
+import type { CensorRule } from '@scrawlix/core';
+
+const rule: CensorRule = {
+  id: 'example-custom',
+  matcher: {
+    *find(text) {
+      const start = text.indexOf('prefixtermsuffix');
+      if (start < 0) return;
+
+      yield {
+        start,
+        end: start + 'prefixtermsuffix'.length,
+        targetStart: start + 'prefix'.length,
+        targetEnd: start + 'prefixterm'.length,
+      };
+    },
+  },
+};
+```
+
+Matcher ranges are UTF-16 offsets into the exact original JavaScript source string. `start`/`end` identify the complete match. `targetStart`/`targetEnd` are optional; omit both to make the complete match the semantic target.
+
+Custom matchers may build normalized or otherwise transformed shadow text internally, but they remain responsible for mapping a detected span back to exact original-source offsets before yielding it. Core validates matcher output and rejects empty, out-of-bounds, partial-target, or target-outside-match ranges rather than clamping them.
+
+Keep language-specific matching algorithms in their language packs. The custom matcher seam exists so core can execute source-ranged results without learning a language's morphology, segmentation, normalization, or evasion conventions.
 
 ## Coverage helpers
 

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,8 @@ import {
   censorRuleFromWords,
   createScrawlix,
   rulesFromPacks,
+  type CensorMatcher,
+  type CensorMatcherMatch,
   type CensorRule,
   type ScrawlixSegment,
 } from './index';
@@ -54,6 +56,79 @@ describe('Scrawlix core', () => {
       },
     ]);
   });
+
+  it('supports custom matchers that return exact source and semantic-target ranges', () => {
+    const matcher: CensorMatcher = {
+      *find(text) {
+        const needle = 'motherfucker';
+        const start = text.indexOf(needle);
+        if (start < 0) return;
+
+        yield {
+          start,
+          end: start + needle.length,
+          targetStart: start + 6,
+          targetEnd: start + 10,
+        };
+      },
+    };
+    const pack = {
+      id: 'custom-pack',
+      rules: [{ id: 'custom-matcher', matcher } satisfies CensorRule],
+    };
+    const scrawlix = createScrawlix({
+      rules: rulesFromPacks(pack),
+      coverage: 'middle',
+    });
+
+    const text = 'hey motherfucker!';
+    expect(marked(scrawlix.segment(text))).toBe('hey motherf[uc]ker!');
+    expect(source(scrawlix.segment(text))).toBe(text);
+    expect(scrawlix.find(text)).toEqual([
+      {
+        ruleId: 'custom-matcher',
+        packId: 'custom-pack',
+        text: 'motherfucker',
+        start: 4,
+        end: 16,
+        targetText: 'fuck',
+        targetStart: 10,
+        targetEnd: 14,
+      },
+    ]);
+  });
+
+  it.each([
+    [
+      'out-of-bounds match',
+      { start: -1, end: 2 },
+      'returned an invalid match range',
+    ],
+    [
+      'partial target pair',
+      { start: 0, end: 3, targetStart: 0 },
+      'must return targetStart and targetEnd together',
+    ],
+    [
+      'target outside match',
+      { start: 0, end: 3, targetStart: 0, targetEnd: 4 },
+      'returned an invalid target range',
+    ],
+  ] as const)(
+    'rejects custom matcher output with an invalid %s',
+    (_name, range, message) => {
+      const matcher: CensorMatcher = {
+        find() {
+          return [range as CensorMatcherMatch];
+        },
+      };
+      const scrawlix = createScrawlix({
+        rules: [{ id: 'bad-matcher', matcher }],
+      });
+
+      expect(() => scrawlix.find('bad')).toThrow(message);
+    }
+  );
 
   it('fails loudly when a configured semantic target group is unavailable', () => {
     const brokenRule: CensorRule = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,14 +24,42 @@ export type CensorTarget = {
   group: string;
 };
 
-export type CensorRule = {
+export type CensorMatcherMatch = {
+  /** UTF-16 source offset into the original input. */
+  start: number;
+  /** Exclusive UTF-16 source offset into the original input. */
+  end: number;
+  /** Optional semantic-target start, contained inside the full match. */
+  targetStart?: number;
+  /** Optional semantic-target end, contained inside the full match. */
+  targetEnd?: number;
+};
+
+export type CensorMatcher = {
+  /** Return exact ranges into the original source string. */
+  find(text: string): Iterable<CensorMatcherMatch>;
+};
+
+type CensorRuleBase = {
   id: string;
-  pattern: RegExp;
-  target?: CensorTarget;
   coverage?: CoverageSelector;
   /** Pack provenance attached by rulesFromPacks(). */
   packId?: string;
 };
+
+export type CensorRegexRule = CensorRuleBase & {
+  pattern: RegExp;
+  target?: CensorTarget;
+  matcher?: never;
+};
+
+export type CensorMatcherRule = CensorRuleBase & {
+  matcher: CensorMatcher;
+  pattern?: never;
+  target?: never;
+};
+
+export type CensorRule = CensorRegexRule | CensorMatcherRule;
 
 export type CensorRulePack = {
   id: string;
@@ -68,9 +96,11 @@ export type ScrawlixEngine = {
   segment(text: string): ScrawlixSegment[];
 };
 
-type CompiledRule = Omit<CensorRule, 'pattern'> & {
+type CompiledRegexRule = Omit<CensorRegexRule, 'pattern'> & {
   pattern: RegExp;
 };
+
+type CompiledRule = CompiledRegexRule | CensorMatcherRule;
 
 type ScannedMatch = {
   match: ScrawlixMatch;
@@ -117,6 +147,10 @@ function advanceStringIndex(value: string, index: number, unicode: boolean) {
   if (second < 0xdc00 || second > 0xdfff) return index + 1;
 
   return index + 2;
+}
+
+function isMatcherRule(rule: CensorRule): rule is CensorMatcherRule {
+  return rule.matcher !== undefined;
 }
 
 function graphemeRanges(value: string): RelativeRange[] {
@@ -216,7 +250,30 @@ function ruleIdentity(rule: CompiledRule) {
   return rule.packId ? `${rule.packId}:${rule.id}` : rule.id;
 }
 
-function resolveTargetRange(match: RegExpExecArray, rule: CompiledRule) {
+function scannedMatchFromRange(
+  text: string,
+  rule: CompiledRule,
+  start: number,
+  end: number,
+  targetStart: number,
+  targetEnd: number
+): ScannedMatch {
+  return {
+    rule,
+    match: {
+      ruleId: rule.id,
+      ...(rule.packId ? { packId: rule.packId } : {}),
+      text: text.slice(start, end),
+      start,
+      end,
+      targetText: text.slice(targetStart, targetEnd),
+      targetStart,
+      targetEnd,
+    },
+  };
+}
+
+function resolveTargetRange(match: RegExpExecArray, rule: CompiledRegexRule) {
   const fullStart = match.index;
   const fullEnd = match.index + match[0].length;
 
@@ -234,13 +291,12 @@ function resolveTargetRange(match: RegExpExecArray, rule: CompiledRule) {
   return { start: groupRange[0], end: groupRange[1] };
 }
 
-function scan(text: string, rules: readonly CompiledRule[]): ScannedMatch[] {
+function scanRegexRule(text: string, rule: CompiledRegexRule): ScannedMatch[] {
   const matches: ScannedMatch[] = [];
+  rule.pattern.lastIndex = 0;
 
-  for (const rule of rules) {
-    rule.pattern.lastIndex = 0;
+  try {
     let rawMatch: RegExpExecArray | null;
-
     while ((rawMatch = rule.pattern.exec(text)) !== null) {
       if (!rawMatch[0]) {
         const unicode =
@@ -250,23 +306,106 @@ function scan(text: string, rules: readonly CompiledRule[]): ScannedMatch[] {
       }
 
       const target = resolveTargetRange(rawMatch, rule);
-      matches.push({
-        rule,
-        match: {
-          ruleId: rule.id,
-          ...(rule.packId ? { packId: rule.packId } : {}),
-          text: rawMatch[0],
-          start: rawMatch.index,
-          end: rawMatch.index + rawMatch[0].length,
-          targetText: text.slice(target.start, target.end),
-          targetStart: target.start,
-          targetEnd: target.end,
-        },
-      });
+      matches.push(
+        scannedMatchFromRange(
+          text,
+          rule,
+          rawMatch.index,
+          rawMatch.index + rawMatch[0].length,
+          target.start,
+          target.end
+        )
+      );
     }
-
+  } finally {
     rule.pattern.lastIndex = 0;
   }
+
+  return matches;
+}
+
+function validatedMatcherRange(
+  textLength: number,
+  rule: CensorMatcherRule,
+  range: CensorMatcherMatch
+) {
+  if (
+    !Number.isInteger(range.start) ||
+    !Number.isInteger(range.end) ||
+    range.start < 0 ||
+    range.end > textLength ||
+    range.end <= range.start
+  ) {
+    throw new Error(
+      `Censor rule "${ruleIdentity(rule)}" returned an invalid match range [${range.start}, ${range.end}) for source length ${textLength}.`
+    );
+  }
+
+  const hasTargetStart = range.targetStart !== undefined;
+  const hasTargetEnd = range.targetEnd !== undefined;
+  if (hasTargetStart !== hasTargetEnd) {
+    throw new Error(
+      `Censor rule "${ruleIdentity(rule)}" must return targetStart and targetEnd together.`
+    );
+  }
+
+  if (!hasTargetStart || !hasTargetEnd) {
+    return {
+      start: range.start,
+      end: range.end,
+      targetStart: range.start,
+      targetEnd: range.end,
+    };
+  }
+
+  const targetStart = range.targetStart!;
+  const targetEnd = range.targetEnd!;
+  if (
+    !Number.isInteger(targetStart) ||
+    !Number.isInteger(targetEnd) ||
+    targetStart < range.start ||
+    targetEnd > range.end ||
+    targetEnd <= targetStart
+  ) {
+    throw new Error(
+      `Censor rule "${ruleIdentity(rule)}" returned an invalid target range [${targetStart}, ${targetEnd}) inside match [${range.start}, ${range.end}).`
+    );
+  }
+
+  return {
+    start: range.start,
+    end: range.end,
+    targetStart,
+    targetEnd,
+  };
+}
+
+function scanMatcherRule(text: string, rule: CensorMatcherRule): ScannedMatch[] {
+  const matches: ScannedMatch[] = [];
+
+  for (const rawRange of rule.matcher.find(text)) {
+    const range = validatedMatcherRange(text.length, rule, rawRange);
+    matches.push(
+      scannedMatchFromRange(
+        text,
+        rule,
+        range.start,
+        range.end,
+        range.targetStart,
+        range.targetEnd
+      )
+    );
+  }
+
+  return matches;
+}
+
+function scan(text: string, rules: readonly CompiledRule[]): ScannedMatch[] {
+  const matches = rules.flatMap(rule =>
+    isMatcherRule(rule)
+      ? scanMatcherRule(text, rule)
+      : scanRegexRule(text, rule)
+  );
 
   matches.sort(
     (left, right) =>
@@ -413,10 +552,13 @@ export function rulesFromPacks(
   ...packs: readonly CensorRulePack[]
 ): CensorRule[] {
   return packs.flatMap(pack =>
-    pack.rules.map(rule => ({
-      ...rule,
-      packId: pack.id,
-    }))
+    pack.rules.map(
+      rule =>
+        ({
+          ...rule,
+          packId: pack.id,
+        }) as CensorRule
+    )
   );
 }
 
@@ -424,10 +566,14 @@ export function createScrawlix({
   rules = [],
   coverage = 'middle',
 }: ScrawlixOptions = {}): ScrawlixEngine {
-  const compiledRules: CompiledRule[] = rules.map(rule => ({
-    ...rule,
-    pattern: compilePattern(rule.pattern),
-  }));
+  const compiledRules: CompiledRule[] = rules.map(rule =>
+    isMatcherRule(rule)
+      ? rule
+      : {
+          ...rule,
+          pattern: compilePattern(rule.pattern),
+        }
+  );
 
   return {
     find(text) {


### PR DESCRIPTION
## Summary
Add an additive custom matcher path alongside RegExp rules. Matchers yield exact UTF-16 ranges into the original source: `start`/`end` for the full match and optional `targetStart`/`targetEnd` for the semantic target.

Core validates every matcher range and rejects empty, non-integer, out-of-bounds, partial-target, and target-outside-match results. It never clamps matcher output.

Existing regex rules keep their current API. Pack provenance, semantic-target coverage, and exact source reconstruction flow through the same downstream path.

This gives language packs an execution seam for canonical normalization, locale segmentation, tries, and obfuscation profiles while keeping those linguistic policies outside core.

Progress on #38
Related: #35, #36, #52