### PR TITLE
Unify grapheme counting across packages

### DIFF
--- a/apps/extension/src/config.test.ts
+++ b/apps/extension/src/config.test.ts
@@ -59,10 +59,11 @@ describe('extension settings', () => {
     expect(coverageSelector('middle')).toBe('middle');
   });
 
-  it('generates symbol masks without rewriting source text', () => {
+  it('generates symbol masks by grapheme count without rewriting source text', () => {
     expect(maskFor('fuck', 'asterisk')).toBe('****');
     expect(maskFor('abcdef', 'grawlix')).toBe('@#$%&!');
-    expect(maskFor('🔥x', 'asterisk')).toBe('**');
+    expect(maskFor('e\u0301❤️👍🏽🇺🇸👨‍👩‍👧‍👦', 'asterisk')).toBe('*****');
+    expect(maskFor('e\u0301❤️👍🏽🇺🇸👨‍👩‍👧‍👦', 'grawlix')).toBe('@#$%&');
     expect(maskFor('fuck', 'bar')).toBe('');
   });
 });

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -1,4 +1,4 @@
-import type { CoverageSelector } from '@scrawlix/core';
+import { graphemeCount, type CoverageSelector } from '@scrawlix/core';
 import { englishVowelCoverage } from '@scrawlix/en';
 
 export type ExtensionAppearance =
@@ -132,7 +132,7 @@ export function coverageSelector(coverage: ExtensionCoverage): CoverageSelector 
 }
 
 export function maskFor(text: string, appearance: ExtensionAppearance) {
-  const length = Array.from(text).length;
+  const length = graphemeCount(text);
   if (appearance === 'asterisk') return '*'.repeat(length);
   if (appearance === 'grawlix') {
     const symbols = '@#$%&!';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,7 +119,7 @@ function advanceStringIndex(value: string, index: number, unicode: boolean) {
   return index + 2;
 }
 
-function graphemeRanges(value: string): RelativeRange[] {
+export function graphemeRanges(value: string): RelativeRange[] {
   if (!value) return [];
 
   if (graphemeSegmenter) {
@@ -136,6 +136,10 @@ function graphemeRanges(value: string): RelativeRange[] {
     cursor += character.length;
   }
   return ranges;
+}
+
+export function graphemeCount(value: string) {
+  return graphemeRanges(value).length;
 }
 
 function fullRange(value: string): RelativeRange[] {

--- a/packages/en/src/index.ts
+++ b/packages/en/src/index.ts
@@ -1,33 +1,9 @@
-import type {
-  CensorRule,
-  CensorRulePack,
-  CoverageSelector,
-  RelativeRange,
+import {
+  graphemeRanges,
+  type CensorRule,
+  type CensorRulePack,
+  type CoverageSelector,
 } from '@scrawlix/core';
-
-const graphemeSegmenter =
-  typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
-    ? new Intl.Segmenter('en', { granularity: 'grapheme' })
-    : null;
-
-function graphemeRanges(value: string): RelativeRange[] {
-  if (!value) return [];
-
-  if (graphemeSegmenter) {
-    return [...graphemeSegmenter.segment(value)].map(part => ({
-      start: part.index,
-      end: part.index + part.segment.length,
-    }));
-  }
-
-  const ranges: RelativeRange[] = [];
-  let cursor = 0;
-  for (const character of Array.from(value)) {
-    ranges.push({ start: cursor, end: cursor + character.length });
-    cursor += character.length;
-  }
-  return ranges;
-}
 
 /**
  * Covers orthographic English vowels (a/e/i/o/u) inside the semantic target.

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -143,18 +143,19 @@ describe('CensoredText', () => {
   });
 
   it('cycles grawlix symbols by covered grapheme count', () => {
-    const fullRule = [{ id: 'whole', pattern: /abcdef/giu }] as const;
+    const graphemeText = 'e\u0301❤️👍🏽🇺🇸👨‍👩‍👧‍👦';
+    const fullRule = [{ id: 'whole', pattern: /.+/u }] as const;
     const container = render(
       <CensoredText
         appearance="grawlix"
         coverage="full"
         rules={fullRule}
-        text="abcdef"
+        text={graphemeText}
       />
     );
 
     expect(
       container.querySelector<HTMLElement>('[data-scrawlix-mask]')?.textContent
-    ).toBe('@#$%&!');
+    ).toBe('@#$%&');
   });
 });

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,5 +1,6 @@
 import {
   createScrawlix,
+  graphemeCount,
   type CensorRule,
   type CoverageSelector,
 } from '@scrawlix/core';
@@ -27,12 +28,13 @@ export type CensoredTextProps = {
 const GRAWLIX = '@#$%&!';
 
 function symbolsFor(text: string, appearance: ScrawlixAppearance) {
-  const characters = Array.from(text);
-  if (appearance === 'asterisk') return characters.map(() => '*').join('');
+  const length = graphemeCount(text);
+  if (appearance === 'asterisk') return '*'.repeat(length);
   if (appearance === 'grawlix') {
-    return characters
-      .map((_, index) => GRAWLIX[index % GRAWLIX.length])
-      .join('');
+    return Array.from(
+      { length },
+      (_, index) => GRAWLIX[index % GRAWLIX.length]
+    ).join('');
   }
   return text;
 }


### PR DESCRIPTION
## What changed

- export `graphemeRanges()` and `graphemeCount()` from `@scrawlix/core`
- reuse core grapheme segmentation from the English vowel coverage helper instead of carrying a second implementation
- count React asterisk/grawlix masks by grapheme cluster
- count extension asterisk/grawlix masks by grapheme cluster
- replace friendly ASCII/code-point mask checks with decomposed accent, variation-selector, skin-tone, flag, and family-ZWJ regression cases

## Why

Core coverage already operates on grapheme clusters while React and extension presentation counted `Array.from()` code points. Multi-code-point graphemes therefore produced too many mask symbols.

The combining-mark/custom-word boundary portion of #56 landed independently in #43. Canonical normalization policy remains a separate decision in #56.

Refs #56.