### PR TITLE
Carry match identity into rendering and add per-match reveal

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ scrawlix.segment('what the fuck');
 
 The English pack understands semantic targets inside larger matches, so `fuck`, `fucking`, and `motherfucker` can all apply coverage specifically to the `fuck` portion.
 
+### Match and segment metadata
+
+`find()` returns each sorted semantic match with an opaque render-local `matchId` plus its match/target offsets. `segment()` preserves source offsets on every segment and carries presentation metadata on covered ranges:
+
+- `ruleIds` — rules contributing to the covered union
+- `matchIds` — semantic matches contributing to that union; treat this collection as unordered provenance
+- `revealId` — the disclosure-group key renderers should use for interaction
+- `coverageEdge` — `solo`, `start`, `middle`, or `end`, allowing several covered islands from one disclosure group to read as one visual gesture
+
+The IDs and offsets are local to the source string passed into that `find()` / `segment()` call. React therefore scopes them to one `CensoredText` input. DOM and rehype adapters run against individual source text nodes, so their `m0` identifiers and numeric offsets are source-node local as well.
+
 ## React
 
 ```tsx
@@ -51,7 +62,9 @@ Current appearances: `scrawl`, `bar`, `blur`, `whiteout`, `mosaic`, `asterisk`, 
 
 Current reveal modes: `hover`, `focus`, `click`, and `never`.
 
-The renderer exposes a namespaced presentation contract through `data-scrawlix-root`, `data-scrawlix-appearance`, `data-scrawlix-reveal`, `data-scrawlix-revealed`, `data-scrawlix-cover`, `data-scrawlix-rules`, and optional `data-scrawlix-mask` attributes. Preset styling can be tuned with CSS custom properties including `--scrawlix-ink`, `--scrawlix-surface`, `--scrawlix-bar-height`, `--scrawlix-blur-radius`, and `--scrawlix-mosaic-cell`.
+Reveal scope is independent too. `revealScope="component"` keeps the original whole-component behavior and remains the compatibility default. `revealScope="match"` reveals one disclosure group at a time. Pointer hover/click targets the corresponding covered range; keyboard focus/click uses visually hidden controls outside the `aria-hidden` visual copy and paints focus onto the matching censor mark.
+
+The renderer exposes a namespaced presentation contract through `data-scrawlix-root`, `data-scrawlix-appearance`, `data-scrawlix-reveal`, `data-scrawlix-reveal-scope`, `data-scrawlix-revealed`, `data-scrawlix-cover`, `data-scrawlix-rules`, `data-scrawlix-matches`, `data-scrawlix-reveal-id`, `data-scrawlix-edge`, source-local offset attributes, and optional `data-scrawlix-mask`. Preset styling can be tuned with CSS custom properties including `--scrawlix-ink`, `--scrawlix-surface`, `--scrawlix-bar-height`, `--scrawlix-blur-radius`, and `--scrawlix-mosaic-cell`.
 
 ## Markdown / rehype
 
@@ -77,7 +90,7 @@ import ReactMarkdown from 'react-markdown';
 </ReactMarkdown>;
 ```
 
-Covered fragments become spans carrying `data-scrawlix-cover` and `data-scrawlix-rules`. The adapter keeps appearance policy out of the syntax-tree pass, so a site can style those spans with its own editorial language.
+Covered fragments become spans carrying the same rule/match/reveal/edge metadata used by the other adapters. Numeric offsets and match IDs are local to each HAST text node. The adapter keeps appearance policy out of the syntax-tree pass, so a site can style those spans with its own editorial language.
 
 `code`, `pre`, `script`, `style`, and `textarea` subtrees are skipped by default. Applications can add excluded tags, place `data-scrawlix-ignore` on a subtree, or provide a `shouldSkip` predicate. The transformer also skips its own output, so repeated processing stays idempotent.
 
@@ -97,7 +110,7 @@ const censor = createDomScrawlix({
 const observation = censor.observe(document.body);
 ```
 
-Only text nodes with actual covered ranges are wrapped. Generated roots use `data-scrawlix-dom-root`; covered fragments use the same `data-scrawlix-cover` and `data-scrawlix-rules` attributes as the rehype adapter.
+Only text nodes with actual covered ranges are wrapped. Generated roots use `data-scrawlix-dom-root`; covered fragments carry rule/match/reveal/edge metadata and source-node-local offsets. Each generated root forms its own source unit, so repeated `m0` identifiers across separate wrappers are expected.
 
 Dynamic observation queues only nodes reported by `MutationObserver`. Turning a site off can be one lifecycle call:
 
@@ -173,7 +186,7 @@ pnpm install
 pnpm dev
 ```
 
-The demo includes an editable live proof, coverage and reveal controls, a seven-style specimen sheet, semantic-match examples, and a live component snippet.
+The demo includes an editable live proof, coverage/reveal/reveal-scope controls, a seven-style specimen sheet, semantic-match examples, and a live component snippet.
 
 ### Vercel
 
@@ -214,6 +227,8 @@ pnpm smoke:packages
 - [Appearance DOM/CSS contract](https://github.com/teamleaderleo/scrawlix/issues/26)
 - [Per-match reveal metadata](https://github.com/teamleaderleo/scrawlix/issues/27)
 - [Demo X-ray and specimen lab](https://github.com/teamleaderleo/scrawlix/issues/28)
+- [Custom appearance hooks](https://github.com/teamleaderleo/scrawlix/issues/42)
+- [Gesture-aware and archival censor presets](https://github.com/teamleaderleo/scrawlix/issues/66)
 
 ## Status
 

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -7,6 +7,7 @@ import {
   CensoredText,
   type ScrawlixAppearance,
   type ScrawlixReveal,
+  type ScrawlixRevealScope,
 } from '@scrawlix/react';
 import { useMemo, useState } from 'react';
 
@@ -31,6 +32,7 @@ const coverages: readonly CoverageChoice[] = [
 ];
 
 const reveals: readonly ScrawlixReveal[] = ['hover', 'focus', 'click', 'never'];
+const revealScopes: readonly ScrawlixRevealScope[] = ['match', 'component'];
 
 const defaultText =
   'This fucking delightful little thing can censor shit without flattening every word into the same black rectangle.';
@@ -80,6 +82,7 @@ export function App() {
   const [appearance, setAppearance] = useState<ScrawlixAppearance>('scrawl');
   const [coverage, setCoverage] = useState<CoverageChoice>('middle');
   const [reveal, setReveal] = useState<ScrawlixReveal>('hover');
+  const [revealScope, setRevealScope] = useState<ScrawlixRevealScope>('match');
   const [text, setText] = useState(defaultText);
   const coverageSelector = selectorForCoverage(coverage);
 
@@ -89,8 +92,10 @@ export function App() {
         ? '  coverage={englishVowelCoverage}'
         : `  coverage="${coverage}"`;
 
-    return `import { englishProfanityRules${coverage === 'vowel' ? ', englishVowelCoverage' : ''} } from '@scrawlix/en';\nimport { CensoredText } from '@scrawlix/react';\n\n<CensoredText\n  text={copy}\n  rules={englishProfanityRules}\n${coverageLine}\n  appearance="${appearance}"\n  reveal="${reveal}"\n/>`;
-  }, [appearance, coverage, reveal]);
+    return `import { englishProfanityRules${coverage === 'vowel' ? ', englishVowelCoverage' : ''} } from '@scrawlix/en';\nimport { CensoredText } from '@scrawlix/react';\n\n<CensoredText\n  text={copy}\n  rules={englishProfanityRules}\n${coverageLine}\n  appearance="${appearance}"\n  reveal="${reveal}"\n  revealScope="${revealScope}"\n/>`;
+  }, [appearance, coverage, reveal, revealScope]);
+
+  const proofTarget = revealScope === 'match' ? 'a censored term' : 'the proof';
 
   return (
     <main>
@@ -130,14 +135,16 @@ export function App() {
               appearance={appearance}
               coverage={coverageSelector}
               reveal={reveal}
+              revealScope={revealScope}
               rules={englishProfanityRules}
               text={text}
             />
           </div>
           <p className="proof-hint">
-            {reveal === 'hover' && 'hover the proof to reveal'}
-            {reveal === 'focus' && 'tab into the proof to reveal'}
-            {reveal === 'click' && 'click or press enter to toggle reveal'}
+            {reveal === 'hover' && `hover ${proofTarget} to reveal`}
+            {reveal === 'focus' && `tab to ${proofTarget} to reveal`}
+            {reveal === 'click' &&
+              `click ${proofTarget} or use the keyboard controls to toggle reveal`}
             {reveal === 'never' && 'this proof stays censored'}
           </p>
         </div>
@@ -162,6 +169,12 @@ export function App() {
             onChange={setReveal}
             value={reveal}
             values={reveals}
+          />
+          <SegmentControl
+            label="reveal scope"
+            onChange={setRevealScope}
+            value={revealScope}
+            values={revealScopes}
           />
         </div>
 
@@ -200,6 +213,7 @@ export function App() {
                       appearance={style}
                       coverage={coverageSelector}
                       reveal="hover"
+                      revealScope="match"
                       rules={englishProfanityRules}
                       text={sample}
                     />

--- a/apps/extension/src/content.css
+++ b/apps/extension/src/content.css
@@ -72,34 +72,52 @@
 
 [data-scrawlix-root][data-scrawlix-appearance='mosaic'] [data-scrawlix-cover] {
   -webkit-text-fill-color: transparent;
-  background:
+  background-color: var(--scrawlix-soft-ink);
+  background-image:
     linear-gradient(
-        90deg,
-        var(--scrawlix-ink) 0 24%,
-        transparent 24% 42%,
-        var(--scrawlix-fuzzy-ink) 42% 67%,
-        transparent 67% 78%,
-        var(--scrawlix-ink) 78% 100%
+      90deg,
+      var(--scrawlix-ink) 0 22%,
+      var(--scrawlix-fuzzy-ink) 22% 52%,
+      var(--scrawlix-ink) 52% 73%,
+      var(--scrawlix-soft-ink) 73% 100%
+    ),
+    linear-gradient(
+      90deg,
+      var(--scrawlix-fuzzy-ink) 0 18%,
+      var(--scrawlix-ink) 18% 47%,
+      var(--scrawlix-soft-ink) 47% 69%,
+      var(--scrawlix-ink) 69% 100%
+    ),
+    linear-gradient(
+      90deg,
+      var(--scrawlix-ink) 0 31%,
+      var(--scrawlix-soft-ink) 31% 48%,
+      var(--scrawlix-ink) 48% 78%,
+      var(--scrawlix-fuzzy-ink) 78% 100%
+    );
+  background-position:
+    0 0.03em,
+    var(--scrawlix-mosaic-cell) calc(var(--scrawlix-mosaic-cell) + 0.03em),
+    0 calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) + 0.03em
+      );
+  background-size:
+    calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+          var(--scrawlix-mosaic-cell)
       )
-      0 0 /
-      calc(
-          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
-            var(--scrawlix-mosaic-cell)
-        )
       var(--scrawlix-mosaic-cell),
-    linear-gradient(
-        90deg,
-        var(--scrawlix-soft-ink) 0 31%,
-        var(--scrawlix-ink) 31% 55%,
-        var(--scrawlix-fuzzy-ink) 55% 77%,
-        var(--scrawlix-ink) 77% 100%
+    calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell)
       )
-      var(--scrawlix-mosaic-cell) var(--scrawlix-mosaic-cell) /
-      calc(
-          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
-            var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell)
-        )
+      var(--scrawlix-mosaic-cell),
+    calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+          var(--scrawlix-mosaic-cell)
+      )
       var(--scrawlix-mosaic-cell);
+  background-repeat: repeat-x;
   border-radius: 0.035em;
 }
 

--- a/apps/extension/src/content.css
+++ b/apps/extension/src/content.css
@@ -31,18 +31,20 @@
   -webkit-text-fill-color: transparent;
   background:
     repeating-linear-gradient(
-      -13deg,
-      var(--scrawlix-soft-ink) 0 0.07em,
-      transparent 0.07em 0.16em
+      -11deg,
+      color-mix(in srgb, var(--scrawlix-ink) 74%, transparent) 0 0.055em,
+      transparent 0.055em 0.12em,
+      color-mix(in srgb, var(--scrawlix-ink) 46%, transparent) 0.12em 0.18em,
+      transparent 0.18em 0.23em
     ),
     repeating-linear-gradient(
-      9deg,
-      transparent 0 0.09em,
-      var(--scrawlix-fuzzy-ink) 0.09em 0.13em,
-      transparent 0.13em 0.23em
+      7deg,
+      transparent 0 0.075em,
+      color-mix(in srgb, var(--scrawlix-ink) 84%, transparent) 0.075em 0.105em,
+      transparent 0.105em 0.17em
     );
-  border-radius: 0.16em;
-  text-shadow: 0 0 0.3em var(--scrawlix-fuzzy-ink);
+  border-radius: 0.1em;
+  text-shadow: 0 0 0.16em color-mix(in srgb, var(--scrawlix-ink) 46%, transparent);
 }
 
 [data-scrawlix-root][data-scrawlix-appearance='bar'] [data-scrawlix-cover] {
@@ -63,19 +65,42 @@
     0.94em no-repeat;
   border-radius: 0.04em;
   box-shadow:
-    inset 0 0.055em color-mix(in srgb, var(--scrawlix-ink) 10%, transparent),
-    inset 0 -0.055em color-mix(in srgb, var(--scrawlix-ink) 7%, transparent);
+    inset 0 0.055em color-mix(in srgb, var(--scrawlix-ink) 12%, transparent),
+    inset 0 -0.055em color-mix(in srgb, var(--scrawlix-ink) 8%, transparent),
+    0 0.045em 0.09em color-mix(in srgb, var(--scrawlix-ink) 12%, transparent);
 }
 
 [data-scrawlix-root][data-scrawlix-appearance='mosaic'] [data-scrawlix-cover] {
   -webkit-text-fill-color: transparent;
-  background: repeating-conic-gradient(
-      from 45deg,
-      var(--scrawlix-ink) 0 25%,
-      var(--scrawlix-soft-ink) 0 50%
-    )
-    center / var(--scrawlix-mosaic-cell) var(--scrawlix-mosaic-cell);
-  border-radius: 0.04em;
+  background:
+    linear-gradient(
+        90deg,
+        var(--scrawlix-ink) 0 24%,
+        transparent 24% 42%,
+        var(--scrawlix-fuzzy-ink) 42% 67%,
+        transparent 67% 78%,
+        var(--scrawlix-ink) 78% 100%
+      )
+      0 0 /
+      calc(
+          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+            var(--scrawlix-mosaic-cell)
+        )
+      var(--scrawlix-mosaic-cell),
+    linear-gradient(
+        90deg,
+        var(--scrawlix-soft-ink) 0 31%,
+        var(--scrawlix-ink) 31% 55%,
+        var(--scrawlix-fuzzy-ink) 55% 77%,
+        var(--scrawlix-ink) 77% 100%
+      )
+      var(--scrawlix-mosaic-cell) var(--scrawlix-mosaic-cell) /
+      calc(
+          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+            var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell)
+        )
+      var(--scrawlix-mosaic-cell);
+  border-radius: 0.035em;
 }
 
 [data-scrawlix-root] [data-scrawlix-cover][data-scrawlix-mask] {

--- a/packages/core/src/disclosure.test.ts
+++ b/packages/core/src/disclosure.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { createScrawlix, type CensorRule } from './index';
+
+describe('Scrawlix disclosure grouping', () => {
+  it('keeps every island of a match in one disclosure cluster when another rule overlaps one island', () => {
+    const primary: CensorRule = {
+      id: 'primary',
+      pattern: /abcdef/giu,
+      coverage: () => [
+        { start: 1, end: 2 },
+        { start: 4, end: 5 },
+      ],
+    };
+    const overlapping: CensorRule = {
+      id: 'overlap',
+      pattern: /bc/giu,
+      coverage: 'full',
+    };
+    const engine = createScrawlix({
+      rules: [primary, overlapping],
+      coverage: 'full',
+    });
+
+    const covered = engine.segment('abcdef').filter(segment => segment.covered);
+
+    expect(covered.map(segment => segment.text)).toEqual(['bc', 'e']);
+    expect(covered.map(segment => segment.revealId)).toEqual([
+      'g:1:5:m0+m1',
+      'g:1:5:m0+m1',
+    ]);
+    expect(covered.map(segment => segment.coverageEdge)).toEqual(['start', 'end']);
+    expect(new Set(covered[0]!.matchIds)).toEqual(new Set(['m0', 'm1']));
+    expect(covered[1]!.matchIds).toEqual(['m0']);
+  });
+
+  it('keeps independent match clusters independent', () => {
+    const engine = createScrawlix({
+      rules: [
+        { id: 'first', pattern: /abc/giu, coverage: 'full' },
+        { id: 'second', pattern: /xyz/giu, coverage: 'full' },
+      ],
+    });
+
+    const covered = engine.segment('abc xyz').filter(segment => segment.covered);
+    expect(covered.map(segment => segment.revealId)).toEqual(['m0', 'm1']);
+    expect(covered.map(segment => segment.coverageEdge)).toEqual(['solo', 'solo']);
+  });
+});

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -51,7 +51,7 @@ describe('Scrawlix core', () => {
 
     expect(scrawlix.find('motherfucker')).toEqual([
       {
-        id: 'm0',
+        matchId: 'm0',
         ruleId: 'semantic-test',
         text: 'motherfucker',
         start: 0,
@@ -143,7 +143,7 @@ describe('Scrawlix core', () => {
 
     expect(second).toEqual(first);
     expect(afterFind).toHaveLength(2);
-    expect(afterFind.map(match => match.id)).toEqual(['m0', 'm1']);
+    expect(afterFind.map(match => match.matchId)).toEqual(['m0', 'm1']);
     expect(third).toEqual(first);
   });
 
@@ -190,10 +190,10 @@ describe('Scrawlix core', () => {
       covered: true,
       start: 0,
       end: 12,
-      matchIds: ['m0', 'm1'],
       revealId: 'g:0:12:m0+m1',
       coverageEdge: 'solo',
     });
+    expect(new Set(segments[0]!.matchIds)).toEqual(new Set(['m0', 'm1']));
     expect([...segments[0]!.ruleIds].sort()).toEqual([
       'semantic-test',
       'whole',

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -27,7 +27,14 @@ function source(segments: readonly ScrawlixSegment[]) {
 describe('Scrawlix core', () => {
   it('is language-neutral and does nothing until rules are supplied', () => {
     expect(createScrawlix().segment('fuck')).toEqual([
-      { text: 'fuck', covered: false, ruleIds: [] },
+      {
+        text: 'fuck',
+        covered: false,
+        start: 0,
+        end: 4,
+        ruleIds: [],
+        matchIds: [],
+      },
     ]);
     expect(createScrawlix().find('fuck')).toEqual([]);
   });
@@ -44,6 +51,7 @@ describe('Scrawlix core', () => {
 
     expect(scrawlix.find('motherfucker')).toEqual([
       {
+        id: 'm0',
         ruleId: 'semantic-test',
         text: 'motherfucker',
         start: 0,
@@ -135,10 +143,41 @@ describe('Scrawlix core', () => {
 
     expect(second).toEqual(first);
     expect(afterFind).toHaveLength(2);
+    expect(afterFind.map(match => match.id)).toEqual(['m0', 'm1']);
     expect(third).toEqual(first);
   });
 
-  it('merges overlapping covered ranges and keeps contributing rule ids', () => {
+  it('gives separate matches separate reveal ids', () => {
+    const scrawlix = createScrawlix({
+      rules: [censorRuleFromWords('secret', ['secret'])],
+      coverage: 'middle',
+    });
+    const covered = scrawlix
+      .segment('secret and secret')
+      .filter(segment => segment.covered);
+
+    expect(covered).toHaveLength(2);
+    expect(covered.map(segment => segment.matchIds)).toEqual([['m0'], ['m1']]);
+    expect(covered.map(segment => segment.revealId)).toEqual(['m0', 'm1']);
+    expect(covered.map(segment => segment.coverageEdge)).toEqual(['solo', 'solo']);
+  });
+
+  it('shares one reveal id across disjoint coverage islands from the same match', () => {
+    const scrawlix = createScrawlix({
+      rules: [censorRuleFromWords('secret', ['secret'])],
+      coverage: () => [
+        { start: 1, end: 2 },
+        { start: 4, end: 5 },
+      ],
+    });
+    const covered = scrawlix.segment('secret').filter(segment => segment.covered);
+
+    expect(covered.map(segment => segment.text)).toEqual(['e', 'e']);
+    expect(covered.map(segment => segment.revealId)).toEqual(['m0', 'm0']);
+    expect(covered.map(segment => segment.coverageEdge)).toEqual(['start', 'end']);
+  });
+
+  it('merges overlapping covered ranges into one disclosure group', () => {
     const scrawlix = createScrawlix({
       rules: [semanticRule, { id: 'whole', pattern: /motherfucker/gi }],
       coverage: 'full',
@@ -149,6 +188,11 @@ describe('Scrawlix core', () => {
     expect(segments[0]).toMatchObject({
       text: 'motherfucker',
       covered: true,
+      start: 0,
+      end: 12,
+      matchIds: ['m0', 'm1'],
+      revealId: 'g:0:12:m0+m1',
+      coverageEdge: 'solo',
     });
     expect([...segments[0]!.ruleIds].sort()).toEqual([
       'semantic-test',
@@ -237,14 +281,25 @@ describe('Scrawlix core', () => {
 
       expect(source(first)).toBe(text);
       expect(second).toEqual(first);
+      let cursor = 0;
       for (const segment of first) {
         expect(segment.text.length).toBeGreaterThan(0);
+        expect(segment.start).toBe(cursor);
+        expect(segment.end - segment.start).toBe(segment.text.length);
+        cursor = segment.end;
         if (segment.covered) {
           expect(segment.ruleIds.length).toBeGreaterThan(0);
+          expect(segment.matchIds.length).toBeGreaterThan(0);
+          expect(segment.revealId).toBeTruthy();
+          expect(segment.coverageEdge).toBeTruthy();
         } else {
           expect(segment.ruleIds).toEqual([]);
+          expect(segment.matchIds).toEqual([]);
+          expect(segment.revealId).toBeUndefined();
+          expect(segment.coverageEdge).toBeUndefined();
         }
       }
+      expect(cursor).toBe(text.length);
     }
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,7 +39,7 @@ export type CensorRulePack = {
 export type WordBoundaryMode = 'word' | 'substring';
 
 export type ScrawlixMatch = {
-  id: string;
+  matchId: string;
   ruleId: string;
   text: string;
   start: number;
@@ -76,7 +76,7 @@ type CompiledRule = Omit<CensorRule, 'pattern'> & {
   pattern: RegExp;
 };
 
-type MatchWithoutId = Omit<ScrawlixMatch, 'id'>;
+type MatchWithoutId = Omit<ScrawlixMatch, 'matchId'>;
 
 type ScannedMatch = {
   match: MatchWithoutId;
@@ -266,7 +266,7 @@ function scan(text: string, rules: readonly CompiledRule[]): IdentifiedScannedMa
   return matches.map((scanned, index) => ({
     rule: scanned.rule,
     match: {
-      id: `m${index}`,
+      matchId: `m${index}`,
       ...scanned.match,
     },
   }));
@@ -302,7 +302,7 @@ function collectCoveredRanges(
         start: match.targetStart + relative.start,
         end: match.targetStart + relative.end,
         ruleIds: new Set([match.ruleId]),
-        matchIds: new Set([match.id]),
+        matchIds: new Set([match.matchId]),
       });
     }
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -334,49 +334,84 @@ function mergeCoveredRanges(ranges: readonly CoveredRange[]) {
   return merged;
 }
 
-function revealIdForRange(range: CoveredRange) {
-  const matchIds = [...range.matchIds].sort();
-  if (matchIds.length === 1) return matchIds[0]!;
-  return `g:${range.start}:${range.end}:${matchIds.join('+')}`;
-}
-
-function addCoverageEdges(
+function addDisclosureMetadata(
   ranges: readonly CoveredRange[]
 ): PresentedCoveredRange[] {
-  const prepared = ranges.map(range => ({
-    ...range,
-    revealId: revealIdForRange(range),
-  }));
-  const groupIndexes = new Map<string, number[]>();
+  if (ranges.length === 0) return [];
 
-  prepared.forEach((range, index) => {
-    const indexes = groupIndexes.get(range.revealId) ?? [];
-    indexes.push(index);
-    groupIndexes.set(range.revealId, indexes);
+  const parents = ranges.map((_, index) => index);
+
+  function find(index: number): number {
+    const parent = parents[index]!;
+    if (parent === index) return index;
+    const root = find(parent);
+    parents[index] = root;
+    return root;
+  }
+
+  function union(left: number, right: number) {
+    const leftRoot = find(left);
+    const rightRoot = find(right);
+    if (leftRoot !== rightRoot) parents[rightRoot] = leftRoot;
+  }
+
+  const firstRangeByMatch = new Map<string, number>();
+  ranges.forEach((range, index) => {
+    for (const matchId of range.matchIds) {
+      const firstIndex = firstRangeByMatch.get(matchId);
+      if (firstIndex === undefined) firstRangeByMatch.set(matchId, index);
+      else union(firstIndex, index);
+    }
   });
 
+  const groupIndexes = new Map<number, number[]>();
+  ranges.forEach((_, index) => {
+    const root = find(index);
+    const indexes = groupIndexes.get(root) ?? [];
+    indexes.push(index);
+    groupIndexes.set(root, indexes);
+  });
+
+  const revealIds = new Map<number, string>();
   const edges = new Map<number, ScrawlixCoverageEdge>();
+
   for (const indexes of groupIndexes.values()) {
-    if (indexes.length === 1) {
-      edges.set(indexes[0]!, 'solo');
-      continue;
+    const matchIds = new Set<string>();
+    let start = Number.POSITIVE_INFINITY;
+    let end = Number.NEGATIVE_INFINITY;
+
+    for (const index of indexes) {
+      const range = ranges[index]!;
+      start = Math.min(start, range.start);
+      end = Math.max(end, range.end);
+      for (const matchId of range.matchIds) matchIds.add(matchId);
     }
 
+    const sortedMatchIds = [...matchIds].sort();
+    const revealId =
+      sortedMatchIds.length === 1
+        ? sortedMatchIds[0]!
+        : `g:${start}:${end}:${sortedMatchIds.join('+')}`;
+
     indexes.forEach((index, position) => {
+      revealIds.set(index, revealId);
       edges.set(
         index,
-        position === 0
-          ? 'start'
-          : position === indexes.length - 1
-            ? 'end'
-            : 'middle'
+        indexes.length === 1
+          ? 'solo'
+          : position === 0
+            ? 'start'
+            : position === indexes.length - 1
+              ? 'end'
+              : 'middle'
       );
     });
   }
 
-  return prepared.map((range, index) => ({
+  return ranges.map((range, index) => ({
     ...range,
-    coverageEdge: edges.get(index) ?? 'solo',
+    revealId: revealIds.get(index)!,
+    coverageEdge: edges.get(index)!,
   }));
 }
 
@@ -488,7 +523,7 @@ export function createScrawlix({
       }
 
       const matches = scan(text, compiledRules);
-      const coveredRanges = addCoverageEdges(
+      const coveredRanges = addDisclosureMetadata(
         mergeCoveredRanges(collectCoveredRanges(matches, coverage))
       );
       return segmentFromRanges(text, coveredRanges);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export type CensorRulePack = {
 export type WordBoundaryMode = 'word' | 'substring';
 
 export type ScrawlixMatch = {
+  id: string;
   ruleId: string;
   text: string;
   start: number;
@@ -48,10 +49,17 @@ export type ScrawlixMatch = {
   targetEnd: number;
 };
 
+export type ScrawlixCoverageEdge = 'solo' | 'start' | 'middle' | 'end';
+
 export type ScrawlixSegment = {
   text: string;
   covered: boolean;
+  start: number;
+  end: number;
   ruleIds: readonly string[];
+  matchIds: readonly string[];
+  revealId?: string;
+  coverageEdge?: ScrawlixCoverageEdge;
 };
 
 export type ScrawlixOptions = {
@@ -68,7 +76,14 @@ type CompiledRule = Omit<CensorRule, 'pattern'> & {
   pattern: RegExp;
 };
 
+type MatchWithoutId = Omit<ScrawlixMatch, 'id'>;
+
 type ScannedMatch = {
+  match: MatchWithoutId;
+  rule: CompiledRule;
+};
+
+type IdentifiedScannedMatch = {
   match: ScrawlixMatch;
   rule: CompiledRule;
 };
@@ -77,6 +92,12 @@ type CoveredRange = {
   start: number;
   end: number;
   ruleIds: Set<string>;
+  matchIds: Set<string>;
+};
+
+type PresentedCoveredRange = CoveredRange & {
+  revealId: string;
+  coverageEdge: ScrawlixCoverageEdge;
 };
 
 const graphemeSegmenter =
@@ -204,7 +225,7 @@ function resolveTargetRange(match: RegExpExecArray, rule: CompiledRule) {
   return { start: groupRange[0], end: groupRange[1] };
 }
 
-function scan(text: string, rules: readonly CompiledRule[]): ScannedMatch[] {
+function scan(text: string, rules: readonly CompiledRule[]): IdentifiedScannedMatch[] {
   const matches: ScannedMatch[] = [];
 
   for (const rule of rules) {
@@ -242,11 +263,17 @@ function scan(text: string, rules: readonly CompiledRule[]): ScannedMatch[] {
       left.match.ruleId.localeCompare(right.match.ruleId)
   );
 
-  return matches;
+  return matches.map((scanned, index) => ({
+    rule: scanned.rule,
+    match: {
+      id: `m${index}`,
+      ...scanned.match,
+    },
+  }));
 }
 
 function collectCoveredRanges(
-  matches: readonly ScannedMatch[],
+  matches: readonly IdentifiedScannedMatch[],
   defaultCoverage: CoverageSelector
 ) {
   const ranges: CoveredRange[] = [];
@@ -275,6 +302,7 @@ function collectCoveredRanges(
         start: match.targetStart + relative.start,
         end: match.targetStart + relative.end,
         ruleIds: new Set([match.ruleId]),
+        matchIds: new Set([match.id]),
       });
     }
   }
@@ -293,20 +321,82 @@ function mergeCoveredRanges(ranges: readonly CoveredRange[]) {
         start: range.start,
         end: range.end,
         ruleIds: new Set(range.ruleIds),
+        matchIds: new Set(range.matchIds),
       });
       continue;
     }
 
     previous.end = Math.max(previous.end, range.end);
     for (const ruleId of range.ruleIds) previous.ruleIds.add(ruleId);
+    for (const matchId of range.matchIds) previous.matchIds.add(matchId);
   }
 
   return merged;
 }
 
-function segmentFromRanges(text: string, ranges: readonly CoveredRange[]) {
+function revealIdForRange(range: CoveredRange) {
+  const matchIds = [...range.matchIds].sort();
+  if (matchIds.length === 1) return matchIds[0]!;
+  return `g:${range.start}:${range.end}:${matchIds.join('+')}`;
+}
+
+function addCoverageEdges(
+  ranges: readonly CoveredRange[]
+): PresentedCoveredRange[] {
+  const prepared = ranges.map(range => ({
+    ...range,
+    revealId: revealIdForRange(range),
+  }));
+  const groupIndexes = new Map<string, number[]>();
+
+  prepared.forEach((range, index) => {
+    const indexes = groupIndexes.get(range.revealId) ?? [];
+    indexes.push(index);
+    groupIndexes.set(range.revealId, indexes);
+  });
+
+  const edges = new Map<number, ScrawlixCoverageEdge>();
+  for (const indexes of groupIndexes.values()) {
+    if (indexes.length === 1) {
+      edges.set(indexes[0]!, 'solo');
+      continue;
+    }
+
+    indexes.forEach((index, position) => {
+      edges.set(
+        index,
+        position === 0
+          ? 'start'
+          : position === indexes.length - 1
+            ? 'end'
+            : 'middle'
+      );
+    });
+  }
+
+  return prepared.map((range, index) => ({
+    ...range,
+    coverageEdge: edges.get(index) ?? 'solo',
+  }));
+}
+
+function plainSegment(text: string, start: number, end: number): ScrawlixSegment {
+  return {
+    text: text.slice(start, end),
+    covered: false,
+    start,
+    end,
+    ruleIds: [],
+    matchIds: [],
+  };
+}
+
+function segmentFromRanges(
+  text: string,
+  ranges: readonly PresentedCoveredRange[]
+) {
   if (ranges.length === 0) {
-    return [{ text, covered: false, ruleIds: [] }] satisfies ScrawlixSegment[];
+    return [plainSegment(text, 0, text.length)] satisfies ScrawlixSegment[];
   }
 
   const segments: ScrawlixSegment[] = [];
@@ -314,27 +404,24 @@ function segmentFromRanges(text: string, ranges: readonly CoveredRange[]) {
 
   for (const range of ranges) {
     if (range.start > cursor) {
-      segments.push({
-        text: text.slice(cursor, range.start),
-        covered: false,
-        ruleIds: [],
-      });
+      segments.push(plainSegment(text, cursor, range.start));
     }
 
     segments.push({
       text: text.slice(range.start, range.end),
       covered: true,
+      start: range.start,
+      end: range.end,
       ruleIds: [...range.ruleIds],
+      matchIds: [...range.matchIds],
+      revealId: range.revealId,
+      coverageEdge: range.coverageEdge,
     });
     cursor = range.end;
   }
 
   if (cursor < text.length) {
-    segments.push({
-      text: text.slice(cursor),
-      covered: false,
-      ruleIds: [],
-    });
+    segments.push(plainSegment(text, cursor, text.length));
   }
 
   return segments;
@@ -397,12 +484,12 @@ export function createScrawlix({
 
     segment(text) {
       if (!text || compiledRules.length === 0) {
-        return [{ text, covered: false, ruleIds: [] }];
+        return [plainSegment(text, 0, text.length)];
       }
 
       const matches = scan(text, compiledRules);
-      const coveredRanges = mergeCoveredRanges(
-        collectCoveredRanges(matches, coverage)
+      const coveredRanges = addCoverageEdges(
+        mergeCoveredRanges(collectCoveredRanges(matches, coverage))
       );
       return segmentFromRanges(text, coveredRanges);
     },

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -155,6 +155,15 @@ function coverElement(document: Document, segment: ScrawlixSegment) {
   const element = document.createElement('span');
   element.setAttribute('data-scrawlix-cover', '');
   element.setAttribute('data-scrawlix-rules', segment.ruleIds.join(','));
+  element.setAttribute('data-scrawlix-matches', segment.matchIds.join(','));
+  element.setAttribute('data-scrawlix-start', String(segment.start));
+  element.setAttribute('data-scrawlix-end', String(segment.end));
+  if (segment.revealId) {
+    element.setAttribute('data-scrawlix-reveal-id', segment.revealId);
+  }
+  if (segment.coverageEdge) {
+    element.setAttribute('data-scrawlix-edge', segment.coverageEdge);
+  }
   element.append(document.createTextNode(segment.text));
   return element;
 }

--- a/packages/dom/src/metadata.test.ts
+++ b/packages/dom/src/metadata.test.ts
@@ -1,0 +1,30 @@
+/** @vitest-environment jsdom */
+
+import { censorRuleFromWords } from '@scrawlix/core';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createDomScrawlix } from './index';
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('@scrawlix/dom match metadata', () => {
+  it('projects segment identity and coverage edges onto cover spans', () => {
+    document.body.innerHTML = '<p>well, fuck this</p>';
+    const controller = createDomScrawlix({
+      rules: [censorRuleFromWords('fuck', ['fuck'])],
+      coverage: 'middle',
+    });
+
+    controller.apply(document.body);
+
+    const cover = document.querySelector<HTMLElement>('[data-scrawlix-cover]')!;
+    expect(cover.textContent).toBe('uc');
+    expect(cover.dataset.scrawlixRules).toBe('fuck');
+    expect(cover.dataset.scrawlixMatches).toBe('m0');
+    expect(cover.dataset.scrawlixRevealId).toBe('m0');
+    expect(cover.dataset.scrawlixEdge).toBe('solo');
+    expect(cover.dataset.scrawlixStart).toBe('7');
+    expect(cover.dataset.scrawlixEnd).toBe('9');
+  });
+});

--- a/packages/react/src/control-isolation.test.tsx
+++ b/packages/react/src/control-isolation.test.tsx
@@ -1,0 +1,106 @@
+/** @vitest-environment jsdom */
+
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CensoredText } from './index';
+
+const rules = [{ id: 'fuck', pattern: /fuck/giu }] as const;
+const mountedRoots: Array<{ root: Root; container: HTMLDivElement }> = [];
+
+function render(element: ReactElement) {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+  mountedRoots.push({ root, container });
+  act(() => root.render(element));
+  return container;
+}
+
+afterEach(() => {
+  while (mountedRoots.length > 0) {
+    const mounted = mountedRoots.pop()!;
+    act(() => mounted.root.unmount());
+    mounted.container.remove();
+  }
+});
+
+describe('per-match reveal control isolation', () => {
+  it('does not bubble an internal control click into a clickable parent', () => {
+    const parentClick = vi.fn();
+    const container = render(
+      <div onClick={parentClick}>
+        <CensoredText
+          coverage="middle"
+          reveal="click"
+          revealScope="match"
+          rules={rules}
+          text="fuck"
+        />
+      </div>
+    );
+    const control = container.querySelector<HTMLButtonElement>(
+      '[data-scrawlix-control]'
+    )!;
+    const cover = container.querySelector<HTMLElement>('[data-scrawlix-cover]')!;
+
+    act(() => control.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+    expect(cover.dataset.scrawlixRevealed).toBe('true');
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it.each(['Enter', ' ', 'Escape'])('keeps %j inside the reveal control', key => {
+    const parentKeyDown = vi.fn();
+    const container = render(
+      <div onKeyDown={parentKeyDown}>
+        <CensoredText
+          coverage="middle"
+          reveal="click"
+          revealScope="match"
+          rules={rules}
+          text="fuck"
+        />
+      </div>
+    );
+    const control = container.querySelector<HTMLButtonElement>(
+      '[data-scrawlix-control]'
+    )!;
+
+    act(() =>
+      control.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          key,
+        })
+      )
+    );
+
+    expect(parentKeyDown).not.toHaveBeenCalled();
+  });
+
+  it('swallows focus-mode control activation without creating click reveal state', () => {
+    const parentClick = vi.fn();
+    const container = render(
+      <div onClick={parentClick}>
+        <CensoredText
+          coverage="middle"
+          reveal="focus"
+          revealScope="match"
+          rules={rules}
+          text="fuck"
+        />
+      </div>
+    );
+    const control = container.querySelector<HTMLButtonElement>(
+      '[data-scrawlix-control]'
+    )!;
+    const cover = container.querySelector<HTMLElement>('[data-scrawlix-cover]')!;
+
+    act(() => control.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+    expect(cover.dataset.scrawlixRevealed).toBe('false');
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -3,7 +3,13 @@ import {
   type CensorRule,
   type CoverageSelector,
 } from '@scrawlix/core';
-import { useMemo, useState, type KeyboardEvent } from 'react';
+import {
+  useMemo,
+  useState,
+  type FocusEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+} from 'react';
 
 export type ScrawlixAppearance =
   | 'scrawl'
@@ -15,6 +21,7 @@ export type ScrawlixAppearance =
   | 'grawlix';
 
 export type ScrawlixReveal = 'hover' | 'focus' | 'click' | 'never';
+export type ScrawlixRevealScope = 'component' | 'match';
 
 export type CensoredTextProps = {
   text: string;
@@ -22,6 +29,7 @@ export type CensoredTextProps = {
   coverage?: CoverageSelector;
   appearance?: ScrawlixAppearance;
   reveal?: ScrawlixReveal;
+  revealScope?: ScrawlixRevealScope;
   className?: string;
   title?: string;
 };
@@ -50,12 +58,22 @@ function maskFor(text: string, appearance: ScrawlixAppearance) {
   return '';
 }
 
+function revealIdFromTarget(target: EventTarget | null) {
+  if (!(target instanceof Element)) return null;
+  return (
+    target
+      .closest<HTMLElement>('[data-scrawlix-cover][data-scrawlix-reveal-id]')
+      ?.getAttribute('data-scrawlix-reveal-id') ?? null
+  );
+}
+
 export function CensoredText({
   text,
   rules,
   coverage = 'middle',
   appearance = 'scrawl',
   reveal = 'hover',
+  revealScope = 'component',
   className = '',
   title = 'Censored text',
 }: CensoredTextProps) {
@@ -63,20 +81,104 @@ export function CensoredText({
     () => createScrawlix({ rules, coverage }),
     [rules, coverage]
   );
-  const segments = engine.segment(text);
+  const segments = useMemo(() => engine.segment(text), [engine, text]);
   const hasCoveredText = segments.some(segment => segment.covered);
-  const [revealed, setRevealed] = useState(false);
+  const revealIds = useMemo(
+    () => [
+      ...new Set(
+        segments
+          .filter(segment => segment.covered && segment.revealId)
+          .map(segment => segment.revealId!)
+      ),
+    ],
+    [segments]
+  );
+  const [componentRevealed, setComponentRevealed] = useState(false);
+  const [revealedIds, setRevealedIds] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
+  const [hoveredRevealId, setHoveredRevealId] = useState<string | null>(null);
+  const [focusedRevealId, setFocusedRevealId] = useState<string | null>(null);
 
   if (!hasCoveredText) return <>{text}</>;
 
-  const interactive = reveal === 'focus' || reveal === 'click';
+  const componentInteractive =
+    revealScope === 'component' && (reveal === 'focus' || reveal === 'click');
+  const matchControls =
+    revealScope === 'match' && (reveal === 'focus' || reveal === 'click');
 
-  function onKeyDown(event: KeyboardEvent<HTMLSpanElement>) {
-    if (reveal !== 'click') return;
+  function toggleRevealId(revealId: string) {
+    setRevealedIds(current => {
+      const next = new Set(current);
+      if (next.has(revealId)) next.delete(revealId);
+      else next.add(revealId);
+      return next;
+    });
+  }
+
+  function onRootKeyDown(event: KeyboardEvent<HTMLSpanElement>) {
+    if (revealScope !== 'component' || reveal !== 'click') return;
+    if (event.key === 'Escape') {
+      setComponentRevealed(false);
+      return;
+    }
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
-      setRevealed(value => !value);
+      setComponentRevealed(value => !value);
     }
+  }
+
+  function onRootClick(event: MouseEvent<HTMLSpanElement>) {
+    if (reveal !== 'click') return;
+    if (revealScope === 'component') {
+      setComponentRevealed(value => !value);
+      return;
+    }
+
+    const revealId = revealIdFromTarget(event.target);
+    if (revealId) toggleRevealId(revealId);
+  }
+
+  function onRootMouseOver(event: MouseEvent<HTMLSpanElement>) {
+    if (revealScope !== 'match' || reveal !== 'hover') return;
+    setHoveredRevealId(revealIdFromTarget(event.target));
+  }
+
+  function onControlFocus(revealId: string) {
+    setFocusedRevealId(revealId);
+  }
+
+  function onControlBlur(event: FocusEvent<HTMLButtonElement>) {
+    const next = event.relatedTarget;
+    if (
+      next instanceof HTMLElement &&
+      next.hasAttribute('data-scrawlix-control')
+    ) {
+      return;
+    }
+    setFocusedRevealId(null);
+  }
+
+  function onControlKeyDown(
+    event: KeyboardEvent<HTMLButtonElement>,
+    revealId: string
+  ) {
+    if (event.key !== 'Escape') return;
+    event.preventDefault();
+    setRevealedIds(current => {
+      if (!current.has(revealId)) return current;
+      const next = new Set(current);
+      next.delete(revealId);
+      return next;
+    });
+  }
+
+  function isMatchRevealed(revealId: string | undefined) {
+    if (!revealId || revealScope !== 'match') return false;
+    if (reveal === 'hover') return hoveredRevealId === revealId;
+    if (reveal === 'focus') return focusedRevealId === revealId;
+    if (reveal === 'click') return revealedIds.has(revealId);
+    return false;
   }
 
   return (
@@ -85,26 +187,70 @@ export function CensoredText({
       data-scrawlix-root
       data-scrawlix-appearance={appearance}
       data-scrawlix-reveal={reveal}
-      data-scrawlix-revealed={revealed ? 'true' : 'false'}
-      tabIndex={interactive ? 0 : undefined}
-      onClick={reveal === 'click' ? () => setRevealed(value => !value) : undefined}
-      onKeyDown={onKeyDown}
+      data-scrawlix-reveal-scope={revealScope}
+      data-scrawlix-revealed={componentRevealed ? 'true' : 'false'}
+      tabIndex={componentInteractive ? 0 : undefined}
+      onClick={reveal === 'click' ? onRootClick : undefined}
+      onKeyDown={onRootKeyDown}
+      onMouseLeave={
+        revealScope === 'match' && reveal === 'hover'
+          ? () => setHoveredRevealId(null)
+          : undefined
+      }
+      onMouseOver={
+        revealScope === 'match' && reveal === 'hover'
+          ? onRootMouseOver
+          : undefined
+      }
     >
       <span data-scrawlix-a11y>{text}</span>
+      {matchControls && (
+        <span data-scrawlix-controls>
+          {revealIds.map((revealId, index) => {
+            const isRevealed = revealedIds.has(revealId);
+            const verb = reveal === 'click' && isRevealed ? 'Conceal' : 'Reveal';
+            return (
+              <button
+                aria-label={`${verb} censored text ${index + 1} of ${revealIds.length}`}
+                data-scrawlix-control
+                data-scrawlix-reveal-id={revealId}
+                key={revealId}
+                onBlur={onControlBlur}
+                onClick={
+                  reveal === 'click' ? () => toggleRevealId(revealId) : undefined
+                }
+                onFocus={() => onControlFocus(revealId)}
+                onKeyDown={event => onControlKeyDown(event, revealId)}
+                type="button"
+              />
+            );
+          })}
+        </span>
+      )}
       <span aria-hidden="true" data-scrawlix-visual>
         {segments.map((segment, index) => {
           if (!segment.covered) {
-            return <span key={`${index}-${segment.text}`}>{segment.text}</span>;
+            return <span key={`${index}-${segment.start}`}>{segment.text}</span>;
           }
 
           const mask = maskFor(segment.text, appearance);
+          const matchRevealed = isMatchRevealed(segment.revealId);
+          const matchFocused =
+            revealScope === 'match' && focusedRevealId === segment.revealId;
 
           return (
             <span
               data-scrawlix-cover
+              data-scrawlix-edge={segment.coverageEdge}
+              data-scrawlix-end={segment.end}
+              data-scrawlix-focused={matchFocused ? 'true' : 'false'}
               data-scrawlix-mask={mask || undefined}
+              data-scrawlix-matches={segment.matchIds.join(',')}
+              data-scrawlix-reveal-id={segment.revealId}
+              data-scrawlix-revealed={matchRevealed ? 'true' : 'false'}
               data-scrawlix-rules={segment.ruleIds.join(',')}
-              key={`${index}-${segment.text}`}
+              data-scrawlix-start={segment.start}
+              key={`${index}-${segment.start}`}
               title={title}
             >
               {segment.text}

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -83,6 +83,17 @@ function revealIdFromTarget(target: EventTarget | null) {
   );
 }
 
+function hasSelectedText(root: HTMLElement) {
+  const selection = root.ownerDocument.defaultView?.getSelection();
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+    return false;
+  }
+
+  return [selection.anchorNode, selection.focusNode].some(
+    node => node !== null && root.contains(node)
+  );
+}
+
 export function CensoredText({
   text,
   rules,
@@ -195,7 +206,7 @@ export function CensoredText({
   }
 
   function onRootClick(event: MouseEvent<HTMLSpanElement>) {
-    if (reveal !== 'click') return;
+    if (reveal !== 'click' || hasSelectedText(event.currentTarget)) return;
     if (revealScope === 'component') {
       setComponentRevealed(value => !value);
       return;

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -4,6 +4,7 @@ import {
   type CoverageSelector,
 } from '@scrawlix/core';
 import {
+  useEffect,
   useMemo,
   useState,
   type FocusEvent,
@@ -99,6 +100,13 @@ export function CensoredText({
   );
   const [hoveredRevealId, setHoveredRevealId] = useState<string | null>(null);
   const [focusedRevealId, setFocusedRevealId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setComponentRevealed(false);
+    setRevealedIds(new Set());
+    setHoveredRevealId(null);
+    setFocusedRevealId(null);
+  }, [engine, text, reveal, revealScope]);
 
   if (!hasCoveredText) return <>{text}</>;
 

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -4,7 +4,6 @@ import {
   type CoverageSelector,
 } from '@scrawlix/core';
 import {
-  useEffect,
   useMemo,
   useState,
   type FocusEvent,
@@ -35,7 +34,23 @@ export type CensoredTextProps = {
   title?: string;
 };
 
+type ComponentRevealState = {
+  revision: object;
+  revealed: boolean;
+};
+
+type RevealIdsState = {
+  revision: object;
+  ids: ReadonlySet<string>;
+};
+
+type ActiveRevealState = {
+  revision: object;
+  revealId: string | null;
+};
+
 const GRAWLIX = '@#$%&!';
+const EMPTY_REVEAL_IDS: ReadonlySet<string> = new Set();
 const graphemeSegmenter =
   typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
     ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
@@ -83,6 +98,10 @@ export function CensoredText({
     [rules, coverage]
   );
   const segments = useMemo(() => engine.segment(text), [engine, text]);
+  const interactionRevision = useMemo(
+    () => ({}),
+    [engine, text, reveal, revealScope]
+  );
   const hasCoveredText = segments.some(segment => segment.covered);
   const revealIds = useMemo(
     () => [
@@ -94,34 +113,73 @@ export function CensoredText({
     ],
     [segments]
   );
-  const [componentRevealed, setComponentRevealed] = useState(false);
-  const [revealedIds, setRevealedIds] = useState<ReadonlySet<string>>(
-    () => new Set()
-  );
-  const [hoveredRevealId, setHoveredRevealId] = useState<string | null>(null);
-  const [focusedRevealId, setFocusedRevealId] = useState<string | null>(null);
-
-  useEffect(() => {
-    setComponentRevealed(false);
-    setRevealedIds(new Set());
-    setHoveredRevealId(null);
-    setFocusedRevealId(null);
-  }, [engine, text, reveal, revealScope]);
+  const [componentRevealState, setComponentRevealState] =
+    useState<ComponentRevealState>(() => ({
+      revision: interactionRevision,
+      revealed: false,
+    }));
+  const [revealIdsState, setRevealIdsState] = useState<RevealIdsState>(() => ({
+    revision: interactionRevision,
+    ids: new Set(),
+  }));
+  const [hoverState, setHoverState] = useState<ActiveRevealState>(() => ({
+    revision: interactionRevision,
+    revealId: null,
+  }));
+  const [focusState, setFocusState] = useState<ActiveRevealState>(() => ({
+    revision: interactionRevision,
+    revealId: null,
+  }));
 
   if (!hasCoveredText) return <>{text}</>;
 
+  const componentRevealed =
+    componentRevealState.revision === interactionRevision &&
+    componentRevealState.revealed;
+  const revealedIds =
+    revealIdsState.revision === interactionRevision
+      ? revealIdsState.ids
+      : EMPTY_REVEAL_IDS;
+  const hoveredRevealId =
+    hoverState.revision === interactionRevision ? hoverState.revealId : null;
+  const focusedRevealId =
+    focusState.revision === interactionRevision ? focusState.revealId : null;
   const componentInteractive =
     revealScope === 'component' && (reveal === 'focus' || reveal === 'click');
   const matchControls =
     revealScope === 'match' && (reveal === 'focus' || reveal === 'click');
 
+  function setComponentRevealed(
+    update: boolean | ((current: boolean) => boolean)
+  ) {
+    setComponentRevealState(current => {
+      const currentValue =
+        current.revision === interactionRevision ? current.revealed : false;
+      return {
+        revision: interactionRevision,
+        revealed:
+          typeof update === 'function' ? update(currentValue) : update,
+      };
+    });
+  }
+
   function toggleRevealId(revealId: string) {
-    setRevealedIds(current => {
-      const next = new Set(current);
+    setRevealIdsState(current => {
+      const next = new Set(
+        current.revision === interactionRevision ? current.ids : EMPTY_REVEAL_IDS
+      );
       if (next.has(revealId)) next.delete(revealId);
       else next.add(revealId);
-      return next;
+      return { revision: interactionRevision, ids: next };
     });
+  }
+
+  function setHoveredRevealId(revealId: string | null) {
+    setHoverState({ revision: interactionRevision, revealId });
+  }
+
+  function setFocusedRevealId(revealId: string | null) {
+    setFocusState({ revision: interactionRevision, revealId });
   }
 
   function onRootKeyDown(event: KeyboardEvent<HTMLSpanElement>) {
@@ -173,11 +231,12 @@ export function CensoredText({
   ) {
     if (event.key !== 'Escape') return;
     event.preventDefault();
-    setRevealedIds(current => {
-      if (!current.has(revealId)) return current;
-      const next = new Set(current);
+    setRevealIdsState(current => {
+      const next = new Set(
+        current.revision === interactionRevision ? current.ids : EMPTY_REVEAL_IDS
+      );
       next.delete(revealId);
-      return next;
+      return { revision: interactionRevision, ids: next };
     });
   }
 
@@ -220,6 +279,7 @@ export function CensoredText({
             return (
               <button
                 aria-label={`${verb} censored text ${index + 1} of ${revealIds.length}`}
+                aria-pressed={reveal === 'click' ? isRevealed : undefined}
                 data-scrawlix-control
                 data-scrawlix-reveal-id={revealId}
                 key={revealId}

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -236,10 +236,21 @@ export function CensoredText({
     setFocusedRevealId(null);
   }
 
+  function onControlClick(
+    event: MouseEvent<HTMLButtonElement>,
+    revealId: string
+  ) {
+    event.stopPropagation();
+    if (reveal === 'click') toggleRevealId(revealId);
+  }
+
   function onControlKeyDown(
     event: KeyboardEvent<HTMLButtonElement>,
     revealId: string
   ) {
+    if (event.key === 'Enter' || event.key === ' ' || event.key === 'Escape') {
+      event.stopPropagation();
+    }
     if (event.key !== 'Escape') return;
     event.preventDefault();
     setRevealIdsState(current => {
@@ -295,9 +306,7 @@ export function CensoredText({
                 data-scrawlix-reveal-id={revealId}
                 key={revealId}
                 onBlur={onControlBlur}
-                onClick={
-                  reveal === 'click' ? () => toggleRevealId(revealId) : undefined
-                }
+                onClick={event => onControlClick(event, revealId)}
                 onFocus={() => onControlFocus(revealId)}
                 onKeyDown={event => onControlKeyDown(event, revealId)}
                 type="button"

--- a/packages/react/src/match-reveal.test.tsx
+++ b/packages/react/src/match-reveal.test.tsx
@@ -18,6 +18,7 @@ function render(element: ReactElement) {
 }
 
 afterEach(() => {
+  window.getSelection()?.removeAllRanges();
   while (mountedRoots.length > 0) {
     const mounted = mountedRoots.pop()!;
     act(() => mounted.root.unmount());
@@ -92,6 +93,36 @@ describe('CensoredText per-match reveal', () => {
     act(() => covers[1]!.dispatchEvent(new MouseEvent('click', { bubbles: true })));
     expect(covers[0]!.dataset.scrawlixRevealed).toBe('true');
     expect(covers[1]!.dataset.scrawlixRevealed).toBe('true');
+  });
+
+  it('keeps revealed text open while the user has selected it', () => {
+    const container = render(
+      <CensoredText
+        coverage="middle"
+        reveal="click"
+        revealScope="match"
+        rules={rules}
+        text="fuck"
+      />
+    );
+    const cover = container.querySelector<HTMLElement>('[data-scrawlix-cover]')!;
+
+    act(() => cover.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(cover.dataset.scrawlixRevealed).toBe('true');
+
+    const selection = window.getSelection()!;
+    const range = document.createRange();
+    range.selectNodeContents(cover);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    expect(selection.isCollapsed).toBe(false);
+
+    act(() => cover.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(cover.dataset.scrawlixRevealed).toBe('true');
+
+    selection.removeAllRanges();
+    act(() => cover.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(cover.dataset.scrawlixRevealed).toBe('false');
   });
 
   it('reveals every disjoint coverage island from the same match together', () => {

--- a/packages/react/src/match-reveal.test.tsx
+++ b/packages/react/src/match-reveal.test.tsx
@@ -1,0 +1,149 @@
+/** @vitest-environment jsdom */
+
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CensoredText } from './index';
+
+const rules = [{ id: 'fuck', pattern: /fuck/giu }] as const;
+const mountedRoots: Array<{ root: Root; container: HTMLDivElement }> = [];
+
+function render(element: ReactElement) {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+  mountedRoots.push({ root, container });
+  act(() => root.render(element));
+  return container;
+}
+
+afterEach(() => {
+  while (mountedRoots.length > 0) {
+    const mounted = mountedRoots.pop()!;
+    act(() => mounted.root.unmount());
+    mounted.container.remove();
+  }
+});
+
+describe('CensoredText per-match reveal', () => {
+  it('exposes match identity, offsets, and edge metadata on cover spans', () => {
+    const container = render(
+      <CensoredText
+        coverage="middle"
+        revealScope="match"
+        rules={rules}
+        text="fuck and fuck"
+      />
+    );
+    const covers = container.querySelectorAll<HTMLElement>('[data-scrawlix-cover]');
+
+    expect(covers).toHaveLength(2);
+    expect(covers[0]!.dataset.scrawlixMatches).toBe('m0');
+    expect(covers[0]!.dataset.scrawlixRevealId).toBe('m0');
+    expect(covers[0]!.dataset.scrawlixEdge).toBe('solo');
+    expect(covers[0]!.dataset.scrawlixStart).toBe('1');
+    expect(covers[0]!.dataset.scrawlixEnd).toBe('3');
+    expect(covers[1]!.dataset.scrawlixMatches).toBe('m1');
+    expect(covers[1]!.dataset.scrawlixRevealId).toBe('m1');
+  });
+
+  it('toggles one matched term without revealing its neighbor', () => {
+    const container = render(
+      <CensoredText
+        coverage="middle"
+        reveal="click"
+        revealScope="match"
+        rules={rules}
+        text="fuck and fuck"
+      />
+    );
+    const covers = container.querySelectorAll<HTMLElement>('[data-scrawlix-cover]');
+
+    act(() => covers[0]!.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(covers[0]!.dataset.scrawlixRevealed).toBe('true');
+    expect(covers[1]!.dataset.scrawlixRevealed).toBe('false');
+
+    act(() => covers[1]!.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(covers[0]!.dataset.scrawlixRevealed).toBe('true');
+    expect(covers[1]!.dataset.scrawlixRevealed).toBe('true');
+  });
+
+  it('reveals every disjoint coverage island from the same match together', () => {
+    const container = render(
+      <CensoredText
+        coverage={() => [
+          { start: 1, end: 2 },
+          { start: 2, end: 3 },
+        ]}
+        reveal="click"
+        revealScope="match"
+        rules={rules}
+        text="fuck"
+      />
+    );
+    const covers = container.querySelectorAll<HTMLElement>('[data-scrawlix-cover]');
+
+    // Touching coverage ranges stay as separate visual islands, but share one match id.
+    expect(covers).toHaveLength(2);
+    expect(covers[0]!.dataset.scrawlixRevealId).toBe('m0');
+    expect(covers[1]!.dataset.scrawlixRevealId).toBe('m0');
+
+    act(() => covers[0]!.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(covers[0]!.dataset.scrawlixRevealed).toBe('true');
+    expect(covers[1]!.dataset.scrawlixRevealed).toBe('true');
+  });
+
+  it('provides keyboard controls without making the aria-hidden visual tree focusable', () => {
+    const container = render(
+      <CensoredText
+        coverage="middle"
+        reveal="click"
+        revealScope="match"
+        rules={rules}
+        text="fuck and fuck"
+      />
+    );
+    const root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
+    const visual = root.querySelector<HTMLElement>('[data-scrawlix-visual]')!;
+    const controls = root.querySelectorAll<HTMLButtonElement>('[data-scrawlix-control]');
+    const covers = visual.querySelectorAll<HTMLElement>('[data-scrawlix-cover]');
+
+    expect(root.getAttribute('tabindex')).toBeNull();
+    expect(visual.getAttribute('aria-hidden')).toBe('true');
+    expect(covers[0]!.getAttribute('tabindex')).toBeNull();
+    expect(controls).toHaveLength(2);
+
+    act(() => controls[0]!.dispatchEvent(new FocusEvent('focusin', { bubbles: true })));
+    expect(covers[0]!.dataset.scrawlixFocused).toBe('true');
+    expect(covers[1]!.dataset.scrawlixFocused).toBe('false');
+
+    act(() => controls[0]!.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(covers[0]!.dataset.scrawlixRevealed).toBe('true');
+    expect(covers[1]!.dataset.scrawlixRevealed).toBe('false');
+
+    act(() =>
+      controls[0]!.dispatchEvent(
+        new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: 'Escape' })
+      )
+    );
+    expect(covers[0]!.dataset.scrawlixRevealed).toBe('false');
+  });
+
+  it('uses keyboard focus itself as the reveal trigger in focus mode', () => {
+    const container = render(
+      <CensoredText
+        coverage="middle"
+        reveal="focus"
+        revealScope="match"
+        rules={rules}
+        text="fuck and fuck"
+      />
+    );
+    const controls = container.querySelectorAll<HTMLButtonElement>('[data-scrawlix-control]');
+    const covers = container.querySelectorAll<HTMLElement>('[data-scrawlix-cover]');
+
+    act(() => controls[1]!.dispatchEvent(new FocusEvent('focusin', { bubbles: true })));
+    expect(covers[0]!.dataset.scrawlixRevealed).toBe('false');
+    expect(covers[1]!.dataset.scrawlixRevealed).toBe('true');
+  });
+});

--- a/packages/react/src/match-reveal.test.tsx
+++ b/packages/react/src/match-reveal.test.tsx
@@ -47,6 +47,32 @@ describe('CensoredText per-match reveal', () => {
     expect(covers[1]!.dataset.scrawlixRevealId).toBe('m1');
   });
 
+  it('reveals only the hovered match', () => {
+    const container = render(
+      <CensoredText
+        coverage="middle"
+        reveal="hover"
+        revealScope="match"
+        rules={rules}
+        text="fuck and fuck"
+      />
+    );
+    const root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
+    const covers = container.querySelectorAll<HTMLElement>('[data-scrawlix-cover]');
+
+    act(() => covers[0]!.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })));
+    expect(covers[0]!.dataset.scrawlixRevealed).toBe('true');
+    expect(covers[1]!.dataset.scrawlixRevealed).toBe('false');
+
+    act(() => covers[1]!.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })));
+    expect(covers[0]!.dataset.scrawlixRevealed).toBe('false');
+    expect(covers[1]!.dataset.scrawlixRevealed).toBe('true');
+
+    act(() => root.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })));
+    expect(covers[0]!.dataset.scrawlixRevealed).toBe('false');
+    expect(covers[1]!.dataset.scrawlixRevealed).toBe('false');
+  });
+
   it('toggles one matched term without revealing its neighbor', () => {
     const container = render(
       <CensoredText
@@ -83,7 +109,6 @@ describe('CensoredText per-match reveal', () => {
     );
     const covers = container.querySelectorAll<HTMLElement>('[data-scrawlix-cover]');
 
-    // Touching coverage ranges stay as separate visual islands, but share one match id.
     expect(covers).toHaveLength(2);
     expect(covers[0]!.dataset.scrawlixRevealId).toBe('m0');
     expect(covers[1]!.dataset.scrawlixRevealId).toBe('m0');

--- a/packages/react/src/match-reveal.test.tsx
+++ b/packages/react/src/match-reveal.test.tsx
@@ -118,7 +118,7 @@ describe('CensoredText per-match reveal', () => {
     expect(covers[1]!.dataset.scrawlixRevealed).toBe('true');
   });
 
-  it('provides keyboard controls without making the aria-hidden visual tree focusable', () => {
+  it('provides keyboard toggle controls without making the aria-hidden visual tree focusable', () => {
     const container = render(
       <CensoredText
         coverage="middle"
@@ -137,6 +137,7 @@ describe('CensoredText per-match reveal', () => {
     expect(visual.getAttribute('aria-hidden')).toBe('true');
     expect(covers[0]!.getAttribute('tabindex')).toBeNull();
     expect(controls).toHaveLength(2);
+    expect(controls[0]!.getAttribute('aria-pressed')).toBe('false');
 
     act(() => controls[0]!.dispatchEvent(new FocusEvent('focusin', { bubbles: true })));
     expect(covers[0]!.dataset.scrawlixFocused).toBe('true');
@@ -145,6 +146,7 @@ describe('CensoredText per-match reveal', () => {
     act(() => controls[0]!.dispatchEvent(new MouseEvent('click', { bubbles: true })));
     expect(covers[0]!.dataset.scrawlixRevealed).toBe('true');
     expect(covers[1]!.dataset.scrawlixRevealed).toBe('false');
+    expect(controls[0]!.getAttribute('aria-pressed')).toBe('true');
 
     act(() =>
       controls[0]!.dispatchEvent(
@@ -152,6 +154,7 @@ describe('CensoredText per-match reveal', () => {
       )
     );
     expect(covers[0]!.dataset.scrawlixRevealed).toBe('false');
+    expect(controls[0]!.getAttribute('aria-pressed')).toBe('false');
   });
 
   it('uses keyboard focus itself as the reveal trigger in focus mode', () => {
@@ -167,6 +170,7 @@ describe('CensoredText per-match reveal', () => {
     const controls = container.querySelectorAll<HTMLButtonElement>('[data-scrawlix-control]');
     const covers = container.querySelectorAll<HTMLElement>('[data-scrawlix-cover]');
 
+    expect(controls[0]!.getAttribute('aria-pressed')).toBeNull();
     act(() => controls[1]!.dispatchEvent(new FocusEvent('focusin', { bubbles: true })));
     expect(covers[0]!.dataset.scrawlixRevealed).toBe('false');
     expect(covers[1]!.dataset.scrawlixRevealed).toBe('true');

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -8,7 +8,8 @@
   --scrawlix-mosaic-cell: 0.3em;
 }
 
-[data-scrawlix-a11y] {
+[data-scrawlix-a11y],
+[data-scrawlix-control] {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -21,9 +22,19 @@
   border: 0;
 }
 
+[data-scrawlix-controls] {
+  display: contents;
+}
+
 [data-scrawlix-root]:focus-visible {
   outline: 1px solid currentColor;
   outline-offset: 0.2em;
+  border-radius: 0.12em;
+}
+
+[data-scrawlix-root] [data-scrawlix-cover][data-scrawlix-focused='true'] {
+  outline: 1px solid currentColor;
+  outline-offset: 0.16em;
   border-radius: 0.12em;
 }
 
@@ -112,10 +123,14 @@
   transition: opacity 140ms ease;
 }
 
-[data-scrawlix-root][data-scrawlix-reveal='hover']:hover [data-scrawlix-cover],
-[data-scrawlix-root][data-scrawlix-reveal='focus']:focus [data-scrawlix-cover],
-[data-scrawlix-root][data-scrawlix-reveal='click'][data-scrawlix-revealed='true']
-  [data-scrawlix-cover] {
+[data-scrawlix-root][data-scrawlix-reveal-scope='component'][data-scrawlix-reveal='hover']:hover
+  [data-scrawlix-cover],
+[data-scrawlix-root][data-scrawlix-reveal-scope='component'][data-scrawlix-reveal='focus']:focus
+  [data-scrawlix-cover],
+[data-scrawlix-root][data-scrawlix-reveal-scope='component'][data-scrawlix-reveal='click'][data-scrawlix-revealed='true']
+  [data-scrawlix-cover],
+[data-scrawlix-root][data-scrawlix-reveal-scope='match']
+  [data-scrawlix-cover][data-scrawlix-revealed='true'] {
   -webkit-text-fill-color: currentColor;
   background: transparent;
   box-shadow: none;
@@ -124,12 +139,14 @@
   user-select: text;
 }
 
-[data-scrawlix-root][data-scrawlix-reveal='hover']:hover
+[data-scrawlix-root][data-scrawlix-reveal-scope='component'][data-scrawlix-reveal='hover']:hover
   [data-scrawlix-cover][data-scrawlix-mask]::after,
-[data-scrawlix-root][data-scrawlix-reveal='focus']:focus
+[data-scrawlix-root][data-scrawlix-reveal-scope='component'][data-scrawlix-reveal='focus']:focus
   [data-scrawlix-cover][data-scrawlix-mask]::after,
-[data-scrawlix-root][data-scrawlix-reveal='click'][data-scrawlix-revealed='true']
-  [data-scrawlix-cover][data-scrawlix-mask]::after {
+[data-scrawlix-root][data-scrawlix-reveal-scope='component'][data-scrawlix-reveal='click'][data-scrawlix-revealed='true']
+  [data-scrawlix-cover][data-scrawlix-mask]::after,
+[data-scrawlix-root][data-scrawlix-reveal-scope='match']
+  [data-scrawlix-cover][data-scrawlix-revealed='true'][data-scrawlix-mask]::after {
   opacity: 0;
 }
 

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -55,18 +55,20 @@
   -webkit-text-fill-color: transparent;
   background:
     repeating-linear-gradient(
-      -13deg,
-      var(--scrawlix-soft-ink) 0 0.07em,
-      transparent 0.07em 0.16em
+      -11deg,
+      color-mix(in srgb, var(--scrawlix-ink) 74%, transparent) 0 0.055em,
+      transparent 0.055em 0.12em,
+      color-mix(in srgb, var(--scrawlix-ink) 46%, transparent) 0.12em 0.18em,
+      transparent 0.18em 0.23em
     ),
     repeating-linear-gradient(
-      9deg,
-      transparent 0 0.09em,
-      var(--scrawlix-fuzzy-ink) 0.09em 0.13em,
-      transparent 0.13em 0.23em
+      7deg,
+      transparent 0 0.075em,
+      color-mix(in srgb, var(--scrawlix-ink) 84%, transparent) 0.075em 0.105em,
+      transparent 0.105em 0.17em
     );
-  border-radius: 0.16em;
-  text-shadow: 0 0 0.3em var(--scrawlix-fuzzy-ink);
+  border-radius: 0.1em;
+  text-shadow: 0 0 0.16em color-mix(in srgb, var(--scrawlix-ink) 46%, transparent);
 }
 
 [data-scrawlix-root][data-scrawlix-appearance='bar'] [data-scrawlix-cover] {
@@ -87,19 +89,42 @@
     0.94em no-repeat;
   border-radius: 0.04em;
   box-shadow:
-    inset 0 0.055em color-mix(in srgb, var(--scrawlix-ink) 10%, transparent),
-    inset 0 -0.055em color-mix(in srgb, var(--scrawlix-ink) 7%, transparent);
+    inset 0 0.055em color-mix(in srgb, var(--scrawlix-ink) 12%, transparent),
+    inset 0 -0.055em color-mix(in srgb, var(--scrawlix-ink) 8%, transparent),
+    0 0.045em 0.09em color-mix(in srgb, var(--scrawlix-ink) 12%, transparent);
 }
 
 [data-scrawlix-root][data-scrawlix-appearance='mosaic'] [data-scrawlix-cover] {
   -webkit-text-fill-color: transparent;
-  background: repeating-conic-gradient(
-      from 45deg,
-      var(--scrawlix-ink) 0 25%,
-      var(--scrawlix-soft-ink) 0 50%
-    )
-    center / var(--scrawlix-mosaic-cell) var(--scrawlix-mosaic-cell);
-  border-radius: 0.04em;
+  background:
+    linear-gradient(
+        90deg,
+        var(--scrawlix-ink) 0 24%,
+        transparent 24% 42%,
+        var(--scrawlix-fuzzy-ink) 42% 67%,
+        transparent 67% 78%,
+        var(--scrawlix-ink) 78% 100%
+      )
+      0 0 /
+      calc(
+          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+            var(--scrawlix-mosaic-cell)
+        )
+      var(--scrawlix-mosaic-cell),
+    linear-gradient(
+        90deg,
+        var(--scrawlix-soft-ink) 0 31%,
+        var(--scrawlix-ink) 31% 55%,
+        var(--scrawlix-fuzzy-ink) 55% 77%,
+        var(--scrawlix-ink) 77% 100%
+      )
+      var(--scrawlix-mosaic-cell) var(--scrawlix-mosaic-cell) /
+      calc(
+          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+            var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell)
+        )
+      var(--scrawlix-mosaic-cell);
+  border-radius: 0.035em;
 }
 
 [data-scrawlix-root] [data-scrawlix-cover][data-scrawlix-mask] {

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -96,34 +96,52 @@
 
 [data-scrawlix-root][data-scrawlix-appearance='mosaic'] [data-scrawlix-cover] {
   -webkit-text-fill-color: transparent;
-  background:
+  background-color: var(--scrawlix-soft-ink);
+  background-image:
     linear-gradient(
-        90deg,
-        var(--scrawlix-ink) 0 24%,
-        transparent 24% 42%,
-        var(--scrawlix-fuzzy-ink) 42% 67%,
-        transparent 67% 78%,
-        var(--scrawlix-ink) 78% 100%
+      90deg,
+      var(--scrawlix-ink) 0 22%,
+      var(--scrawlix-fuzzy-ink) 22% 52%,
+      var(--scrawlix-ink) 52% 73%,
+      var(--scrawlix-soft-ink) 73% 100%
+    ),
+    linear-gradient(
+      90deg,
+      var(--scrawlix-fuzzy-ink) 0 18%,
+      var(--scrawlix-ink) 18% 47%,
+      var(--scrawlix-soft-ink) 47% 69%,
+      var(--scrawlix-ink) 69% 100%
+    ),
+    linear-gradient(
+      90deg,
+      var(--scrawlix-ink) 0 31%,
+      var(--scrawlix-soft-ink) 31% 48%,
+      var(--scrawlix-ink) 48% 78%,
+      var(--scrawlix-fuzzy-ink) 78% 100%
+    );
+  background-position:
+    0 0.03em,
+    var(--scrawlix-mosaic-cell) calc(var(--scrawlix-mosaic-cell) + 0.03em),
+    0 calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) + 0.03em
+      );
+  background-size:
+    calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+          var(--scrawlix-mosaic-cell)
       )
-      0 0 /
-      calc(
-          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
-            var(--scrawlix-mosaic-cell)
-        )
       var(--scrawlix-mosaic-cell),
-    linear-gradient(
-        90deg,
-        var(--scrawlix-soft-ink) 0 31%,
-        var(--scrawlix-ink) 31% 55%,
-        var(--scrawlix-fuzzy-ink) 55% 77%,
-        var(--scrawlix-ink) 77% 100%
+    calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell)
       )
-      var(--scrawlix-mosaic-cell) var(--scrawlix-mosaic-cell) /
-      calc(
-          var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
-            var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell)
-        )
+      var(--scrawlix-mosaic-cell),
+    calc(
+        var(--scrawlix-mosaic-cell) + var(--scrawlix-mosaic-cell) +
+          var(--scrawlix-mosaic-cell)
+      )
       var(--scrawlix-mosaic-cell);
+  background-repeat: repeat-x;
   border-radius: 0.035em;
 }
 

--- a/packages/rehype/src/index.ts
+++ b/packages/rehype/src/index.ts
@@ -56,13 +56,25 @@ function shouldSkipElement(element: Element, options: PreparedOptions) {
 }
 
 function coveredElement(segment: ScrawlixSegment): Element {
+  const properties: Element['properties'] = {
+    'data-scrawlix-cover': '',
+    'data-scrawlix-rules': segment.ruleIds.join(','),
+    'data-scrawlix-matches': segment.matchIds.join(','),
+    'data-scrawlix-start': segment.start,
+    'data-scrawlix-end': segment.end,
+  };
+
+  if (segment.revealId) {
+    properties['data-scrawlix-reveal-id'] = segment.revealId;
+  }
+  if (segment.coverageEdge) {
+    properties['data-scrawlix-edge'] = segment.coverageEdge;
+  }
+
   return {
     type: 'element',
     tagName: 'span',
-    properties: {
-      'data-scrawlix-cover': '',
-      'data-scrawlix-rules': segment.ruleIds.join(','),
-    },
+    properties,
     children: [{ type: 'text', value: segment.text }],
   };
 }

--- a/packages/rehype/src/metadata.test.ts
+++ b/packages/rehype/src/metadata.test.ts
@@ -1,0 +1,37 @@
+import { censorRuleFromWords } from '@scrawlix/core';
+import type { Element, Root } from 'hast';
+import { describe, expect, it } from 'vitest';
+import { transformHast } from './index';
+
+describe('@scrawlix/rehype match metadata', () => {
+  it('projects segment identity and coverage edges onto HAST spans', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'p',
+          properties: {},
+          children: [{ type: 'text', value: 'well, fuck this' }],
+        },
+      ],
+    };
+
+    transformHast(tree, {
+      rules: [censorRuleFromWords('fuck', ['fuck'])],
+      coverage: 'middle',
+    });
+
+    const paragraph = tree.children[0] as Element;
+    const cover = paragraph.children.find(
+      child => child.type === 'element'
+    ) as Element;
+
+    expect(cover.properties['data-scrawlix-rules']).toBe('fuck');
+    expect(cover.properties['data-scrawlix-matches']).toBe('m0');
+    expect(cover.properties['data-scrawlix-reveal-id']).toBe('m0');
+    expect(cover.properties['data-scrawlix-edge']).toBe('solo');
+    expect(cover.properties['data-scrawlix-start']).toBe(7);
+    expect(cover.properties['data-scrawlix-end']).toBe(9);
+  });
+});

--- a/tests/browser/browser.spec.ts
+++ b/tests/browser/browser.spec.ts
@@ -8,9 +8,11 @@ test('demo controls drive real rendered coverage and reveal state', async ({ pag
 
   const proof = page.locator('.proof-output [data-scrawlix-root]');
   const firstCover = proof.locator('[data-scrawlix-cover]').first();
+  const secondCover = proof.locator('[data-scrawlix-cover]').nth(1);
 
   await expect(proof).toBeVisible();
   await expect(proof).toHaveAttribute('data-scrawlix-appearance', 'scrawl');
+  await expect(proof).toHaveAttribute('data-scrawlix-reveal-scope', 'match');
   await expect(firstCover).toHaveText('uc');
 
   await page.getByRole('button', { name: 'bar', exact: true }).click();
@@ -27,16 +29,26 @@ test('demo controls drive real rendered coverage and reveal state', async ({ pag
   await page.getByRole('button', { name: 'click', exact: true }).click();
   await expect(proof).toHaveAttribute('data-scrawlix-reveal', 'click');
   await expect(proof).toHaveAttribute('data-scrawlix-revealed', 'false');
+  await expect(firstCover).toHaveAttribute('data-scrawlix-revealed', 'false');
+  await expect(secondCover).toHaveAttribute('data-scrawlix-revealed', 'false');
 
   const beforeRevealBox = await firstCover.boundingBox();
-  await proof.click();
-  await expect(proof).toHaveAttribute('data-scrawlix-revealed', 'true');
+  await firstCover.click();
+  await expect(firstCover).toHaveAttribute('data-scrawlix-revealed', 'true');
+  await expect(secondCover).toHaveAttribute('data-scrawlix-revealed', 'false');
+  await expect(proof).toHaveAttribute('data-scrawlix-revealed', 'false');
   const afterRevealBox = await firstCover.boundingBox();
 
   if (!beforeRevealBox || !afterRevealBox) {
     throw new Error('Expected the first covered segment to have a layout box.');
   }
   expect(Math.abs(beforeRevealBox.width - afterRevealBox.width)).toBeLessThan(0.5);
+
+  await page.getByRole('button', { name: 'component', exact: true }).click();
+  await expect(proof).toHaveAttribute('data-scrawlix-reveal-scope', 'component');
+  await expect(proof).toHaveAttribute('data-scrawlix-revealed', 'false');
+  await proof.click();
+  await expect(proof).toHaveAttribute('data-scrawlix-revealed', 'true');
 
   await page.setViewportSize({ width: 390, height: 844 });
   const overflow = await page.evaluate(


### PR DESCRIPTION
## Summary

This is stacked on #37.

- give every sorted semantic match a deterministic render-local `matchId`
- add source-local `start` / `end` offsets to every `ScrawlixSegment`
- carry contributing `matchIds` into covered segments as unordered provenance
- assign a deterministic `revealId` interaction key to each connected disclosure group
- annotate several coverage islands from one disclosure group with `solo` / `start` / `middle` / `end`
- group overlaps transitively by shared match identity, so one match's disjoint islands stay together even when another rule overlaps only one island
- project match/reveal/edge/offset metadata through DOM and rehype adapters
- add `revealScope="component" | "match"` to `CensoredText`
- keep component-wide reveal as the compatibility default
- support per-match pointer reveal and keyboard-accessible focus/click controls without focusable descendants inside the aria-hidden visual copy
- use revision-scoped interaction state so changing text/rules/coverage/reveal cannot flash a newly reused `m0` open for one render
- make click reveal selection-aware so revealing and then selecting/copying source text does not accidentally conceal it
- expose proper `aria-pressed` toggle semantics for per-match click controls
- isolate internal reveal controls from host application activation: generated clicks and Enter/Space/Escape key events do not bubble into clickable/key-handled parents
- expose reveal scope in the demo, where `match` is the default live-proof setting
- document ID/offset locality and the distinction between provenance (`matchIds`) and interaction grouping (`revealId`)

## Metadata semantics

`matchId` values are opaque identities for one sorted scan of one source string. DOM and rehype transforms scan individual text nodes, so IDs and offsets are source-node local. They are intentionally unsuitable as persistent/page-global identifiers.

`matchIds` on a merged covered union represent contributing matches and should be treated as an unordered collection. `revealId` is the deterministic interaction key renderers should use.

## Disclosure grouping

Covered ranges form disclosure groups by connected match identity. If match A has two disjoint coverage islands and match B overlaps only the first island, both islands and the overlap belong to one disclosure group. This preserves the promise that one semantic match reveals cohesively while preventing a smaller overlapping target from exposing only part of a larger hidden union.

## Accessibility and interaction

The existing exact source copy remains the single accessible reading of the text. For per-match focus/click reveal, keyboard controls are visually hidden siblings of the visual tree; focus is painted onto the corresponding censor range. The aria-hidden visual spans themselves remain outside the tab order.

Pointer click reveal ignores the click aftermath of an active text selection, so users can reveal a term and select/copy source text without toggling the disclosure underneath the selection.

The hidden keyboard controls are intentionally event-isolated. Activating one can reveal/conceal its match, while its generated click and Enter/Space/Escape key events stop at the control. A `CensoredText` inside a clickable card therefore cannot activate that host card merely because the user keyboard-activated an internal reveal button.

## Verification

The current head is green across typecheck, unit/jsdom regressions (including connected disclosure and host-event isolation), build, Chromium demo smoke, Chromium extension smoke, and packed-package consumer smoke.

## Follow-up

The extension receives the new DOM metadata automatically in this PR. Per-match interaction policy for arbitrary webpages can follow after the React behavior settles.

Part of #27
Depends on #37