### PR TITLE
Tighten first-release adoption ergonomics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,17 +15,36 @@ A change in one layer should rarely require logic in another.
 
 ## Workspace map
 
-- `packages/core` — language-neutral matching, segmentation, generic coverage, custom-word helpers
-- `packages/en` — English profanity rules, English-specific coverage helpers, English regression corpus
+- `packages/core` — language-neutral matching, segmentation, generic coverage, custom-term helpers
+- `packages/en` — English strong-profanity rules, English-specific coverage helpers, English regression corpus
 - `packages/react` — React renderer and appearance/reveal behavior
 - `packages/rehype` — HAST/rehype transformer for syntax-tree prose
 - `packages/dom` — arbitrary-page text-node transformation, restoration, and mutation observation
 - `apps/demo` — public interactive proof sheet and integration consumer
 - `apps/extension` — Manifest V3 application: browser state, popup UI, and injected presentation
 - `fixtures/consumer` — external packed-package smoke consumer
-- `docs` — design and extension guidance
+- `docs` — design, adoption, and extension guidance
 
 Scrapbook adoption remains tracked separately as a real-consumer integration.
+
+## Canonical public names and defaults
+
+Use these names in code, docs, examples, and agent-generated changes:
+
+- `createScrawlix`
+- `censorRuleFromTerms`
+- `rulesFromPacks`
+- `englishStrongProfanityRules`
+- `englishStrongProfanityPack`
+- `englishVowelCoverage`
+- `CensoredText`
+- `rehypeScrawlix`
+- `transformHast`
+- `createDomScrawlix`
+
+Core defaults to `coverage: 'full'`. React defaults to `appearance="scrawl"` and `reveal="never"`. Partial coverage and reveal behavior are deliberate caller choices.
+
+Do not invent convenience packages, automatic English selection, compatibility aliases, or alternate spellings for the public API.
 
 ## Commands
 
@@ -39,7 +58,7 @@ pnpm build
 pnpm smoke:packages
 ```
 
-The demo and extension builds are part of the workspace build. The package smoke test installs packed tarballs into a consumer outside the workspace dependency graph.
+The demo and extension builds are part of the workspace build. The package smoke test installs packed tarballs into a consumer outside the workspace dependency graph and typechecks published declarations with library checking enabled.
 
 ## Invariants
 
@@ -57,6 +76,10 @@ Generic coverage belongs in core. A behavior such as “cover English vowels” 
 
 `createScrawlix()` with zero rules is a no-op. Adapters should receive rules explicitly. Avoid hidden language detection or surprise bundled moderation behavior.
 
+### Keep first-use coverage conservative
+
+When rules are supplied without a coverage selector, core covers the full semantic target. Renderers may expose richer partial treatments, but those should be explicit choices. React keeps source concealed by default with `reveal="never"`.
+
 ### Preserve caller-owned RegExp state
 
 The engine compiles its own RegExp copies. Never mutate a caller's `lastIndex`. Repeated `find()` / `segment()` calls on the same engine must be stable.
@@ -70,6 +93,8 @@ When a larger match contains the meaningful censored core, use a named capture g
 Visual censorship is decorative. When text is transformed, React keeps exactly one visually-hidden source copy in the accessibility tree (`data-scrawlix-a11y`) and marks the complete rendered visual tree `aria-hidden="true"`. Preserve that single accessible reading of the source across every appearance and reveal mode.
 
 Passive reveal modes (`hover`, `never`) stay outside the tab order. Keyboard-driven reveal modes must retain an operable focus path and regression coverage.
+
+`@scrawlix/react/styles.css` is part of the documented React adoption path because it owns the built-in treatment CSS and the visually-hidden accessibility helper.
 
 ### Keep syntax-tree adapters semantic
 
@@ -114,18 +139,20 @@ When a bug or rule change teaches a durable positive or false-positive example, 
 3. Keep morphology and language-specific coverage helpers inside that package.
 4. Add a reviewable positive corpus and a clean/false-positive corpus.
 5. Test semantic target text, casing, punctuation, compounds/inflections, and known ambiguity.
-6. For phrase lists that can sit beside other letters, use `censorRuleFromWords(..., { boundary: 'substring' })` deliberately.
+6. For phrase lists that can sit beside other letters, use `censorRuleFromTerms(..., { boundary: 'substring' })` deliberately.
 7. Document dialect/severity assumptions. Do not imply complete language coverage from a small pack.
+8. Give the package README an exact install command and canonical consumer snippet.
 
 ## Adding a visual appearance
 
-1. Add the appearance name to `ScrawlixAppearance` in `packages/react`.
-2. Keep matching logic out of React.
-3. Prefer CSS/data-attribute presentation over rebuilding source strings.
-4. Add the appearance to the demo specimen sheet.
-5. Preserve reveal modes and reduced-motion behavior.
-6. Extend rendered regressions for any new DOM contract or interaction.
-7. If the extension should expose the same appearance, update its local presentation union/CSS and test its mask semantics separately.
+1. Coordinate with the shared appearance contract tracked in issue #26.
+2. Add the appearance name to `ScrawlixAppearance` in `packages/react` when it is a built-in preset.
+3. Keep matching logic out of React.
+4. Prefer CSS/data-attribute presentation over rebuilding source strings.
+5. Add the appearance to the demo specimen sheet.
+6. Preserve reveal modes and reduced-motion behavior.
+7. Extend rendered regressions for any new DOM contract or interaction.
+8. If the extension should expose the same appearance, update its presentation union/CSS and test its mask semantics separately.
 
 ## Adding a coverage behavior
 
@@ -133,6 +160,8 @@ Ask whether the behavior is language-neutral. Generic positional coverage may li
 
 ## Public API discipline
 
-Scrawlix is pre-release, so breaking changes are still possible. Use that freedom to remove surprising defaults and awkward names early. Once packages are published, favor additive changes and explicit deprecation paths.
+Scrawlix is pre-release, so breaking changes are still possible. Use that freedom to remove surprising defaults and awkward names before publication. Once packages are published, classify 0.x changes deliberately and use explicit deprecation paths when compatibility aliases become necessary.
 
 Packed-package smoke tests are a release gate: external consumers must receive compiled JavaScript, declarations, CSS exports, and valid package metadata rather than workspace-only source imports. Every new public package belongs in `scripts/smoke-packages.mjs` and `fixtures/consumer`.
+
+Human quickstarts live in the root/package READMEs. Agent quickstarts live in the demo `llms.txt`. Keep those surfaces synchronized whenever public names, defaults, package selection, or required side-effect imports change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added custom coverage callbacks and per-rule coverage overrides.
 - Added Unicode-aware custom term/phrase rules through `censorRuleFromTerms()` with explicit `word` and `substring` boundary modes.
 - Added rule-pack composition and caller-safe compiled RegExp handling.
+- Preserve source-pack provenance in composed rules, matches, and coverage callbacks.
+- Reject configured semantic target groups that are unavailable for a produced match instead of silently widening coverage.
+- Treat combining marks, Unicode connector punctuation, ZWNJ, and ZWJ as continuing word context for custom term/phrase boundaries.
 - Added deterministic source-preservation and cursor-state regressions.
 
 ### English pack
@@ -20,6 +23,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added `@scrawlix/en` with explicit English strong-profanity rules exported as `englishStrongProfanityRules` and `englishStrongProfanityPack`.
 - Added English-specific vowel coverage outside the neutral core.
 - Added positive and clean regression corpora, including false-positive traps.
+- Hardened English word edges around combining marks, connector punctuation, ZWNJ, and ZWJ.
 
 ### React
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,15 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added language-neutral `@scrawlix/core` matching and segmentation.
 - Added semantic target ranges for inflected/compound matches.
 - Added positional coverage presets: `full`, `tail`, `middle`, and `inner`.
+- Made `full` the conservative default coverage when rules are supplied.
 - Added custom coverage callbacks and per-rule coverage overrides.
-- Added Unicode-aware custom word/phrase rules with explicit `word` and `substring` boundary modes.
+- Added Unicode-aware custom term/phrase rules through `censorRuleFromTerms()` with explicit `word` and `substring` boundary modes.
 - Added rule-pack composition and caller-safe compiled RegExp handling.
 - Added deterministic source-preservation and cursor-state regressions.
 
 ### English pack
 
-- Added `@scrawlix/en` with explicit English strong-profanity rules.
+- Added `@scrawlix/en` with explicit English strong-profanity rules exported as `englishStrongProfanityRules` and `englishStrongProfanityPack`.
 - Added English-specific vowel coverage outside the neutral core.
 - Added positive and clean regression corpora, including false-positive traps.
 
@@ -25,6 +26,8 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added `@scrawlix/react` and `CensoredText`.
 - Added `scrawl`, `bar`, `blur`, `asterisk`, and `grawlix` appearances.
 - Added `hover`, `focus`, `click`, and `never` reveal behavior.
+- Made `reveal="never"` the first-use default while keeping `scrawl` as the default appearance.
+- Added a React Client Component boundary for hook-based reveal behavior.
 - Added keyboard reveal handling and a single-source accessibility contract with rendered regressions.
 - Added the public CSS subpath export.
 
@@ -48,5 +51,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 ### Developer experience
 
 - Added compiled ESM/declaration artifacts for public packages.
-- Added an external tarball consumer smoke test as a CI release gate.
-- Added `AGENTS.md`, `llms.txt`, language-pack docs, DOM lifecycle docs, extension docs, and the first-release runbook.
+- Added an external tarball consumer smoke test as a CI release gate and enabled strict checking of published declaration dependencies in that consumer.
+- Added package-local READMEs for every public package, exact install commands, a top-level integration chooser, a docs index, React CSS troubleshooting, Next.js client-boundary guidance, and clearer source/accessibility notes.
+- Aligned `README.md`, `AGENTS.md`, `llms.txt`, demo, extension, tests, and smoke consumers on the canonical pre-release public names and conservative defaults.
+- Added `docs/releasing.md`, language-pack docs, DOM lifecycle docs, extension docs, and the first-release runbook.

--- a/README.md
+++ b/README.md
@@ -2,28 +2,84 @@
 
 **Programmable censorship for text and the web.**
 
-Scrawlix separates the interesting parts of censorship so they can be mixed deliberately:
+Scrawlix separates four concerns so applications can combine them deliberately:
 
 - **matching** — what semantic term or phrase was found?
-- **coverage** — which part of that match gets covered?
+- **coverage** — which part of that semantic target gets covered?
 - **appearance** — how should the covered part look?
 - **reveal** — when, if ever, should the original text show through?
 
-That means the same word can become `████`, `f███`, `f██k`, `f█ck`, `f**k`, a blur, an inked-over scrawl, or a grawlix — while callers keep control of the underlying source text.
+The same word can become `████`, `f███`, `f██k`, `f█ck`, `f**k`, a blur, an inked-over scrawl, or a grawlix while the caller keeps control of the original source text.
 
-Scrawlix began as a censor/reveal primitive in [Scrapbook](https://github.com/teamleaderleo/scrapbook). The standalone project turns that experiment into a small language-neutral engine with rule packs and adapters for React, Markdown, arbitrary DOMs, and a browser extension built from the same pieces.
+## Choose your path
 
-## Quick start
+| You want to… | Install | Start with |
+| --- | --- | --- |
+| render censored text in React | `@scrawlix/react @scrawlix/en` | `CensoredText` |
+| transform Markdown / HAST | `@scrawlix/rehype @scrawlix/en` | `rehypeScrawlix` |
+| transform an existing webpage / DOM | `@scrawlix/dom @scrawlix/en` | `createDomScrawlix` |
+| match/segment text or build your own renderer | `@scrawlix/core` plus rules | `createScrawlix` |
+| use packaged English strong-profanity rules | `@scrawlix/en` | `englishStrongProfanityRules` |
 
-Scrawlix asks callers to pick a rule pack explicitly:
+The five packages stay deliberately small: core contains no hidden language policy, and adapters receive rules explicitly.
+
+## React — five-minute start
+
+```sh
+npm install @scrawlix/react @scrawlix/en
+```
+
+Import the stylesheet once in your application entry/global CSS path:
+
+```tsx
+import { englishStrongProfanityRules } from '@scrawlix/en';
+import { CensoredText } from '@scrawlix/react';
+import '@scrawlix/react/styles.css';
+
+<CensoredText
+  text="what the fuck"
+  rules={englishStrongProfanityRules}
+/>;
+```
+
+The first-use defaults are deliberately conservative: full semantic-target coverage, `scrawl` appearance, and `reveal="never"`.
+
+Opt into partial coverage and reveal behavior explicitly:
+
+```tsx
+<CensoredText
+  text="what the fuck"
+  rules={englishStrongProfanityRules}
+  coverage="middle"
+  appearance="grawlix"
+  reveal="hover"
+/>;
+```
+
+Current appearances: `scrawl`, `bar`, `blur`, `asterisk`, `grawlix`.
+
+Current reveal modes: `never`, `hover`, `focus`, `click`.
+
+### React CSS and source text
+
+`@scrawlix/react/styles.css` is required for the built-in treatments and the visually-hidden accessibility copy. If text appears duplicated or visibly uncensored, check that import first.
+
+`CensoredText` is reversible presentation. It keeps one exact source copy available to assistive technology and marks the decorative visual tree `aria-hidden="true"`. Secrets or destructive redaction belong upstream; Scrawlix intentionally preserves caller-owned source text.
+
+The React entry is a Client Component, so Next.js App Router consumers can import it across a normal client boundary. Put the global stylesheet in the application’s global CSS path.
+
+## Core
+
+```sh
+npm install @scrawlix/core @scrawlix/en
+```
 
 ```ts
 import { createScrawlix } from '@scrawlix/core';
-import { englishProfanityRules } from '@scrawlix/en';
+import { englishStrongProfanityRules } from '@scrawlix/en';
 
 const scrawlix = createScrawlix({
-  rules: englishProfanityRules,
-  coverage: 'middle',
+  rules: englishStrongProfanityRules,
 });
 
 scrawlix.segment('what the fuck');
@@ -31,83 +87,94 @@ scrawlix.segment('what the fuck');
 
 The English pack understands semantic targets inside larger matches, so `fuck`, `fucking`, and `motherfucker` can all apply coverage specifically to the `fuck` portion.
 
-## React
-
-```tsx
-import { englishProfanityRules } from '@scrawlix/en';
-import { CensoredText } from '@scrawlix/react';
-import '@scrawlix/react/styles.css';
-
-<CensoredText
-  text="what the fuck"
-  rules={englishProfanityRules}
-  coverage="middle"
-  appearance="scrawl"
-  reveal="hover"
-/>;
-```
-
-Current appearances: `scrawl`, `bar`, `blur`, `asterisk`, and `grawlix`.
-
-Current reveal modes: `hover`, `focus`, `click`, and `never`.
+Generic core coverage presets are `full`, `tail`, `middle`, and `inner`. `full` is the engine default; partial coverage is an explicit editorial choice.
 
 ## Markdown / rehype
 
-`@scrawlix/rehype` walks HAST text nodes and marks covered ranges while leaving the source text intact:
+```sh
+npm install @scrawlix/rehype @scrawlix/en
+```
+
+`@scrawlix/rehype` walks HAST text nodes and marks covered ranges while leaving source text intact:
 
 ```tsx
-import { englishProfanityRules } from '@scrawlix/en';
+import { englishStrongProfanityRules } from '@scrawlix/en';
 import { rehypeScrawlix } from '@scrawlix/rehype';
 import ReactMarkdown from 'react-markdown';
 
 <ReactMarkdown
   rehypePlugins={[
-    [
-      rehypeScrawlix,
-      {
-        rules: englishProfanityRules,
-        coverage: 'middle',
-      },
-    ],
+    [rehypeScrawlix, { rules: englishStrongProfanityRules }],
   ]}
 >
   {markdown}
 </ReactMarkdown>;
 ```
 
-Covered fragments become spans carrying `data-scrawlix-cover` and `data-scrawlix-rules`. The adapter keeps appearance policy out of the syntax-tree pass, so a site can style those spans with its own editorial language.
+Covered fragments become spans carrying `data-scrawlix-cover` and `data-scrawlix-rules`. Appearance policy stays outside the syntax-tree pass so a site can style those spans in its own editorial language.
 
-`code`, `pre`, `script`, `style`, and `textarea` subtrees are skipped by default. Applications can add excluded tags, place `data-scrawlix-ignore` on a subtree, or provide a `shouldSkip` predicate. The transformer also skips its own output, so repeated processing stays idempotent.
+`code`, `pre`, `script`, `style`, and `textarea` subtrees are skipped by default. Applications can add excluded tags, place `data-scrawlix-ignore` on a subtree, or provide a `shouldSkip` predicate. The transformer skips its own output so repeated processing remains idempotent.
 
 ## Arbitrary webpages / DOM
 
-`@scrawlix/dom` applies the same rules to an existing DOM and can observe future page mutations:
+```sh
+npm install @scrawlix/dom @scrawlix/en
+```
 
 ```ts
 import { createDomScrawlix } from '@scrawlix/dom';
-import { englishProfanityRules } from '@scrawlix/en';
+import { englishStrongProfanityRules } from '@scrawlix/en';
 
 const censor = createDomScrawlix({
-  rules: englishProfanityRules,
-  coverage: 'middle',
+  rules: englishStrongProfanityRules,
 });
 
 const observation = censor.observe(document.body);
 ```
 
-Only text nodes with actual covered ranges are wrapped. Generated roots use `data-scrawlix-dom-root`; covered fragments use the same `data-scrawlix-cover` and `data-scrawlix-rules` attributes as the rehype adapter.
+Only text nodes with covered ranges are wrapped. Generated roots use `data-scrawlix-dom-root`; covered fragments use the same `data-scrawlix-cover` and `data-scrawlix-rules` attributes as the rehype adapter.
 
-Dynamic observation queues only nodes reported by `MutationObserver`. Turning a site off can be one lifecycle call:
+Turning a site off can be one lifecycle call:
 
 ```ts
 observation.restore();
 ```
 
-That disconnects observation, clears pending work, and restores the controller-owned source strings. Form/editable/code-like regions, non-HTML namespaces, and generated output are skipped by default. See `docs/dom.md` for exclusion and lifecycle details.
+That disconnects observation, clears pending work, and restores controller-owned source strings. Form/editable/code-like regions, non-HTML namespaces, and generated output are skipped by default. See [`docs/dom.md`](docs/dom.md).
+
+## Custom terms and phrases
+
+Profanity is one rule pack. Callers can censor names, spoilers, codenames, or arbitrary phrases:
+
+```ts
+import { censorRuleFromTerms, createScrawlix } from '@scrawlix/core';
+
+const privateTerms = censorRuleFromTerms('private', [
+  'Project Velvet',
+  'Mothbit',
+]);
+
+const censor = createScrawlix({ rules: [privateTerms] });
+```
+
+`censorRuleFromTerms()` uses Unicode-aware word boundaries by default. Packs for scripts where matches can sit directly beside other letters can opt into `boundary: 'substring'`.
+
+## Language packs
+
+`@scrawlix/core` owns matching mechanics and generic positional coverage. Linguistic assumptions live in packages such as `@scrawlix/en`.
+
+The English package currently exports:
+
+- `englishStrongProfanityRules`
+- `englishStrongProfanityPack`
+- `englishVowelCoverage`
+- a regression corpus at `@scrawlix/en/corpus`
+
+Future language packs can carry their own rules, locale metadata, coverage helpers, and regression corpora. Consumers can combine packs with `rulesFromPacks(...)`. See [`docs/language-packs.md`](docs/language-packs.md).
 
 ## Browser extension
 
-The unpacked Manifest V3 extension lives in `apps/extension`. It is a thin application around `@scrawlix/dom` and `@scrawlix/en`: page matching/restoration stays in the packages, while browser storage, per-host preferences, injected presentation, and popup UI stay in the extension.
+The unpacked Manifest V3 extension lives in `apps/extension`. It is a thin application around `@scrawlix/dom` and `@scrawlix/en`: page matching/restoration stays in packages, while browser storage, per-host preferences, injected presentation, and popup UI stay in the extension.
 
 ```sh
 pnpm install
@@ -116,72 +183,24 @@ pnpm build
 
 Then load `apps/extension/dist` as an unpacked extension in a Chromium browser.
 
-The popup currently supports:
-
-- a global on/off switch
-- per-host **follow global / always on / always off** behavior
-- all five appearances
-- all generic coverage modes plus English vowel coverage
-- hover / focus / click / never reveal
-- local custom words and phrases
-
-Small preferences and sparse hostname overrides use `chrome.storage.sync`; custom terms use `chrome.storage.local`. A settings change restores the current page's source text before starting the newly configured observation session.
-
-The development manifest runs automatically on HTTP/HTTPS pages so per-site behavior survives navigation. That broad host access is intentionally called out as a store-release review item; see `apps/extension/README.md` for the permission, privacy, build, and lifecycle notes.
-
-## Custom words and phrases
-
-Profanity is only one rule pack. Callers can censor names, spoilers, codenames, or arbitrary phrases:
-
-```ts
-import { censorRuleFromWords, createScrawlix } from '@scrawlix/core';
-
-const privateTerms = censorRuleFromWords('private', [
-  'Project Velvet',
-  'Mothbit',
-]);
-
-const censor = createScrawlix({
-  rules: [privateTerms],
-  coverage: 'full',
-});
-```
-
-`censorRuleFromWords` uses Unicode-aware word boundaries by default. Packs for scripts where matches can sit directly beside other letters can opt into `boundary: 'substring'`.
-
-## Language packs
-
-`@scrawlix/core` owns matching mechanics and generic coverage (`full`, `tail`, `middle`, `inner`). Linguistic assumptions live in packages such as `@scrawlix/en`.
-
-The English package currently exports:
-
-- `englishProfanityRules`
-- `englishStrongProfanityPack`
-- `englishVowelCoverage`
-- a small regression corpus at `@scrawlix/en/corpus`
-
-Future language packs can carry their own rules, locale metadata, coverage helpers, and regression corpora. Consumers can combine packs with `rulesFromPacks(...)`. See `docs/language-packs.md`.
+The popup supports global and per-host enablement, all five appearances, generic plus English-vowel coverage, all reveal modes, and local custom terms. See [`apps/extension/README.md`](apps/extension/README.md) for permission, privacy, build, and lifecycle notes.
 
 ## Demo
 
-The interactive demo lives in `apps/demo`. It is a small Vite app that consumes the workspace packages exactly like an external React application would.
+The interactive proof sheet lives in `apps/demo` and consumes workspace packages like an external React application.
 
 ```sh
 pnpm install
 pnpm dev
 ```
 
-The demo includes an editable live proof, coverage and reveal controls, a five-style specimen sheet, semantic-match examples, and a live component snippet.
+The demo includes editable live text, coverage/reveal controls, a five-style specimen sheet, semantic-match examples, and a live component snippet.
 
-### Vercel
+## Documentation
 
-The repository includes `vercel.json` at the root. Importing the Git repository into Vercel uses:
+Start with [`docs/README.md`](docs/README.md) for the recipe index. Maintainers and coding agents should also read [`AGENTS.md`](AGENTS.md), which records package responsibilities, invariants, commands, and extension rules.
 
-- install: `pnpm install --no-frozen-lockfile`
-- build: `pnpm build`
-- output: `apps/demo/dist`
-
-The demo builds to static assets.
+The demo serves `llms.txt` with canonical package selection and copy/paste usage for coding agents.
 
 ## Contributing
 
@@ -194,22 +213,8 @@ pnpm build
 pnpm smoke:packages
 ```
 
-`AGENTS.md` is the maintainer/agent map: package responsibilities, invariants, commands, and extension rules. Corpus regressions should be data-first: when a matcher bug teaches us a durable example, add that example to the relevant language corpus.
-
-## Roadmap
-
-- [Core engine: matching, semantic targets, and coverage](https://github.com/teamleaderleo/scrawlix/issues/1)
-- [React adapter and visual presets](https://github.com/teamleaderleo/scrawlix/issues/2)
-- [Rehype adapter](https://github.com/teamleaderleo/scrawlix/issues/3)
-- [DOM adapter](https://github.com/teamleaderleo/scrawlix/issues/4)
-- [Browser extension](https://github.com/teamleaderleo/scrawlix/issues/5)
-- [Scrapbook adoption](https://github.com/teamleaderleo/scrawlix/issues/6)
-- [Interactive demo and deployment](https://github.com/teamleaderleo/scrawlix/issues/8)
-- [Corpus-driven regressions](https://github.com/teamleaderleo/scrawlix/issues/11)
-- [Language packs](https://github.com/teamleaderleo/scrawlix/issues/12)
-- [Human and agent adoption ergonomics](https://github.com/teamleaderleo/scrawlix/issues/13)
-- [First public release readiness](https://github.com/teamleaderleo/scrawlix/issues/18)
+The packed-package smoke test installs real tarballs into a consumer outside the workspace graph, then typechecks and production-builds through public package exports.
 
 ## Status
 
-Early development. The API is being discovered through real use before publication.
+Early development. The public API is being tightened through real consumers before the first npm release. Release readiness is tracked in [issue #18](https://github.com/teamleaderleo/scrawlix/issues/18).

--- a/apps/demo/public/llms.txt
+++ b/apps/demo/public/llms.txt
@@ -1,69 +1,84 @@
 # Scrawlix
 
-Scrawlix is programmable censorship for text and the web. It separates matching, coverage, appearance, and reveal behavior while preserving the caller's original source text.
+Scrawlix is programmable censorship for text and the web. It separates matching, coverage, appearance, and reveal behavior while preserving caller-owned source text.
 
 Source: https://github.com/teamleaderleo/scrawlix
 
 Packages:
 - @scrawlix/core — language-neutral matching and segmentation
-- @scrawlix/en — English profanity rules, English vowel coverage, regression corpus
+- @scrawlix/en — English strong-profanity rules, English vowel coverage, regression corpus
 - @scrawlix/react — React renderer and visual/reveal presets
 - @scrawlix/rehype — HAST/rehype transformer for Markdown-rendered prose
 - @scrawlix/dom — arbitrary-page DOM transformation, restoration, and mutation observation
 
-Applications:
-- apps/demo — interactive proof-sheet demo
-- apps/extension — Manifest V3 browser extension built on @scrawlix/dom
+Choose the smallest package path for the target project. Do not invent aggregate package names or hidden language defaults.
+
+React install:
+
+```sh
+npm install @scrawlix/react @scrawlix/en
+```
 
 Canonical React usage:
 
 ```tsx
-import { englishProfanityRules } from '@scrawlix/en';
+import { englishStrongProfanityRules } from '@scrawlix/en';
 import { CensoredText } from '@scrawlix/react';
 import '@scrawlix/react/styles.css';
 
 <CensoredText
   text="what the fuck"
-  rules={englishProfanityRules}
-  coverage="middle"
-  appearance="scrawl"
-  reveal="hover"
-/>
+  rules={englishStrongProfanityRules}
+/>;
+```
+
+React defaults: `coverage="full"`, `appearance="scrawl"`, `reveal="never"`. Add partial coverage or reveal props only when the application asks for them. The stylesheet import is required for built-in appearances and the visually-hidden accessibility copy. `CensoredText` preserves one exact source copy for assistive technology; it is reversible presentation, not destructive redaction.
+
+Core install:
+
+```sh
+npm install @scrawlix/core @scrawlix/en
 ```
 
 Canonical core usage:
 
 ```ts
 import { createScrawlix } from '@scrawlix/core';
-import { englishProfanityRules } from '@scrawlix/en';
+import { englishStrongProfanityRules } from '@scrawlix/en';
 
 const engine = createScrawlix({
-  rules: englishProfanityRules,
-  coverage: 'middle',
+  rules: englishStrongProfanityRules,
 });
+```
+
+Custom terms and phrases:
+
+```ts
+import { censorRuleFromTerms } from '@scrawlix/core';
+
+const privateTerms = censorRuleFromTerms('private', [
+  'Project Velvet',
+  'Mothbit',
+]);
 ```
 
 Canonical rehype usage:
 
 ```ts
-import { englishProfanityRules } from '@scrawlix/en';
+import { englishStrongProfanityRules } from '@scrawlix/en';
 import { rehypeScrawlix } from '@scrawlix/rehype';
 
-const plugin = [
-  rehypeScrawlix,
-  { rules: englishProfanityRules, coverage: 'middle' },
-];
+const plugin = [rehypeScrawlix, { rules: englishStrongProfanityRules }];
 ```
 
 Canonical arbitrary-page usage:
 
 ```ts
 import { createDomScrawlix } from '@scrawlix/dom';
-import { englishProfanityRules } from '@scrawlix/en';
+import { englishStrongProfanityRules } from '@scrawlix/en';
 
 const controller = createDomScrawlix({
-  rules: englishProfanityRules,
-  coverage: 'middle',
+  rules: englishStrongProfanityRules,
 });
 
 const observation = controller.observe(document.body);
@@ -71,20 +86,19 @@ const observation = controller.observe(document.body);
 observation.restore();
 ```
 
-The browser extension keeps browser state outside reusable packages. Global treatment settings + sparse hostname overrides use chrome.storage.sync; custom terms use chrome.storage.local. Storage changes restore the old DOM session before a newly configured observation begins. Build it with `pnpm build`, then load `apps/extension/dist` as an unpacked Chromium extension.
+Core is deliberately language-neutral. Select language/rule packs explicitly. Generic coverage presets are full, tail, middle, inner. Full coverage is the engine default. English-specific helper: englishVowelCoverage.
 
-The rehype adapter emits spans with `data-scrawlix-cover` and `data-scrawlix-rules`, preserves the original text as text content, and skips code/pre/script/style/textarea by default.
-
-The DOM adapter transforms only matching text nodes, marks controller output with `data-scrawlix-dom-root`, skips editable/form/code/non-HTML regions by default, observes only mutation roots delivered by MutationObserver, and can restore exact controller-owned source strings.
-
-Core is deliberately language-neutral. Select language/rule packs explicitly. Custom names, spoilers, and phrases can be supplied with `censorRuleFromWords()`.
-
-Generic coverage presets: full, tail, middle, inner.
-English-specific helper: englishVowelCoverage.
 React appearances: scrawl, bar, blur, asterisk, grawlix.
-React reveal modes: hover, focus, click, never.
+React reveal modes: never, hover, focus, click.
 
-Maintainer guidance: https://github.com/teamleaderleo/scrawlix/blob/main/AGENTS.md
+The rehype adapter emits spans with `data-scrawlix-cover` and `data-scrawlix-rules`, preserves source as text content, and skips code/pre/script/style/textarea by default.
+
+The DOM adapter transforms only matching eligible text nodes, marks controller output with `data-scrawlix-dom-root`, skips editable/form/code/non-HTML regions by default, observes only mutation roots delivered by MutationObserver, and can restore exact controller-owned source strings.
+
+The browser extension keeps browser state outside reusable packages. Global treatment settings + sparse hostname overrides use chrome.storage.sync; custom terms use chrome.storage.local. Storage changes restore the old DOM session before a newly configured observation begins.
+
+Use only documented public package exports. Maintainer guidance: https://github.com/teamleaderleo/scrawlix/blob/main/AGENTS.md
+Docs index: https://github.com/teamleaderleo/scrawlix/blob/main/docs/README.md
 Language packs: https://github.com/teamleaderleo/scrawlix/blob/main/docs/language-packs.md
 DOM lifecycle: https://github.com/teamleaderleo/scrawlix/blob/main/docs/dom.md
 Extension notes: https://github.com/teamleaderleo/scrawlix/blob/main/apps/extension/README.md

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -1,6 +1,6 @@
 import { type CoveragePreset, type CoverageSelector } from '@scrawlix/core';
 import {
-  englishProfanityRules,
+  englishStrongProfanityRules,
   englishVowelCoverage,
 } from '@scrawlix/en';
 import {
@@ -87,7 +87,7 @@ export function App() {
         ? '  coverage={englishVowelCoverage}'
         : `  coverage="${coverage}"`;
 
-    return `import { englishProfanityRules${coverage === 'vowel' ? ', englishVowelCoverage' : ''} } from '@scrawlix/en';\nimport { CensoredText } from '@scrawlix/react';\n\n<CensoredText\n  text={copy}\n  rules={englishProfanityRules}\n${coverageLine}\n  appearance="${appearance}"\n  reveal="${reveal}"\n/>`;
+    return `import { englishStrongProfanityRules${coverage === 'vowel' ? ', englishVowelCoverage' : ''} } from '@scrawlix/en';\nimport { CensoredText } from '@scrawlix/react';\n\n<CensoredText\n  text={copy}\n  rules={englishStrongProfanityRules}\n${coverageLine}\n  appearance="${appearance}"\n  reveal="${reveal}"\n/>`;
   }, [appearance, coverage, reveal]);
 
   return (
@@ -128,7 +128,7 @@ export function App() {
               appearance={appearance}
               coverage={coverageSelector}
               reveal={reveal}
-              rules={englishProfanityRules}
+              rules={englishStrongProfanityRules}
               text={text}
             />
           </div>
@@ -198,7 +198,7 @@ export function App() {
                       appearance={style}
                       coverage={coverageSelector}
                       reveal="hover"
-                      rules={englishProfanityRules}
+                      rules={englishStrongProfanityRules}
                       text={sample}
                     />
                   </p>

--- a/apps/extension/src/content.ts
+++ b/apps/extension/src/content.ts
@@ -1,6 +1,6 @@
-import { censorRuleFromWords, type CensorRule } from '@scrawlix/core';
+import { censorRuleFromTerms, type CensorRule } from '@scrawlix/core';
 import { createDomScrawlix, type DomObservation } from '@scrawlix/dom';
-import { englishProfanityRules } from '@scrawlix/en';
+import { englishStrongProfanityRules } from '@scrawlix/en';
 import {
   CUSTOM_WORDS_KEY,
   SYNC_SETTINGS_KEY,
@@ -19,9 +19,9 @@ let presentationObserver: MutationObserver | null = null;
 let activeSettings: SyncSettings | null = null;
 let restartGeneration = 0;
 
-function customRule(customWords: readonly string[]): CensorRule[] {
-  if (customWords.length === 0) return [];
-  return [censorRuleFromWords('custom', customWords)];
+function customRule(customTerms: readonly string[]): CensorRule[] {
+  if (customTerms.length === 0) return [];
+  return [censorRuleFromTerms('custom', customTerms)];
 }
 
 function canOwnInteraction(root: HTMLElement) {
@@ -95,7 +95,7 @@ async function restart() {
   if (!document.body || !effectiveEnabled(state.settings, hostname)) return;
 
   const controller = createDomScrawlix({
-    rules: [...englishProfanityRules, ...customRule(state.customWords)],
+    rules: [...englishStrongProfanityRules, ...customRule(state.customWords)],
     coverage: coverageSelector(state.settings.coverage),
   });
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# Scrawlix docs
+
+Start with the repository README for installation and the shortest path for your environment.
+
+## Recipes and design notes
+
+- [`language-packs.md`](./language-packs.md) — author and compose language/rule packs, semantic targets, boundaries, coverage helpers, and corpora
+- [`dom.md`](./dom.md) — arbitrary-page DOM application, observation, exclusions, and exact restoration
+- [`releasing.md`](./releasing.md) — first-release gates, package verification, registry checks, and publication sequence
+- [`../apps/extension/README.md`](../apps/extension/README.md) — extension permissions, storage, build, and page lifecycle
+
+## Choose an integration
+
+- React rendering and reveal behavior: `@scrawlix/react`
+- Markdown / unified / HAST: `@scrawlix/rehype`
+- existing browser DOM or extension content scripts: `@scrawlix/dom`
+- matching/segmentation or a custom renderer: `@scrawlix/core`
+- packaged English rules: `@scrawlix/en`
+
+Each public package has its own README so the npm package page contains a usable quickstart.

--- a/docs/dom.md
+++ b/docs/dom.md
@@ -2,19 +2,26 @@
 
 `@scrawlix/dom` applies Scrawlix to text nodes in an existing webpage. It is intended for browser extensions, enhancement scripts, and other environments where the page did not render through Scrawlix itself.
 
+## Install
+
+```sh
+npm install @scrawlix/dom @scrawlix/en
+```
+
 ## Apply once
 
 ```ts
 import { createDomScrawlix } from '@scrawlix/dom';
-import { englishProfanityRules } from '@scrawlix/en';
+import { englishStrongProfanityRules } from '@scrawlix/en';
 
 const censor = createDomScrawlix({
-  rules: englishProfanityRules,
-  coverage: 'middle',
+  rules: englishStrongProfanityRules,
 });
 
 censor.apply(document.body);
 ```
+
+Core coverage defaults to `full`. Pass another `coverage` selector explicitly when the page should use partial coverage.
 
 Only text nodes containing covered ranges are replaced. Each transformed text node gets one `data-scrawlix-dom-root` wrapper. Covered fragments inside it carry `data-scrawlix-cover` and `data-scrawlix-rules`; their text content remains the original source substring.
 

--- a/docs/language-packs.md
+++ b/docs/language-packs.md
@@ -29,7 +29,6 @@ import { englishStrongProfanityPack } from '@scrawlix/en';
 
 const engine = createScrawlix({
   rules: rulesFromPacks(englishStrongProfanityPack, myPrivateTermsPack),
-  coverage: 'middle',
 });
 ```
 
@@ -37,12 +36,14 @@ Scrawlix deliberately avoids automatic language detection. Applications know mor
 
 ## Boundaries
 
-`censorRuleFromWords()` defaults to `boundary: 'word'`, using Unicode letter/number-aware lookarounds. This works well for many whitespace-delimited words and prevents substring false positives such as a short term firing inside a longer ordinary word.
+`censorRuleFromTerms()` defaults to `boundary: 'word'`, using Unicode letter/number-aware lookarounds. This works well for many whitespace-delimited words and prevents substring false positives such as a short term firing inside a longer ordinary word.
 
 Some scripts and phrase lists need direct substring matching:
 
 ```ts
-const rule = censorRuleFromWords('ja-example', ['くそ'], {
+import { censorRuleFromTerms } from '@scrawlix/core';
+
+const rule = censorRuleFromTerms('ja-example', ['くそ'], {
   boundary: 'substring',
 });
 ```
@@ -74,6 +75,8 @@ Core coverage presets are positional and language-neutral:
 - `middle`
 - `inner`
 
+`full` is the default engine policy. Packs and consumers can choose a different policy explicitly.
+
 Language-specific character classes belong in packs. `@scrawlix/en`, for example, exports `englishVowelCoverage` as a `CoverageSelector` callback instead of teaching core what an English vowel is.
 
 A pack can export several named helpers without changing the core API.
@@ -104,3 +107,16 @@ Prefer narrowly described packs over giant universal lists. Examples:
 - an application-owned private-name pack
 
 A caller can compose several packs. Smaller packs keep policy choices visible and make corpus regressions easier to understand.
+
+## Package author checklist
+
+A publishable third-party pack should contain:
+
+1. a dependency on `@scrawlix/core`
+2. one or more named rule collections plus a `CensorRulePack` export
+3. locale and scope/severity notes
+4. positive and clean/false-positive regression data
+5. tests for semantic targets, casing, punctuation, compounds/inflections, and known ambiguity
+6. an ordinary package README with an install command and copy/paste consumer example
+
+Keep pack-specific presentation and application state outside the pack. Matching policy should remain inspectable as ordinary code/data.

--- a/docs/language-packs.md
+++ b/docs/language-packs.md
@@ -32,11 +32,13 @@ const engine = createScrawlix({
 });
 ```
 
+`rulesFromPacks(...)` copies each rule with its source pack id. `find()` exposes that value as `match.packId`, and coverage callbacks receive the same optional `packId`, so composed rules remain traceable even when different packs use the same local rule id. Caller-authored loose rules can continue to omit pack provenance.
+
 Scrawlix deliberately avoids automatic language detection. Applications know more about their content and can choose one pack, several packs, or caller-authored rules.
 
 ## Boundaries
 
-`censorRuleFromTerms()` defaults to `boundary: 'word'`, using Unicode letter/number-aware lookarounds. This works well for many whitespace-delimited words and prevents substring false positives such as a short term firing inside a longer ordinary word.
+`censorRuleFromTerms()` defaults to `boundary: 'word'`, using Unicode-aware lookarounds. Letters, numbers, combining marks, connector punctuation, ZWNJ, and ZWJ keep a candidate attached to surrounding text. This prevents a boundary from appearing inside many decomposed or connected Unicode sequences while still blocking ordinary substring false positives.
 
 Some scripts and phrase lists need direct substring matching:
 
@@ -64,7 +66,7 @@ const rule = {
 };
 ```
 
-Coverage runs against `core`, while `find()` still reports the full match and both full/target ranges.
+Coverage runs against `core`, while `find()` still reports the full match and both full/target ranges. A declared target group is part of the rule contract: if a produced match cannot resolve that named group, Scrawlix throws a descriptive error instead of widening the target to the full match.
 
 ## Coverage helpers
 
@@ -116,7 +118,7 @@ A publishable third-party pack should contain:
 2. one or more named rule collections plus a `CensorRulePack` export
 3. locale and scope/severity notes
 4. positive and clean/false-positive regression data
-5. tests for semantic targets, casing, punctuation, compounds/inflections, and known ambiguity
+5. tests for semantic targets, casing, punctuation, compounds/inflections, Unicode context, and known ambiguity
 6. an ordinary package README with an install command and copy/paste consumer example
 
 Keep pack-specific presentation and application state outside the pack. Matching policy should remain inspectable as ordinary code/data.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,16 +6,18 @@ Scrawlix is still pre-release. This runbook exists so the first registry publish
 
 Do not publish until all of these are resolved:
 
-1. **npm scope ownership** — the current package names use `@scrawlix/*`. Confirm the npm organization/scope `scrawlix` exists under our control and the publishing account can write public packages there. If it cannot, rename the packages before creating the first registry history.
+1. **npm scope ownership** — the current package names use `@scrawlix/*`. Confirm the npm organization/scope `scrawlix` exists under our control and the publishing identity can write public packages there. If it cannot, rename packages before creating registry history.
 2. **license** — choose an open-source license, add the root license file, and add the matching SPDX `license` field to every publishable package.
-3. **version strategy** — choose the first package version and dist-tag policy. An early `0.x` version published under `next`/`beta` is a reasonable way to preserve API freedom, but this is a maintainer decision.
-4. **release commit** — publish only from a clean `main` commit whose CI is green.
+3. **version strategy** — choose the first package version and dist-tag policy. An early `0.x` version under `next`/`beta` preserves pre-1.0 API freedom.
+4. **reproducible dependency graph** — complete issue #45: commit `pnpm-lock.yaml`, pin pnpm through the root `packageManager` field, and use the same frozen install in CI and release verification.
+5. **trusted publisher** — complete the npm-side trusted-publisher configuration for the GitHub Actions release workflow from #45. Publication should use OIDC instead of a long-lived npm write token.
+6. **release commit** — publish only from a clean `main` commit whose complete CI is green.
 
 The public demo URL can be treated as either a release gate or an immediate follow-up; record that choice in issue #18.
 
 ## Publishable packages
 
-The current public package set is:
+The public package set is:
 
 - `@scrawlix/core`
 - `@scrawlix/en`
@@ -37,9 +39,9 @@ pnpm build
 pnpm smoke:packages
 ```
 
-The packed-package smoke test is a hard release gate. It packs every public package, installs the tarballs into a consumer outside the pnpm workspace, and typechecks/builds the consumer through public exports.
+The packed-package smoke test is a hard release gate. It packs every public package, installs the tarballs into a consumer outside the pnpm workspace, typechecks the public declarations with library checking enabled, and production-builds the consumer through public exports.
 
-Confirm the extension build validator also ran as part of `pnpm build` and produced `apps/extension/dist` successfully.
+Confirm the extension build validator and real Chromium demo/extension smoke tests have also passed in CI on the release commit.
 
 ## 2. Verify package metadata and tarball contents
 
@@ -55,6 +57,7 @@ Before the first publish, inspect each package manifest for:
 - `types`
 - `sideEffects`
 - `publishConfig.access = public`
+- package-specific README
 
 Then perform registry publish dry-runs from the workspace:
 
@@ -68,28 +71,24 @@ pnpm --filter @scrawlix/dom publish --dry-run --access public --tag next
 
 Use the actual chosen prerelease tag in place of `next`.
 
-Review the file list reported by every dry run. Public packages should contain built `dist` output and intended metadata only. In particular, verify:
+Review the file list reported by every dry run. Verify:
 
 - JS entry points exist
 - declaration entry points exist
-- source/declaration maps are present when expected
+- source/declaration maps point somewhere useful
 - `@scrawlix/en/corpus` exists
 - `@scrawlix/react/styles.css` exists
+- each package's README is included
 - tests, workspace fixtures, demo files, and extension files are absent from package tarballs
 - workspace dependency specs are converted into publishable registry ranges by the package manager
 
 ## 3. Verify registry identity before any write
 
-Authenticate with the intended npm account and inspect identity/access:
+Authenticate with the intended npm account and prove the publishing identity controls the `scrawlix` scope. Also search the registry for every final package name.
 
-```sh
-npm whoami
-npm org ls scrawlix
-```
+A missing package name does not prove control of the organization scope; scope access is the authoritative check.
 
-The exact organization command may evolve with npm CLI versions; the requirement is simple: prove the publishing identity has write access to the `scrawlix` scope before publishing `@scrawlix/*`.
-
-Also search the registry for every final package name. A missing package name does not prove ownership of the organization scope; scope access is the authoritative check.
+Configure the npm trusted publisher to the exact GitHub repository and release workflow filename. Keep the workflow on a GitHub-hosted runner and grant the job `id-token: write` plus the minimum read permissions needed for checkout.
 
 ## 4. Version the package set
 
@@ -103,47 +102,26 @@ Until Scrawlix adopts dedicated monorepo version tooling, treat the five public 
 
 Avoid hand-publishing from a dirty tree or from a commit that differs from the reviewed release commit.
 
-## 5. Publish in dependency order
+## 5. Publish through the trusted workflow
 
-`@scrawlix/core` is the dependency root. Publish it first, then packages that depend on it:
+Publish in dependency order: core first, then packages that depend on it.
 
-```sh
-cd packages/core
-pnpm publish --access public --tag next
+The release workflow from #45 should run the same frozen install, verification commands, and package order documented here, then invoke npm publication through trusted publishing. The workflow should carry no long-lived npm write token.
 
-cd ../en
-pnpm publish --access public --tag next
-
-cd ../react
-pnpm publish --access public --tag next
-
-cd ../rehype
-pnpm publish --access public --tag next
-
-cd ../dom
-pnpm publish --access public --tag next
-```
-
-Use the chosen dist-tag. If publishing with 2FA, supply the OTP through the current npm/pnpm flow. If we later move publishing to GitHub Actions, add registry provenance and trusted-publishing controls as part of that workflow instead of copying a local token into CI.
+For a public repository using GitHub OIDC trusted publishing, npm can attach provenance to the published package automatically. Treat that provenance as part of the intended release path.
 
 ## 6. Verify from a clean consumer
 
-After registry publication, create a directory outside the repository and install from the registry:
-
-```sh
-mkdir /tmp/scrawlix-registry-smoke
-cd /tmp/scrawlix-registry-smoke
-pnpm init
-pnpm add @scrawlix/core@next @scrawlix/en@next @scrawlix/react@next @scrawlix/rehype@next @scrawlix/dom@next react react-dom
-```
-
-Use the actual chosen dist-tag.
+After registry publication, create a directory outside the repository and install from the registry using the chosen prerelease tag.
 
 Verify at minimum:
 
 ```ts
-import { createScrawlix } from '@scrawlix/core';
-import { englishProfanityRules } from '@scrawlix/en';
+import { censorRuleFromTerms, createScrawlix } from '@scrawlix/core';
+import {
+  englishStrongProfanityPack,
+  englishStrongProfanityRules,
+} from '@scrawlix/en';
 import { englishProfanityCorpus } from '@scrawlix/en/corpus';
 import { CensoredText } from '@scrawlix/react';
 import '@scrawlix/react/styles.css';
@@ -151,31 +129,31 @@ import { rehypeScrawlix } from '@scrawlix/rehype';
 import { createDomScrawlix } from '@scrawlix/dom';
 ```
 
-Typecheck and production-build that consumer. Confirm the core can find an English match and the public subpath imports resolve.
+Typecheck and production-build that consumer. Confirm core finds an English match, React CSS resolves, and public subpath imports resolve.
 
 ## 7. Inspect public registry pages
 
 For every package, verify the npm page shows the intended:
 
 - version and dist-tag
-- README
+- package-local README
 - repository/homepage links
 - license
 - TypeScript declarations
 - dependencies/peer dependencies
 
-Then add links from the Scrawlix README/demo to the published packages.
+Then add registry links from the repository README/demo.
 
 ## 8. Tag and release notes
 
 After registry verification:
 
 - create the matching Git tag/release from the published commit
-- copy the relevant `CHANGELOG.md` entry into the GitHub release notes
+- copy the relevant `CHANGELOG.md` entry into GitHub release notes
 - include the demo URL if public
-- state the supported package set and the pre-release stability expectation
-- keep browser-store distribution separate from the npm package release unless we intentionally coordinate them
+- state the supported package set and pre-release stability expectation
+- keep browser-store distribution separate from the npm package release unless intentionally coordinated
 
 ## Rollback mindset
 
-npm registry history is durable. Prefer a corrected follow-up version over trying to erase a published mistake. That makes the pre-publish dry run and clean-consumer verification especially valuable for the first release.
+npm registry history is durable. Prefer a corrected follow-up version over trying to erase a published mistake. That makes dry-run tarball review, trusted publication, and clean-consumer verification especially valuable for the first release.

--- a/fixtures/consumer/src/main.tsx
+++ b/fixtures/consumer/src/main.tsx
@@ -1,6 +1,6 @@
 import { createScrawlix } from '@scrawlix/core';
 import { createDomScrawlix } from '@scrawlix/dom';
-import { englishProfanityRules } from '@scrawlix/en';
+import { englishStrongProfanityRules } from '@scrawlix/en';
 import { transformHast } from '@scrawlix/rehype';
 import { CensoredText } from '@scrawlix/react';
 import '@scrawlix/react/styles.css';
@@ -8,7 +8,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 const engine = createScrawlix({
-  rules: englishProfanityRules,
+  rules: englishStrongProfanityRules,
   coverage: 'middle',
 });
 
@@ -30,7 +30,7 @@ const tree: Parameters<typeof transformHast>[0] = {
 };
 
 transformHast(tree, {
-  rules: englishProfanityRules,
+  rules: englishStrongProfanityRules,
   coverage: 'middle',
 });
 
@@ -52,7 +52,7 @@ if (
 const domHost = document.createElement('div');
 domHost.textContent = 'well, fuck';
 const domResult = createDomScrawlix({
-  rules: englishProfanityRules,
+  rules: englishStrongProfanityRules,
   coverage: 'middle',
 }).apply(domHost);
 
@@ -69,7 +69,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       appearance="scrawl"
       coverage="middle"
       reveal="hover"
-      rules={englishProfanityRules}
+      rules={englishStrongProfanityRules}
       text="well, fuck"
     />
   </React.StrictMode>

--- a/fixtures/consumer/tsconfig.json
+++ b/fixtures/consumer/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "skipLibCheck": true
+    "skipLibCheck": false
   },
   "include": ["src"]
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,57 @@
+# @scrawlix/core
+
+Language-neutral matching, semantic targets, and coverage for Scrawlix.
+
+## Install
+
+```sh
+npm install @scrawlix/core
+```
+
+Add a language pack when you want packaged linguistic rules:
+
+```sh
+npm install @scrawlix/core @scrawlix/en
+```
+
+## Quick start
+
+```ts
+import { createScrawlix } from '@scrawlix/core';
+import { englishStrongProfanityRules } from '@scrawlix/en';
+
+const scrawlix = createScrawlix({
+  rules: englishStrongProfanityRules,
+});
+
+const segments = scrawlix.segment('what the fuck');
+```
+
+The engine preserves the caller-owned source string. It reports matches and covered segments; rendering belongs to an adapter such as `@scrawlix/react`, `@scrawlix/rehype`, or `@scrawlix/dom`.
+
+## Custom terms
+
+```ts
+import { censorRuleFromTerms, createScrawlix } from '@scrawlix/core';
+
+const privateTerms = censorRuleFromTerms('private', [
+  'Project Velvet',
+  'Mothbit',
+]);
+
+const scrawlix = createScrawlix({ rules: [privateTerms] });
+```
+
+`censorRuleFromTerms()` uses Unicode-aware word boundaries by default. Use `{ boundary: 'substring' }` deliberately for packs/scripts where adjacent letters are valid.
+
+## Public concepts
+
+- **matching** finds a term or phrase
+- **coverage** chooses which part of the semantic target is covered
+- `find(text)` returns semantic match metadata
+- `segment(text)` returns source-preserving covered/uncovered segments
+- generic coverage presets are `full`, `tail`, `middle`, and `inner`
+
+Scrawlix deliberately has no built-in language or hidden profanity list. Callers select rules explicitly.
+
+See the repository README for framework quickstarts and `docs/language-packs.md` for pack authoring.

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
-  censorRuleFromWords,
+  censorRuleFromTerms,
   createScrawlix,
   rulesFromPacks,
   type CensorRule,
@@ -30,6 +30,11 @@ describe('Scrawlix core', () => {
       { text: 'fuck', covered: false, ruleIds: [] },
     ]);
     expect(createScrawlix().find('fuck')).toEqual([]);
+  });
+
+  it('uses full coverage when rules are supplied without an explicit coverage policy', () => {
+    const scrawlix = createScrawlix({ rules: [semanticRule] });
+    expect(marked(scrawlix.segment('motherfucker'))).toBe('mother[fuck]er');
   });
 
   it('covers a semantic target inside a larger match', () => {
@@ -66,14 +71,14 @@ describe('Scrawlix core', () => {
   });
 
   it('supports custom word and phrase rules', () => {
-    const privateWords = censorRuleFromWords('private', [
+    const privateTerms = censorRuleFromTerms('private', [
       'Mothbit',
       'Luna',
       'C++',
       'Project Velvet',
     ]);
     const scrawlix = createScrawlix({
-      rules: [privateWords],
+      rules: [privateTerms],
       coverage: 'full',
     });
 
@@ -88,8 +93,8 @@ describe('Scrawlix core', () => {
     );
   });
 
-  it('uses Unicode-aware word boundaries for custom words', () => {
-    const cafe = censorRuleFromWords('cafe', ['café']);
+  it('uses Unicode-aware word boundaries for custom terms', () => {
+    const cafe = censorRuleFromTerms('cafe', ['café']);
     const scrawlix = createScrawlix({ rules: [cafe], coverage: 'full' });
 
     expect(marked(scrawlix.segment('caféteria café CAFÉ.'))).toBe(
@@ -98,7 +103,7 @@ describe('Scrawlix core', () => {
   });
 
   it('supports substring boundary mode for scripts without whitespace-delimited words', () => {
-    const japanesePhrase = censorRuleFromWords('ja-example', ['くそ'], {
+    const japanesePhrase = censorRuleFromTerms('ja-example', ['くそ'], {
       boundary: 'substring',
     });
     const scrawlix = createScrawlix({
@@ -124,7 +129,7 @@ describe('Scrawlix core', () => {
 
   it('does not leak compiled RegExp cursor state between calls', () => {
     const scrawlix = createScrawlix({
-      rules: [censorRuleFromWords('secret', ['secret'])],
+      rules: [censorRuleFromTerms('secret', ['secret'])],
       coverage: 'full',
     });
 
@@ -183,11 +188,11 @@ describe('Scrawlix core', () => {
   it('combines explicit rule packs', () => {
     const privatePack = {
       id: 'private',
-      rules: [censorRuleFromWords('private', ['Velvet'])],
+      rules: [censorRuleFromTerms('private', ['Velvet'])],
     };
     const spoilerPack = {
       id: 'spoiler',
-      rules: [censorRuleFromWords('spoiler', ['Rosebud'])],
+      rules: [censorRuleFromTerms('spoiler', ['Rosebud'])],
     };
     const scrawlix = createScrawlix({
       rules: rulesFromPacks(privatePack, spoilerPack),
@@ -202,8 +207,8 @@ describe('Scrawlix core', () => {
   it('preserves core segmentation invariants across deterministic fuzz cases', () => {
     const scrawlix = createScrawlix({
       rules: [
-        censorRuleFromWords('bad', ['bad']),
-        censorRuleFromWords('secret', ['secret']),
+        censorRuleFromTerms('bad', ['bad']),
+        censorRuleFromTerms('secret', ['secret']),
       ],
       coverage: 'middle',
     });

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -10,7 +10,7 @@ import {
 const semanticRule: CensorRule = {
   id: 'semantic-test',
   pattern:
-    /(?<![\p{L}\p{N}_])(?:mother)?(?<core>fuck)(?:ing|ed|er|ers|s)?(?![\p{L}\p{N}_])/giu,
+    /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?:mother)?(?<core>fuck)(?:ing|ed|er|ers|s)?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
   target: { group: 'core' },
 };
 
@@ -60,6 +60,19 @@ describe('Scrawlix core', () => {
     ]);
   });
 
+  it('fails loudly when a configured semantic target group is unavailable', () => {
+    const brokenRule: CensorRule = {
+      id: 'broken-target',
+      pattern: /(?<other>bad)/u,
+      target: { group: 'core' },
+    };
+    const scrawlix = createScrawlix({ rules: [brokenRule] });
+
+    expect(() => scrawlix.find('bad')).toThrow(
+      'Censor rule "broken-target" declares target group "core"'
+    );
+  });
+
   it.each([
     ['full', '[fuck]'],
     ['tail', 'f[uck]'],
@@ -70,7 +83,7 @@ describe('Scrawlix core', () => {
     expect(marked(scrawlix.segment('fuck'))).toBe(expected);
   });
 
-  it('supports custom word and phrase rules', () => {
+  it('supports custom term and phrase rules', () => {
     const privateTerms = censorRuleFromTerms('private', [
       'Mothbit',
       'Luna',
@@ -99,6 +112,16 @@ describe('Scrawlix core', () => {
 
     expect(marked(scrawlix.segment('caféteria café CAFÉ.'))).toBe(
       'caféteria [café] [CAFÉ].'
+    );
+  });
+
+  it('keeps marks, connector punctuation, and join controls inside word context', () => {
+    const bad = censorRuleFromTerms('bad', ['bad']);
+    const scrawlix = createScrawlix({ rules: [bad], coverage: 'full' });
+    const input = 'bad\u0301 bad\u200Dword bad‿word bad';
+
+    expect(marked(scrawlix.segment(input))).toBe(
+      'bad\u0301 bad\u200Dword bad‿word [bad]'
     );
   });
 
@@ -143,6 +166,25 @@ describe('Scrawlix core', () => {
     expect(third).toEqual(first);
   });
 
+  it('advances zero-width Unicode matches across astral characters', () => {
+    const scrawlix = createScrawlix({
+      rules: [{ id: 'mixed', pattern: /(?=🔥)|a/u }],
+      coverage: 'full',
+    });
+
+    expect(scrawlix.find('🔥a')).toEqual([
+      {
+        ruleId: 'mixed',
+        text: 'a',
+        start: 2,
+        end: 3,
+        targetText: 'a',
+        targetStart: 2,
+        targetEnd: 3,
+      },
+    ]);
+  });
+
   it('merges overlapping covered ranges and keeps contributing rule ids', () => {
     const scrawlix = createScrawlix({
       rules: [semanticRule, { id: 'whole', pattern: /motherfucker/gi }],
@@ -185,7 +227,7 @@ describe('Scrawlix core', () => {
     expect(marked(scrawlix.segment('fuck'))).toBe('f[uc]k');
   });
 
-  it('combines explicit rule packs', () => {
+  it('combines explicit rule packs and preserves their provenance', () => {
     const privatePack = {
       id: 'private',
       rules: [censorRuleFromTerms('private', ['Velvet'])],
@@ -202,6 +244,38 @@ describe('Scrawlix core', () => {
     expect(marked(scrawlix.segment('Velvet and Rosebud'))).toBe(
       '[Velvet] and [Rosebud]'
     );
+    expect(
+      scrawlix.find('Velvet and Rosebud').map(match => ({
+        packId: match.packId,
+        ruleId: match.ruleId,
+        text: match.text,
+      }))
+    ).toEqual([
+      { packId: 'private', ruleId: 'private', text: 'Velvet' },
+      { packId: 'spoiler', ruleId: 'spoiler', text: 'Rosebud' },
+    ]);
+  });
+
+  it('distinguishes duplicate rule ids from different packs in find results', () => {
+    const firstPack = {
+      id: 'alpha',
+      rules: [censorRuleFromTerms('shared', ['Velvet'])],
+    };
+    const secondPack = {
+      id: 'beta',
+      rules: [censorRuleFromTerms('shared', ['Velvet'])],
+    };
+    const scrawlix = createScrawlix({
+      rules: rulesFromPacks(firstPack, secondPack),
+      coverage: 'full',
+    });
+
+    expect(
+      scrawlix.find('Velvet').map(match => [match.packId, match.ruleId])
+    ).toEqual([
+      ['alpha', 'shared'],
+      ['beta', 'shared'],
+    ]);
   });
 
   it('preserves core segmentation invariants across deterministic fuzz cases', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -340,9 +340,9 @@ function segmentFromRanges(text: string, ranges: readonly CoveredRange[]) {
   return segments;
 }
 
-export function censorRuleFromWords(
+export function censorRuleFromTerms(
   id: string,
-  words: readonly string[],
+  terms: readonly string[],
   {
     caseSensitive = false,
     coverage,
@@ -353,12 +353,12 @@ export function censorRuleFromWords(
     boundary?: WordBoundaryMode;
   } = {}
 ): CensorRule {
-  const alternatives = [...new Set(words.map(word => word.trim()).filter(Boolean))]
+  const alternatives = [...new Set(terms.map(term => term.trim()).filter(Boolean))]
     .sort((left, right) => right.length - left.length)
     .map(escapeRegExp);
 
   if (alternatives.length === 0) {
-    throw new Error('A censor rule needs at least one non-empty word.');
+    throw new Error('A censor rule needs at least one non-empty term.');
   }
 
   const source = `(?:${alternatives.join('|')})`;
@@ -382,7 +382,7 @@ export function rulesFromPacks(
 
 export function createScrawlix({
   rules = [],
-  coverage = 'middle',
+  coverage = 'full',
 }: ScrawlixOptions = {}): ScrawlixEngine {
   const compiledRules: CompiledRule[] = rules.map(rule => ({
     ...rule,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export type RelativeRange = {
 
 export type CoverageContext = {
   ruleId: string;
+  packId?: string;
   matchText: string;
   targetText: string;
   matchStart: number;
@@ -28,6 +29,8 @@ export type CensorRule = {
   pattern: RegExp;
   target?: CensorTarget;
   coverage?: CoverageSelector;
+  /** Pack provenance attached by rulesFromPacks(). */
+  packId?: string;
 };
 
 export type CensorRulePack = {
@@ -40,6 +43,7 @@ export type WordBoundaryMode = 'word' | 'substring';
 
 export type ScrawlixMatch = {
   ruleId: string;
+  packId?: string;
   text: string;
   start: number;
   end: number;
@@ -83,6 +87,13 @@ const graphemeSegmenter =
   typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
     ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
     : null;
+
+/**
+ * Characters that should keep a custom-term match attached to surrounding text.
+ * Marks and join controls matter here because a boundary inside an extended
+ * grapheme cluster can otherwise turn decomposed/connected text into a false hit.
+ */
+const wordContextClass = '\\p{L}\\p{N}\\p{M}\\p{Pc}\\u200C\\u200D';
 
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -188,6 +199,10 @@ function sanitizeRanges(
     .sort((left, right) => left.start - right.start || left.end - right.end);
 }
 
+function ruleIdentity(rule: CompiledRule) {
+  return rule.packId ? `${rule.packId}:${rule.id}` : rule.id;
+}
+
 function resolveTargetRange(match: RegExpExecArray, rule: CompiledRule) {
   const fullStart = match.index;
   const fullEnd = match.index + match[0].length;
@@ -198,7 +213,9 @@ function resolveTargetRange(match: RegExpExecArray, rule: CompiledRule) {
 
   const groupRange = match.indices?.groups?.[rule.target.group];
   if (!groupRange) {
-    return { start: fullStart, end: fullEnd };
+    throw new Error(
+      `Censor rule "${ruleIdentity(rule)}" declares target group "${rule.target.group}", but that group was unavailable for match "${match[0]}".`
+    );
   }
 
   return { start: groupRange[0], end: groupRange[1] };
@@ -222,6 +239,7 @@ function scan(text: string, rules: readonly CompiledRule[]): ScannedMatch[] {
         rule,
         match: {
           ruleId: rule.id,
+          ...(rule.packId ? { packId: rule.packId } : {}),
           text: rawMatch[0],
           start: rawMatch.index,
           end: rawMatch.index + rawMatch[0].length,
@@ -239,6 +257,7 @@ function scan(text: string, rules: readonly CompiledRule[]): ScannedMatch[] {
     (left, right) =>
       left.match.start - right.match.start ||
       right.match.end - left.match.end ||
+      (left.match.packId ?? '').localeCompare(right.match.packId ?? '') ||
       left.match.ruleId.localeCompare(right.match.ruleId)
   );
 
@@ -255,6 +274,7 @@ function collectCoveredRanges(
     const { match, rule } = scanned;
     const context: CoverageContext = {
       ruleId: match.ruleId,
+      ...(match.packId ? { packId: match.packId } : {}),
       matchText: match.text,
       targetText: match.targetText,
       matchStart: match.start,
@@ -364,7 +384,7 @@ export function censorRuleFromTerms(
   const source = `(?:${alternatives.join('|')})`;
   const boundedSource =
     boundary === 'word'
-      ? `(?<![\\p{L}\\p{N}_])${source}(?![\\p{L}\\p{N}_])`
+      ? `(?<![${wordContextClass}])${source}(?![${wordContextClass}])`
       : source;
 
   return {
@@ -377,7 +397,12 @@ export function censorRuleFromTerms(
 export function rulesFromPacks(
   ...packs: readonly CensorRulePack[]
 ): CensorRule[] {
-  return packs.flatMap(pack => pack.rules);
+  return packs.flatMap(pack =>
+    pack.rules.map(rule => ({
+      ...rule,
+      packId: pack.id,
+    }))
+  );
 }
 
 export function createScrawlix({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,19 @@ function compilePattern(pattern: RegExp) {
   return new RegExp(pattern.source, [...flags].join(''));
 }
 
+function advanceStringIndex(value: string, index: number, unicode: boolean) {
+  if (!unicode) return index + 1;
+  if (index + 1 >= value.length) return index + 1;
+
+  const first = value.charCodeAt(index);
+  if (first < 0xd800 || first > 0xdbff) return index + 1;
+
+  const second = value.charCodeAt(index + 1);
+  if (second < 0xdc00 || second > 0xdfff) return index + 1;
+
+  return index + 2;
+}
+
 function graphemeRanges(value: string): RelativeRange[] {
   if (!value) return [];
 
@@ -230,7 +243,9 @@ function scan(text: string, rules: readonly CompiledRule[]): ScannedMatch[] {
 
     while ((rawMatch = rule.pattern.exec(text)) !== null) {
       if (!rawMatch[0]) {
-        rule.pattern.lastIndex = rawMatch.index + 1;
+        const unicode =
+          rule.pattern.flags.includes('u') || rule.pattern.flags.includes('v');
+        rule.pattern.lastIndex = advanceStringIndex(text, rawMatch.index, unicode);
         continue;
       }
 

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -1,0 +1,36 @@
+# @scrawlix/dom
+
+Apply Scrawlix to existing browser DOM text and optionally observe future mutations.
+
+## Install
+
+```sh
+npm install @scrawlix/dom @scrawlix/en
+```
+
+## Quick start
+
+```ts
+import { createDomScrawlix } from '@scrawlix/dom';
+import { englishStrongProfanityRules } from '@scrawlix/en';
+
+const scrawlix = createDomScrawlix({
+  rules: englishStrongProfanityRules,
+});
+
+const observation = scrawlix.observe(document.body);
+```
+
+When disabling the treatment:
+
+```ts
+observation.restore();
+```
+
+That disconnects observation, clears pending work, and restores controller-owned source strings.
+
+The adapter transforms only matching eligible text nodes. It skips form/editable/code-like regions, non-HTML namespaces, generated Scrawlix output, and ignored subtrees by default.
+
+This package emits semantic wrappers and `data-scrawlix-cover` / `data-scrawlix-rules` attributes. Presentation belongs to the consuming application.
+
+See `docs/dom.md` in the repository for lifecycle, exclusion, and restoration details.

--- a/packages/dom/src/index.test.ts
+++ b/packages/dom/src/index.test.ts
@@ -1,10 +1,10 @@
 /** @vitest-environment jsdom */
 
-import { censorRuleFromWords } from '@scrawlix/core';
+import { censorRuleFromTerms } from '@scrawlix/core';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createDomScrawlix } from './index';
 
-const rules = [censorRuleFromWords('fuck', ['fuck'])] as const;
+const rules = [censorRuleFromTerms('fuck', ['fuck'])] as const;
 
 function controller() {
   return createDomScrawlix({ rules, coverage: 'middle' });

--- a/packages/dom/src/observation.test.ts
+++ b/packages/dom/src/observation.test.ts
@@ -1,10 +1,10 @@
 /** @vitest-environment jsdom */
 
-import { censorRuleFromWords } from '@scrawlix/core';
+import { censorRuleFromTerms } from '@scrawlix/core';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createDomScrawlix } from './index';
 
-const rules = [censorRuleFromWords('fuck', ['fuck'])] as const;
+const rules = [censorRuleFromTerms('fuck', ['fuck'])] as const;
 
 function tick() {
   return new Promise<void>(resolve => setTimeout(resolve, 0));

--- a/packages/en/README.md
+++ b/packages/en/README.md
@@ -1,0 +1,45 @@
+# @scrawlix/en
+
+English rule and coverage helpers for Scrawlix.
+
+## Install
+
+```sh
+npm install @scrawlix/core @scrawlix/en
+```
+
+## Quick start
+
+```ts
+import { createScrawlix } from '@scrawlix/core';
+import { englishStrongProfanityRules } from '@scrawlix/en';
+
+const scrawlix = createScrawlix({
+  rules: englishStrongProfanityRules,
+});
+```
+
+The package also exports `englishStrongProfanityPack` for pack composition and `englishVowelCoverage` for an English-specific coverage policy.
+
+```ts
+import { createScrawlix, rulesFromPacks } from '@scrawlix/core';
+import {
+  englishStrongProfanityPack,
+  englishVowelCoverage,
+} from '@scrawlix/en';
+
+const scrawlix = createScrawlix({
+  rules: rulesFromPacks(englishStrongProfanityPack),
+  coverage: englishVowelCoverage,
+});
+```
+
+Regression data is available from the explicit subpath:
+
+```ts
+import { englishProfanityCorpus } from '@scrawlix/en/corpus';
+```
+
+The current pack is intentionally narrow strong-profanity coverage. It is a reviewable rule pack, not a claim of complete English moderation.
+
+See `docs/language-packs.md` in the repository for authoring and composition guidance.

--- a/packages/en/package.json
+++ b/packages/en/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scrawlix/en",
   "version": "0.0.0",
-  "description": "English profanity rules, coverage helpers, and regression corpora for Scrawlix.",
+  "description": "English strong-profanity rules, coverage helpers, and regression corpora for Scrawlix.",
   "type": "module",
   "sideEffects": false,
   "files": ["dist"],

--- a/packages/en/src/corpus.ts
+++ b/packages/en/src/corpus.ts
@@ -80,5 +80,8 @@ export const englishCleanCorpus: readonly EnglishCorpusCase[] = [
   { id: 'shitake', text: 'shitake mushrooms', matches: [] },
   { id: 'classhole', text: 'classhole', matches: [] },
   { id: 'motherfuckerish', text: 'motherfuckerish', matches: [] },
+  { id: 'fuck-combining-mark-continuation', text: 'fuck\u0301', matches: [] },
+  { id: 'shit-connector-continuation', text: 'shit‿word', matches: [] },
+  { id: 'cunt-join-control-continuation', text: 'cunt\u200Dword', matches: [] },
   { id: 'ordinary-prose', text: 'a perfectly ordinary sentence', matches: [] },
 ] as const;

--- a/packages/en/src/index.test.ts
+++ b/packages/en/src/index.test.ts
@@ -2,8 +2,8 @@ import { createScrawlix, type ScrawlixSegment } from '@scrawlix/core';
 import { describe, expect, it } from 'vitest';
 import { englishCleanCorpus, englishProfanityCorpus } from './corpus';
 import {
-  englishProfanityRules,
   englishStrongProfanityPack,
+  englishStrongProfanityRules,
   englishVowelCoverage,
 } from './index';
 
@@ -15,7 +15,7 @@ function marked(segments: readonly ScrawlixSegment[]) {
 
 describe('@scrawlix/en', () => {
   const engine = createScrawlix({
-    rules: englishProfanityRules,
+    rules: englishStrongProfanityRules,
     coverage: 'full',
   });
 
@@ -36,12 +36,12 @@ describe('@scrawlix/en', () => {
   it('exports a composable language pack with locale metadata', () => {
     expect(englishStrongProfanityPack.id).toBe('en-strong-profanity');
     expect(englishStrongProfanityPack.locale).toBe('en');
-    expect(englishStrongProfanityPack.rules).toBe(englishProfanityRules);
+    expect(englishStrongProfanityPack.rules).toBe(englishStrongProfanityRules);
   });
 
   it('keeps English-specific vowel coverage in the English package', () => {
     const vowelEngine = createScrawlix({
-      rules: englishProfanityRules,
+      rules: englishStrongProfanityRules,
       coverage: englishVowelCoverage,
     });
 

--- a/packages/en/src/index.ts
+++ b/packages/en/src/index.ts
@@ -47,31 +47,31 @@ export const englishStrongProfanityRules: readonly CensorRule[] = [
   {
     id: 'fuck',
     pattern:
-      /(?<![\p{L}\p{N}_])(?:mother)?(?<core>fuck)(?:ing|ed|er|ers|s)?(?![\p{L}\p{N}_])/giu,
+      /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?:mother)?(?<core>fuck)(?:ing|ed|er|ers|s)?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
     target: { group: 'core' },
   },
   {
     id: 'shit',
     pattern:
-      /(?<![\p{L}\p{N}_])(?:bull)?(?<core>shit)(?:ting|ted|ter|ters|s|ty)?(?![\p{L}\p{N}_])/giu,
+      /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?:bull)?(?<core>shit)(?:ting|ted|ter|ters|s|ty)?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
     target: { group: 'core' },
   },
   {
     id: 'bitch',
     pattern:
-      /(?<![\p{L}\p{N}_])(?<core>bitch)(?:es|ing|ed|y)?(?![\p{L}\p{N}_])/giu,
+      /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?<core>bitch)(?:es|ing|ed|y)?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
     target: { group: 'core' },
   },
   {
     id: 'asshole',
     pattern:
-      /(?<![\p{L}\p{N}_])(?<core>asshole)s?(?![\p{L}\p{N}_])/giu,
+      /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?<core>asshole)s?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
     target: { group: 'core' },
   },
   {
     id: 'cunt',
     pattern:
-      /(?<![\p{L}\p{N}_])(?<core>cunt)s?(?![\p{L}\p{N}_])/giu,
+      /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?<core>cunt)s?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
     target: { group: 'core' },
   },
 ] as const;

--- a/packages/en/src/index.ts
+++ b/packages/en/src/index.ts
@@ -43,7 +43,7 @@ export const englishVowelCoverage: CoverageSelector = context =>
     return /[aeiou]/iu.test(grapheme);
   });
 
-export const englishProfanityRules: readonly CensorRule[] = [
+export const englishStrongProfanityRules: readonly CensorRule[] = [
   {
     id: 'fuck',
     pattern:
@@ -79,5 +79,5 @@ export const englishProfanityRules: readonly CensorRule[] = [
 export const englishStrongProfanityPack: CensorRulePack = {
   id: 'en-strong-profanity',
   locale: 'en',
-  rules: englishProfanityRules,
+  rules: englishStrongProfanityRules,
 };

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,60 @@
+# @scrawlix/react
+
+React rendering, appearances, and reveal behavior for Scrawlix.
+
+## Install
+
+```sh
+npm install @scrawlix/react @scrawlix/en
+```
+
+## Quick start
+
+Import the stylesheet once in your application entry point or global stylesheet entry:
+
+```tsx
+import { englishStrongProfanityRules } from '@scrawlix/en';
+import { CensoredText } from '@scrawlix/react';
+import '@scrawlix/react/styles.css';
+
+export function Comment() {
+  return (
+    <CensoredText
+      text="what the fuck"
+      rules={englishStrongProfanityRules}
+    />
+  );
+}
+```
+
+The default presentation covers the complete semantic target with the `scrawl` appearance and keeps it concealed. Opt into partial coverage or reveal behavior explicitly:
+
+```tsx
+<CensoredText
+  text={comment.body}
+  rules={englishStrongProfanityRules}
+  coverage="middle"
+  appearance="grawlix"
+  reveal="hover"
+/>
+```
+
+Built-in appearances: `scrawl`, `bar`, `blur`, `asterisk`, `grawlix`.
+
+Reveal modes: `never`, `hover`, `focus`, `click`.
+
+## CSS import
+
+`@scrawlix/react/styles.css` is required for the built-in visual treatments and the visually-hidden accessibility copy. If source text appears duplicated or uncovered, check this import first.
+
+## Accessibility and source text
+
+`CensoredText` is reversible presentation. It keeps one exact source copy available to assistive technology and marks the decorative visual tree `aria-hidden="true"`. Treat secrets or destructive redaction upstream; Scrawlix intentionally preserves caller-owned source text.
+
+Passive `never`/`hover` modes stay outside the tab order. Keyboard-driven `focus`/`click` modes provide a focus path.
+
+## Next.js App Router
+
+The package entry point is a Client Component because `CensoredText` uses React state for interactive reveal. Import it from Server Components as you would another client-boundary component. Put the global Scrawlix stylesheet in an App Router global CSS entry such as `app/globals.css`/`app/layout.tsx` according to your application's CSS setup.
+
+See the repository README for core, rehype, and arbitrary-DOM paths.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,7 +32,7 @@
     "@scrawlix/core": "workspace:*"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18 <20"
   },
   "devDependencies": {
     "@types/react": "^19.2.7",

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -45,6 +45,17 @@ describe('CensoredText', () => {
     expect(container.querySelector('[data-scrawlix-root]')).toBeNull();
   });
 
+  it('defaults to full coverage with a non-revealing scrawl', () => {
+    const container = render(<CensoredText rules={rules} text="fuck" />);
+    const root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
+    const cover = container.querySelector<HTMLElement>('[data-scrawlix-cover]')!;
+
+    expect(root.dataset.reveal).toBe('never');
+    expect(root.getAttribute('tabindex')).toBeNull();
+    expect(cover.dataset.appearance).toBe('scrawl');
+    expect(cover.textContent).toBe('fuck');
+  });
+
   it('keeps one accessible source copy and hides the visual tree from assistive tech', () => {
     const text = 'well, fuck';
     const container = render(

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   createScrawlix,
   type CensorRule,
@@ -40,9 +42,9 @@ function symbolsFor(text: string, appearance: ScrawlixAppearance) {
 export function CensoredText({
   text,
   rules,
-  coverage = 'middle',
+  coverage = 'full',
   appearance = 'scrawl',
-  reveal = 'hover',
+  reveal = 'never',
   className = '',
   title = 'Censored text',
 }: CensoredTextProps) {

--- a/packages/rehype/README.md
+++ b/packages/rehype/README.md
@@ -1,0 +1,35 @@
+# @scrawlix/rehype
+
+A source-preserving HAST/rehype adapter for Scrawlix.
+
+## Install
+
+```sh
+npm install @scrawlix/rehype @scrawlix/en
+```
+
+Add your normal rehype/unified or Markdown renderer dependencies separately.
+
+## React Markdown quick start
+
+```tsx
+import { englishStrongProfanityRules } from '@scrawlix/en';
+import { rehypeScrawlix } from '@scrawlix/rehype';
+import ReactMarkdown from 'react-markdown';
+
+<ReactMarkdown
+  rehypePlugins={[
+    [rehypeScrawlix, { rules: englishStrongProfanityRules }],
+  ]}
+>
+  {markdown}
+</ReactMarkdown>;
+```
+
+Covered fragments become spans carrying `data-scrawlix-cover` and `data-scrawlix-rules`. The adapter keeps the original source text as text content and leaves visual treatment/reveal policy to your application CSS or renderer.
+
+`code`, `pre`, `script`, `style`, and `textarea` subtrees are skipped by default. You can add excluded tags, use `data-scrawlix-ignore`, or provide `shouldSkip` for application-specific exclusions.
+
+For direct HAST use, import `transformHast`.
+
+See the root README for the adapter chooser and `docs/language-packs.md` for rule-pack authoring.

--- a/packages/rehype/src/index.test.ts
+++ b/packages/rehype/src/index.test.ts
@@ -1,9 +1,9 @@
-import { censorRuleFromWords } from '@scrawlix/core';
+import { censorRuleFromTerms } from '@scrawlix/core';
 import type { Element, Root, RootContent } from 'hast';
 import { describe, expect, it } from 'vitest';
 import { rehypeScrawlix, transformHast } from './index';
 
-const rules = [censorRuleFromWords('fuck', ['fuck'])] as const;
+const rules = [censorRuleFromTerms('fuck', ['fuck'])] as const;
 
 function text(value: string): RootContent {
   return { type: 'text', value };
@@ -59,7 +59,7 @@ function coveredElements(node: Root | RootContent): Element[] {
 
 describe('@scrawlix/rehype', () => {
   it('splits covered ranges while preserving the exact source text', () => {
-    const tree = root(element('p', [text('well, fuck this')]))
+    const tree = root(element('p', [text('well, fuck this')]));
     const original = textContent(tree);
 
     transformHast(tree, { rules, coverage: 'middle' });
@@ -73,7 +73,7 @@ describe('@scrawlix/rehype', () => {
 
   it('transforms text inside ordinary inline elements without replacing the element', () => {
     const link = element('a', [text('fuck')], { href: '/somewhere' });
-    const tree = root(element('p', [text('say '), link, text(' here')]))
+    const tree = root(element('p', [text('say '), link, text(' here')]));
 
     transformHast(tree, { rules, coverage: 'full' });
 
@@ -98,7 +98,7 @@ describe('@scrawlix/rehype', () => {
   it.each(['code', 'pre', 'script', 'style', 'textarea'])(
     'skips <%s> subtrees by default',
     tagName => {
-      const tree = root(element(tagName, [text('fuck')]))
+      const tree = root(element(tagName, [text('fuck')]));
 
       transformHast(tree, { rules, coverage: 'full' });
 
@@ -108,7 +108,7 @@ describe('@scrawlix/rehype', () => {
   );
 
   it('supports additional excluded tags', () => {
-    const tree = root(element('a', [text('fuck')]))
+    const tree = root(element('a', [text('fuck')]));
 
     transformHast(tree, {
       rules,
@@ -146,7 +146,7 @@ describe('@scrawlix/rehype', () => {
   });
 
   it('is idempotent and does not wrap its own covered output again', () => {
-    const tree = root(element('p', [text('fuck')]))
+    const tree = root(element('p', [text('fuck')]));
 
     transformHast(tree, { rules, coverage: 'full' });
     transformHast(tree, { rules, coverage: 'full' });
@@ -156,7 +156,7 @@ describe('@scrawlix/rehype', () => {
   });
 
   it('provides a rehype-compatible transformer factory', () => {
-    const tree = root(element('p', [text('fuck')]))
+    const tree = root(element('p', [text('fuck')]));
     const transform = rehypeScrawlix({ rules, coverage: 'full' });
 
     transform(tree);


### PR DESCRIPTION
## Summary

Turns the cold-start API review into a concrete pre-release cleanup.

### First-use API
- make core default coverage `full`
- make React default reveal `never` while keeping `scrawl` appearance
- add the React `'use client'` boundary
- rename `censorRuleFromWords()` to `censorRuleFromTerms()`
- rename `englishProfanityRules` to `englishStrongProfanityRules`
- bound the React peer range to the currently supported React 18/19 majors

### Adoption docs
- add package-local READMEs for all five public packages
- add a root choose-your-path/install table and five-minute React path
- make the required React CSS import + missing-CSS symptom explicit
- document reversible source/accessibility behavior next to the React quickstart
- add a docs recipe index and stronger language-pack author checklist
- align `AGENTS.md` and `llms.txt` on canonical names/defaults

### Package verification
- update demo, extension, tests, and packed external consumer to canonical names
- typecheck the packed consumer with `skipLibCheck: false`
- record the changes in the changelog
- make reproducible installs + OIDC trusted publishing explicit first-release gates in the release runbook

Progresses #44 and #46. Release reproducibility / trusted publishing remains tracked in #45.