### PR TITLE
Add lenses and profiles to the browser extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added an interactive editorial proof-sheet demo under `apps/demo`.
 - Added a Vercel-ready static deployment configuration.
 - Added a Manifest V3 Chromium extension under `apps/extension` with global/site preferences, five appearances, coverage/reveal controls, and local custom terms.
+- Added local extension lenses and named profiles, with per-profile treatment, legacy custom-term migration, semantic-session reuse, and atomic live-page profile switching.
 
 ### Developer experience
 

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -27,35 +27,65 @@ To try it locally in Chromium:
 3. choose **Load unpacked**
 4. select `apps/extension/dist`
 
-## Preferences
+## Lenses and profiles
 
-Small preferences live in `chrome.storage.sync`:
+The popup separates **what should be caught** from **how the current setup should look**.
+
+A **lens** is a user-facing purpose. The extension always offers a built-in English **Profanity** lens, and users can add local term lenses such as:
+
+- Client privacy
+- Project codenames
+- Spoilers
+- Classroom
+- Stream safety
+
+A **profile** combines any number of lenses with appearance, coverage, and reveal choices. Examples:
+
+- **Everyday** — profanity + spoilers, scrawl appearance, hover reveal
+- **Presentation** — client privacy + codenames, full bars, never reveal
+- **Stream** — private terms + profanity, full coverage, never reveal
+
+Switching the active profile is one popup selection. The content script restores controller-owned source text before starting the newly selected profile, so turning one lens off cannot leave stale generated spans behind.
+
+Custom lenses can be created, renamed, edited, removed, and enabled independently in each profile. Profile creation clones the current profile as a useful starting point.
+
+## Storage and migration
+
+Small cross-browser preferences remain in `chrome.storage.sync`:
 
 - global enabled state
-- appearance
-- coverage
-- reveal mode
 - sparse hostname overrides (`on` / `off`)
+- legacy appearance / coverage / reveal values, retained as migration seeds
 
-Custom words and phrases live in `chrome.storage.local`. They can grow independently of the small synced preference object and stay local to the browser profile.
+Lens/profile state lives in `chrome.storage.local`:
 
-The popup exposes a tri-state site mode:
+- custom lens names and terms
+- profile definitions
+- active profile id
+- per-profile appearance / coverage / reveal
+
+Keeping the active profile local avoids syncing an id to another browser profile that may have a different set of local lenses and profiles.
+
+On first load after upgrading from the single-list model, Scrawlix creates an **Everyday** profile from the previous treatment settings. Existing custom words become a local **My terms** lens and remain active alongside the built-in Profanity lens. The old custom-word key remains readable for that migration path.
+
+The popup still exposes a tri-state site mode:
 
 - **follow global** — no hostname entry is stored
 - **always on** — hostname explicitly overrides the global switch
 - **always off** — hostname explicitly overrides the global switch
 
-Storage changes are observed by the content script. A preference change tears down the current DOM observation with `observation.restore()`, restoring exact source text before a new configured session begins.
+Storage changes are observed by the content script. A settings, lens, or profile change tears down the current DOM observation with `observation.restore()`, restoring exact source text before a new configured session begins.
 
 ## Page lifecycle
 
 The content script:
 
-1. loads the English pack plus one compiled custom-word rule when custom terms exist
-2. creates one `@scrawlix/dom` controller for the current settings
-3. observes `document.body`
-4. decorates only Scrawlix-generated roots with extension presentation metadata
-5. listens for storage changes and restarts atomically
+1. loads the active local profile
+2. composes rules from every lens enabled in that profile
+3. creates one `@scrawlix/dom` controller using the profile coverage setting
+4. observes `document.body`
+5. decorates only Scrawlix-generated roots using the profile appearance/reveal settings
+6. listens for sync/local storage changes and restarts atomically
 
 The DOM adapter watches mutation roots rather than rescanning the document after every page update.
 
@@ -71,13 +101,13 @@ The DOM adapter watches mutation roots rather than rescanning the document after
 
 Asterisk/grawlix masks are presentation metadata on generated cover spans. The source substring remains the actual DOM text underneath.
 
-Hover is the default reveal mode. Focus/click reveal makes a generated wrapper keyboard-focusable only when the wrapper is outside links, buttons, inputs, and other native interactive controls. Scrawlix avoids stealing those controls' interaction semantics.
+Hover is the default reveal mode for migrated/default profiles. Focus/click reveal makes a generated wrapper keyboard-focusable only when the wrapper is outside links, buttons, inputs, and other native interactive controls. Scrawlix avoids stealing those controls' interaction semantics.
 
 ## Permissions
 
 The development manifest requests:
 
-- `storage` — persist preferences
+- `storage` — persist preferences, lenses, and profiles
 - `activeTab` — let the popup identify the current HTTP/HTTPS hostname after the user opens it
 - host access to HTTP and HTTPS pages — run the content script automatically on pages where Scrawlix may be enabled
 
@@ -95,4 +125,4 @@ Broad HTTP/HTTPS host access is a meaningful permission and should remain explic
 - `popup.html` exists
 - every JS/CSS/popup path referenced by the manifest exists in `dist`
 
-Pure preference/mask behavior is covered by `src/config.test.ts`; broader extension/browser E2E coverage can grow after the first unpacked build is exercised manually.
+`src/config.test.ts` covers preference, migration, lens, profile, coverage, and mask behavior. The browser smoke opens the built extension in Chromium; profile coverage also opens the real popup, creates local lenses/profile state, and verifies that an already-open page restores and re-renders when the active profile changes.

--- a/apps/extension/popup.html
+++ b/apps/extension/popup.html
@@ -34,7 +34,31 @@
         </label>
       </section>
 
-      <section class="settings-grid" aria-label="Censor treatment">
+      <section class="profiles" aria-labelledby="profiles-heading">
+        <div class="section-label">
+          <div>
+            <p class="eyebrow">active setup</p>
+            <h2 id="profiles-heading">Profiles</h2>
+          </div>
+          <span id="local-save-status" aria-live="polite"></span>
+        </div>
+
+        <div class="profile-picker">
+          <label>
+            <span class="sr-only">Active profile</span>
+            <select id="profile"></select>
+          </label>
+          <button id="add-profile" type="button">new</button>
+          <button id="delete-profile" type="button">delete</button>
+        </div>
+
+        <label class="stacked-field">
+          <span>profile name</span>
+          <input id="profile-name" autocomplete="off" spellcheck="false" />
+        </label>
+      </section>
+
+      <section class="settings-grid" aria-label="Active profile treatment">
         <label>
           <span>appearance</span>
           <select id="appearance">
@@ -68,21 +92,16 @@
         </label>
       </section>
 
-      <section class="custom-words" aria-labelledby="custom-heading">
+      <section class="lenses" aria-labelledby="lenses-heading">
         <div class="section-label">
           <div>
-            <p class="eyebrow">your list</p>
-            <h2 id="custom-heading">Custom words & phrases</h2>
+            <p class="eyebrow">what gets caught</p>
+            <h2 id="lenses-heading">Lenses</h2>
           </div>
-          <span id="save-status" aria-live="polite"></span>
+          <button id="add-lens" type="button">+ lens</button>
         </div>
-        <textarea
-          id="custom-words"
-          rows="5"
-          placeholder="Project Velvet&#10;Mothbit&#10;spoiler phrase"
-          spellcheck="false"
-        ></textarea>
-        <p class="hint">One per line. Saved locally in this browser.</p>
+        <div id="lens-list" class="lens-list"></div>
+        <p class="hint">Tick the lenses this profile should use. Custom lens terms stay local to this browser.</p>
       </section>
 
       <footer>

--- a/apps/extension/src/config.test.ts
+++ b/apps/extension/src/config.test.ts
@@ -1,13 +1,21 @@
 import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_SETTINGS,
+  ENGLISH_PROFANITY_LENS_ID,
+  activeProfile,
   coverageSelector,
+  createDefaultLocalState,
   effectiveEnabled,
   maskFor,
   normalizeCustomWords,
+  normalizeLocalState,
   normalizeSettings,
+  profileTerms,
+  profileUsesEnglishProfanity,
+  setActiveProfile,
   setSiteMode,
   siteModeFor,
+  updateActiveProfile,
 } from './config';
 
 describe('extension settings', () => {
@@ -52,6 +60,107 @@ describe('extension settings', () => {
     expect(
       normalizeCustomWords([' Velvet ', 'velvet', '', 42, 'Mothbit', 'MOTHBIT'])
     ).toEqual(['Velvet', 'Mothbit']);
+  });
+
+  it('migrates the old treatment and custom-word bucket into an Everyday profile', () => {
+    const settings = {
+      ...DEFAULT_SETTINGS,
+      appearance: 'bar' as const,
+      coverage: 'full' as const,
+      reveal: 'click' as const,
+    };
+    const state = createDefaultLocalState(settings, [' Project Velvet ', 'velvet']);
+    const profile = activeProfile(state);
+
+    expect(profile).toMatchObject({
+      name: 'Everyday',
+      appearance: 'bar',
+      coverage: 'full',
+      reveal: 'click',
+    });
+    expect(profile.lensIds).toEqual([
+      ENGLISH_PROFANITY_LENS_ID,
+      'lens:my-terms',
+    ]);
+    expect(profileTerms(state)).toEqual(['Project Velvet', 'velvet']);
+    expect(profileUsesEnglishProfanity(state)).toBe(true);
+  });
+
+  it('normalizes local lenses and profiles while dropping missing lens references', () => {
+    const state = normalizeLocalState({
+      lenses: [
+        {
+          id: 'private',
+          name: ' Client privacy ',
+          kind: 'terms',
+          terms: [' Alice ', 'alice', 'Project Velvet'],
+        },
+        {
+          id: ENGLISH_PROFANITY_LENS_ID,
+          name: 'fake built in',
+          kind: 'terms',
+          terms: ['nope'],
+        },
+      ],
+      profiles: [
+        {
+          id: 'presentation',
+          name: ' Presentation ',
+          lensIds: ['private', 'missing', 'private'],
+          appearance: 'blur',
+          coverage: 'full',
+          reveal: 'never',
+        },
+      ],
+      activeProfileId: 'missing',
+    });
+
+    expect(state.lenses).toEqual([
+      {
+        id: ENGLISH_PROFANITY_LENS_ID,
+        name: 'Profanity',
+        kind: 'english-profanity',
+        terms: [],
+      },
+      {
+        id: 'private',
+        name: 'Client privacy',
+        kind: 'terms',
+        terms: ['Alice', 'Project Velvet'],
+      },
+    ]);
+    expect(activeProfile(state)).toEqual({
+      id: 'presentation',
+      name: 'Presentation',
+      lensIds: ['private'],
+      appearance: 'blur',
+      coverage: 'full',
+      reveal: 'never',
+    });
+    expect(profileTerms(state)).toEqual(['Alice', 'Project Velvet']);
+    expect(profileUsesEnglishProfanity(state)).toBe(false);
+  });
+
+  it('switches profiles and updates only the active profile', () => {
+    const initial = createDefaultLocalState();
+    const second = {
+      id: 'profile:presentation',
+      name: 'Presentation',
+      lensIds: [],
+      appearance: 'bar' as const,
+      coverage: 'full' as const,
+      reveal: 'never' as const,
+    };
+    const withSecond = {
+      ...initial,
+      profiles: [...initial.profiles, second],
+    };
+    const switched = setActiveProfile(withSecond, second.id);
+    const updated = updateActiveProfile(switched, { reveal: 'click' });
+
+    expect(activeProfile(updated).name).toBe('Presentation');
+    expect(activeProfile(updated).reveal).toBe('click');
+    expect(updated.profiles[0]?.reveal).toBe(initial.profiles[0]?.reveal);
   });
 
   it('maps the vowel setting to the English coverage helper', () => {

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -20,8 +20,33 @@ export type SyncSettings = {
   siteOverrides: Record<string, Exclude<SiteMode, 'inherit'>>;
 };
 
+export type ExtensionLens = {
+  id: string;
+  name: string;
+  kind: 'english-profanity' | 'terms';
+  terms: string[];
+};
+
+export type ExtensionProfile = {
+  id: string;
+  name: string;
+  lensIds: string[];
+  appearance: ExtensionAppearance;
+  coverage: ExtensionCoverage;
+  reveal: ExtensionReveal;
+};
+
+export type ExtensionLocalState = {
+  lenses: ExtensionLens[];
+  profiles: ExtensionProfile[];
+  activeProfileId: string;
+};
+
 export const SYNC_SETTINGS_KEY = 'scrawlixSettings';
 export const CUSTOM_WORDS_KEY = 'scrawlixCustomWords';
+export const LOCAL_STATE_KEY = 'scrawlixLocalState';
+export const ENGLISH_PROFANITY_LENS_ID = 'builtin:english-profanity';
+export const DEFAULT_PROFILE_ID = 'profile:everyday';
 
 export const DEFAULT_SETTINGS: SyncSettings = {
   enabled: true,
@@ -62,6 +87,36 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function normalizedName(value: unknown, fallback: string) {
+  if (typeof value !== 'string') return fallback;
+  const name = value.trim();
+  return name || fallback;
+}
+
+function normalizedId(value: unknown, fallback: string) {
+  if (typeof value !== 'string') return fallback;
+  const id = value.trim();
+  return id || fallback;
+}
+
+function normalizedAppearance(value: unknown, fallback: ExtensionAppearance) {
+  return APPEARANCES.has(value as ExtensionAppearance)
+    ? (value as ExtensionAppearance)
+    : fallback;
+}
+
+function normalizedCoverage(value: unknown, fallback: ExtensionCoverage) {
+  return COVERAGES.has(value as ExtensionCoverage)
+    ? (value as ExtensionCoverage)
+    : fallback;
+}
+
+function normalizedReveal(value: unknown, fallback: ExtensionReveal) {
+  return REVEALS.has(value as ExtensionReveal)
+    ? (value as ExtensionReveal)
+    : fallback;
+}
+
 export function normalizeSettings(value: unknown): SyncSettings {
   if (!isRecord(value)) return { ...DEFAULT_SETTINGS, siteOverrides: {} };
 
@@ -78,15 +133,9 @@ export function normalizeSettings(value: unknown): SyncSettings {
 
   return {
     enabled: typeof value.enabled === 'boolean' ? value.enabled : DEFAULT_SETTINGS.enabled,
-    appearance: APPEARANCES.has(value.appearance as ExtensionAppearance)
-      ? (value.appearance as ExtensionAppearance)
-      : DEFAULT_SETTINGS.appearance,
-    coverage: COVERAGES.has(value.coverage as ExtensionCoverage)
-      ? (value.coverage as ExtensionCoverage)
-      : DEFAULT_SETTINGS.coverage,
-    reveal: REVEALS.has(value.reveal as ExtensionReveal)
-      ? (value.reveal as ExtensionReveal)
-      : DEFAULT_SETTINGS.reveal,
+    appearance: normalizedAppearance(value.appearance, DEFAULT_SETTINGS.appearance),
+    coverage: normalizedCoverage(value.coverage, DEFAULT_SETTINGS.coverage),
+    reveal: normalizedReveal(value.reveal, DEFAULT_SETTINGS.reveal),
     siteOverrides,
   };
 }
@@ -108,6 +157,161 @@ export function normalizeCustomWords(value: unknown): string[] {
   }
 
   return words;
+}
+
+export function createDefaultLocalState(
+  settings: SyncSettings = DEFAULT_SETTINGS,
+  legacyCustomWords: readonly string[] = []
+): ExtensionLocalState {
+  const customTerms = normalizeCustomWords(legacyCustomWords);
+  const lenses: ExtensionLens[] = [
+    {
+      id: ENGLISH_PROFANITY_LENS_ID,
+      name: 'Profanity',
+      kind: 'english-profanity',
+      terms: [],
+    },
+  ];
+  const lensIds = [ENGLISH_PROFANITY_LENS_ID];
+
+  if (customTerms.length > 0) {
+    lenses.push({
+      id: 'lens:my-terms',
+      name: 'My terms',
+      kind: 'terms',
+      terms: customTerms,
+    });
+    lensIds.push('lens:my-terms');
+  }
+
+  return {
+    lenses,
+    profiles: [
+      {
+        id: DEFAULT_PROFILE_ID,
+        name: 'Everyday',
+        lensIds,
+        appearance: settings.appearance,
+        coverage: settings.coverage,
+        reveal: settings.reveal,
+      },
+    ],
+    activeProfileId: DEFAULT_PROFILE_ID,
+  };
+}
+
+export function normalizeLocalState(
+  value: unknown,
+  settings: SyncSettings = DEFAULT_SETTINGS,
+  legacyCustomWords: readonly string[] = []
+): ExtensionLocalState {
+  const fallback = createDefaultLocalState(settings, legacyCustomWords);
+  if (!isRecord(value)) return fallback;
+
+  const lenses: ExtensionLens[] = [fallback.lenses[0]!];
+  const seenLensIds = new Set([ENGLISH_PROFANITY_LENS_ID]);
+
+  if (Array.isArray(value.lenses)) {
+    for (const [index, candidate] of value.lenses.entries()) {
+      if (!isRecord(candidate) || candidate.kind !== 'terms') continue;
+      const id = normalizedId(candidate.id, `lens:${index + 1}`);
+      if (seenLensIds.has(id)) continue;
+      seenLensIds.add(id);
+      lenses.push({
+        id,
+        name: normalizedName(candidate.name, `Lens ${index + 1}`),
+        kind: 'terms',
+        terms: normalizeCustomWords(candidate.terms),
+      });
+    }
+  }
+
+  const profiles: ExtensionProfile[] = [];
+  const seenProfileIds = new Set<string>();
+
+  if (Array.isArray(value.profiles)) {
+    for (const [index, candidate] of value.profiles.entries()) {
+      if (!isRecord(candidate)) continue;
+      const id = normalizedId(candidate.id, `profile:${index + 1}`);
+      if (seenProfileIds.has(id)) continue;
+      seenProfileIds.add(id);
+
+      const lensIds = Array.isArray(candidate.lensIds)
+        ? Array.from(
+            new Set(
+              candidate.lensIds.filter(
+                (lensId): lensId is string =>
+                  typeof lensId === 'string' && seenLensIds.has(lensId)
+              )
+            )
+          )
+        : [];
+
+      profiles.push({
+        id,
+        name: normalizedName(candidate.name, `Profile ${index + 1}`),
+        lensIds,
+        appearance: normalizedAppearance(candidate.appearance, settings.appearance),
+        coverage: normalizedCoverage(candidate.coverage, settings.coverage),
+        reveal: normalizedReveal(candidate.reveal, settings.reveal),
+      });
+    }
+  }
+
+  if (profiles.length === 0) return fallback;
+
+  const requestedActiveProfileId =
+    typeof value.activeProfileId === 'string' ? value.activeProfileId : '';
+  const activeProfileId = profiles.some(profile => profile.id === requestedActiveProfileId)
+    ? requestedActiveProfileId
+    : profiles[0]!.id;
+
+  return { lenses, profiles, activeProfileId };
+}
+
+export function activeProfile(state: ExtensionLocalState): ExtensionProfile {
+  return (
+    state.profiles.find(profile => profile.id === state.activeProfileId) ??
+    state.profiles[0]!
+  );
+}
+
+export function setActiveProfile(
+  state: ExtensionLocalState,
+  profileId: string
+): ExtensionLocalState {
+  if (!state.profiles.some(profile => profile.id === profileId)) return state;
+  return { ...state, activeProfileId: profileId };
+}
+
+export function updateActiveProfile(
+  state: ExtensionLocalState,
+  patch: Partial<Omit<ExtensionProfile, 'id'>>
+): ExtensionLocalState {
+  const active = activeProfile(state);
+  return {
+    ...state,
+    profiles: state.profiles.map(profile =>
+      profile.id === active.id ? { ...profile, ...patch } : profile
+    ),
+  };
+}
+
+export function activeProfileLenses(state: ExtensionLocalState) {
+  const activeIds = new Set(activeProfile(state).lensIds);
+  return state.lenses.filter(lens => activeIds.has(lens.id));
+}
+
+export function profileUsesEnglishProfanity(state: ExtensionLocalState) {
+  return activeProfile(state).lensIds.includes(ENGLISH_PROFANITY_LENS_ID);
+}
+
+export function profileTerms(state: ExtensionLocalState) {
+  return normalizeCustomWords(
+    activeProfileLenses(state).flatMap(lens =>
+      lens.kind === 'terms' ? lens.terms : []
+    )
+  );
 }
 
 export function siteModeFor(settings: SyncSettings, hostname: string): SiteMode {

--- a/apps/extension/src/content.ts
+++ b/apps/extension/src/content.ts
@@ -3,15 +3,20 @@ import { createDomScrawlix, type DomObservation } from '@scrawlix/dom';
 import { englishStrongProfanityRules } from '@scrawlix/en';
 import {
   CUSTOM_WORDS_KEY,
+  LOCAL_STATE_KEY,
   SYNC_SETTINGS_KEY,
+  activeProfile,
   coverageSelector,
   effectiveEnabled,
   maskFor,
-  type SyncSettings,
+  profileTerms,
+  profileUsesEnglishProfanity,
+  type ExtensionProfile,
 } from './config';
 import {
   canReuseSemanticSession,
   presentationSettingsChanged,
+  type ExtensionSessionState,
 } from './session';
 import { loadExtensionState } from './storage';
 
@@ -20,10 +25,9 @@ const INTERACTIVE_ANCESTOR =
 
 let observation: DomObservation | null = null;
 let presentationObserver: MutationObserver | null = null;
-let activeSettings: SyncSettings | null = null;
+let activeState: ExtensionSessionState | null = null;
 let activeBody: HTMLElement | null = null;
 let restartGeneration = 0;
-let semanticDirty = false;
 
 function customRule(customTerms: readonly string[]): CensorRule[] {
   if (customTerms.length === 0) return [];
@@ -34,12 +38,12 @@ function canOwnInteraction(root: HTMLElement) {
   return root.closest(INTERACTIVE_ANCESTOR) === null;
 }
 
-function decorateGeneratedRoot(root: HTMLElement, settings: SyncSettings) {
-  root.dataset.scrawlixAppearance = settings.appearance;
-  root.dataset.scrawlixReveal = settings.reveal;
+function decorateGeneratedRoot(root: HTMLElement, profile: ExtensionProfile) {
+  root.dataset.scrawlixAppearance = profile.appearance;
+  root.dataset.scrawlixReveal = profile.reveal;
   root.dataset.scrawlixRevealed = 'false';
 
-  const interactiveReveal = settings.reveal === 'focus' || settings.reveal === 'click';
+  const interactiveReveal = profile.reveal === 'focus' || profile.reveal === 'click';
   if (interactiveReveal && canOwnInteraction(root)) {
     root.tabIndex = 0;
   } else {
@@ -49,31 +53,31 @@ function decorateGeneratedRoot(root: HTMLElement, settings: SyncSettings) {
   for (const cover of Array.from(
     root.querySelectorAll<HTMLElement>('[data-scrawlix-cover]')
   )) {
-    const mask = maskFor(cover.textContent ?? '', settings.appearance);
+    const mask = maskFor(cover.textContent ?? '', profile.appearance);
     if (mask) cover.dataset.scrawlixMask = mask;
     else delete cover.dataset.scrawlixMask;
   }
 }
 
-function decorateSubtree(node: Node, settings: SyncSettings) {
+function decorateSubtree(node: Node, profile: ExtensionProfile) {
   if (!(node instanceof Element)) return;
 
   if (node.matches('[data-scrawlix-dom-root]')) {
-    decorateGeneratedRoot(node as HTMLElement, settings);
+    decorateGeneratedRoot(node as HTMLElement, profile);
   }
 
   for (const root of Array.from(
     node.querySelectorAll<HTMLElement>('[data-scrawlix-dom-root]')
   )) {
-    decorateGeneratedRoot(root, settings);
+    decorateGeneratedRoot(root, profile);
   }
 }
 
-function startPresentationObserver(root: HTMLElement, settings: SyncSettings) {
+function startPresentationObserver(root: HTMLElement, profile: ExtensionProfile) {
   const observer = new MutationObserver(records => {
     for (const record of records) {
       for (const added of Array.from(record.addedNodes)) {
-        decorateSubtree(added, settings);
+        decorateSubtree(added, profile);
       }
     }
   });
@@ -82,11 +86,11 @@ function startPresentationObserver(root: HTMLElement, settings: SyncSettings) {
   presentationObserver = observer;
 }
 
-function refreshPresentation(root: HTMLElement, settings: SyncSettings) {
+function refreshPresentation(root: HTMLElement, profile: ExtensionProfile) {
   presentationObserver?.disconnect();
   presentationObserver = null;
-  decorateSubtree(root, settings);
-  startPresentationObserver(root, settings);
+  decorateSubtree(root, profile);
+  startPresentationObserver(root, profile);
 }
 
 function stopCurrentSession() {
@@ -94,7 +98,7 @@ function stopCurrentSession() {
   presentationObserver = null;
   observation?.restore();
   observation = null;
-  activeSettings = null;
+  activeState = null;
   activeBody = null;
 }
 
@@ -105,40 +109,45 @@ async function restart() {
 
   const hostname = location.hostname.toLowerCase();
   const body = document.body;
-  const previousSettings = activeSettings;
+  const previousState = activeState;
 
   if (
     body &&
     observation &&
-    previousSettings &&
+    previousState &&
     activeBody === body &&
-    !semanticDirty &&
-    canReuseSemanticSession(previousSettings, state.settings, hostname)
+    canReuseSemanticSession(previousState, state, hostname)
   ) {
-    if (presentationSettingsChanged(previousSettings, state.settings)) {
-      refreshPresentation(body, state.settings);
+    if (presentationSettingsChanged(previousState, state)) {
+      refreshPresentation(body, activeProfile(state.localState));
     }
-    activeSettings = state.settings;
+    activeState = state;
     return;
   }
 
   stopCurrentSession();
 
-  if (!body || !effectiveEnabled(state.settings, hostname)) {
-    semanticDirty = false;
-    return;
-  }
+  if (!body || !effectiveEnabled(state.settings, hostname)) return;
+
+  const profile = activeProfile(state.localState);
+  const rules: CensorRule[] = [
+    ...(profileUsesEnglishProfanity(state.localState)
+      ? englishStrongProfanityRules
+      : []),
+    ...customRule(profileTerms(state.localState)),
+  ];
+
+  if (rules.length === 0) return;
 
   const controller = createDomScrawlix({
-    rules: [...englishStrongProfanityRules, ...customRule(state.customWords)],
-    coverage: coverageSelector(state.settings.coverage),
+    rules,
+    coverage: coverageSelector(profile.coverage),
   });
 
-  activeSettings = state.settings;
+  activeState = state;
   activeBody = body;
   observation = controller.observe(body);
-  refreshPresentation(body, state.settings);
-  semanticDirty = false;
+  refreshPresentation(body, profile);
 }
 
 function clickRootFromEvent(event: Event) {
@@ -172,9 +181,10 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
   const relevantSync =
     areaName === 'sync' && Object.prototype.hasOwnProperty.call(changes, SYNC_SETTINGS_KEY);
   const relevantLocal =
-    areaName === 'local' && Object.prototype.hasOwnProperty.call(changes, CUSTOM_WORDS_KEY);
+    areaName === 'local' &&
+    (Object.prototype.hasOwnProperty.call(changes, LOCAL_STATE_KEY) ||
+      Object.prototype.hasOwnProperty.call(changes, CUSTOM_WORDS_KEY));
 
-  if (relevantLocal) semanticDirty = true;
   if (relevantSync || relevantLocal) void restart();
 });
 

--- a/apps/extension/src/popup.css
+++ b/apps/extension/src/popup.css
@@ -24,6 +24,36 @@ textarea {
   font: inherit;
 }
 
+button {
+  color: inherit;
+  background: transparent;
+  border: 1px solid rgba(23, 21, 16, 0.48);
+  border-radius: 0;
+  padding: 7px 9px;
+  cursor: pointer;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+button:hover,
+button:focus-visible {
+  color: #f2eddf;
+  background: #171510;
+}
+
+button:disabled {
+  cursor: default;
+  opacity: 0.35;
+}
+
+button:disabled:hover {
+  color: inherit;
+  background: transparent;
+}
+
 .popup-shell {
   width: 340px;
   padding: 14px;
@@ -31,8 +61,9 @@ textarea {
 
 .masthead,
 .site-card,
+.profiles,
 .settings-grid,
-.custom-words,
+.lenses,
 footer {
   border-top: 1px solid #171510;
 }
@@ -68,7 +99,9 @@ footer {
 footer,
 .switch-row span,
 .settings-grid label > span,
-#save-status {
+.stacked-field > span,
+#local-save-status,
+.lens-title span {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
@@ -92,7 +125,8 @@ footer,
   letter-spacing: 0.08em;
 }
 
-.switch-row input {
+.switch-row input,
+.lens-toggle input {
   width: 17px;
   height: 17px;
   accent-color: #171510;
@@ -116,7 +150,8 @@ footer,
 }
 
 .site-card h1,
-.custom-words h2 {
+.profiles h2,
+.lenses h2 {
   margin: 0;
   font-family: Georgia, "Times New Roman", serif;
   font-weight: 600;
@@ -128,6 +163,11 @@ footer,
   font-size: 18px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.profiles h2,
+.lenses h2 {
+  font-size: 16px;
 }
 
 .status-line {
@@ -144,6 +184,7 @@ footer,
   content: '○ ';
 }
 
+input:not([type='checkbox']),
 select,
 textarea {
   width: 100%;
@@ -154,35 +195,22 @@ textarea {
   outline: none;
 }
 
+input:not([type='checkbox']),
 select {
   min-height: 34px;
   padding: 6px 8px;
   font-size: 11px;
 }
 
+input:focus,
 select:focus,
 textarea:focus {
   border-color: #171510;
   box-shadow: 0 0 0 1px #171510;
 }
 
-.settings-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 8px;
-  padding: 14px 0;
-}
-
-.settings-grid label > span {
-  display: block;
-  margin-bottom: 5px;
-  font-size: 8px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.custom-words {
+.profiles,
+.lenses {
   padding: 14px 0;
 }
 
@@ -194,12 +222,8 @@ textarea:focus {
   margin-bottom: 9px;
 }
 
-.custom-words h2 {
-  font-size: 16px;
-}
-
-#save-status {
-  min-width: 60px;
+#local-save-status {
+  min-width: 58px;
   font-size: 8px;
   text-align: right;
   text-transform: uppercase;
@@ -207,9 +231,105 @@ textarea:focus {
   opacity: 0.6;
 }
 
+.profile-picker {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 6px;
+}
+
+.stacked-field {
+  display: block;
+  margin-top: 8px;
+}
+
+.stacked-field > span,
+.settings-grid label > span {
+  display: block;
+  margin-bottom: 5px;
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.settings-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  padding: 14px 0;
+}
+
+.lens-list {
+  display: grid;
+  gap: 7px;
+}
+
+.lens-card {
+  border: 1px solid rgba(23, 21, 16, 0.42);
+  background: rgba(255, 255, 255, 0.22);
+  padding: 9px;
+}
+
+.lens-card[data-lens-kind='english-profanity'] {
+  background: rgba(23, 21, 16, 0.045);
+}
+
+.lens-card-header {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.lens-card-header > .lens-name,
+.lens-card-header > .lens-title {
+  flex: 1;
+  min-width: 0;
+}
+
+.lens-title {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.lens-title strong {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 14px;
+}
+
+.lens-title span {
+  font-size: 7px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.52;
+}
+
+.lens-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.lens-toggle span {
+  min-width: 18px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 7px;
+  text-transform: uppercase;
+  opacity: 0.58;
+}
+
+.lens-card textarea {
+  margin-top: 8px;
+}
+
+.danger-button {
+  border-color: rgba(23, 21, 16, 0.3);
+  opacity: 0.68;
+}
+
 textarea {
   resize: vertical;
-  min-height: 88px;
+  min-height: 70px;
   padding: 9px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 10px;
@@ -217,8 +337,9 @@ textarea {
 }
 
 .hint {
-  margin: 5px 0 0;
+  margin: 8px 0 0;
   font-size: 8px;
+  line-height: 1.4;
   opacity: 0.58;
 }
 

--- a/apps/extension/src/popup.ts
+++ b/apps/extension/src/popup.ts
@@ -1,18 +1,25 @@
 import './popup.css';
 import {
+  ENGLISH_PROFANITY_LENS_ID,
+  activeProfile,
   effectiveEnabled,
   normalizeCustomWords,
+  setActiveProfile,
   setSiteMode,
   siteModeFor,
+  updateActiveProfile,
   type ExtensionAppearance,
   type ExtensionCoverage,
+  type ExtensionLens,
+  type ExtensionLocalState,
+  type ExtensionProfile,
   type ExtensionReveal,
   type SiteMode,
   type SyncSettings,
 } from './config';
 import {
   loadExtensionState,
-  saveCustomWords,
+  saveLocalState,
   saveSettings,
 } from './storage';
 
@@ -27,14 +34,21 @@ const siteModeSelect = required<HTMLSelectElement>('site-mode');
 const appearanceSelect = required<HTMLSelectElement>('appearance');
 const coverageSelect = required<HTMLSelectElement>('coverage');
 const revealSelect = required<HTMLSelectElement>('reveal');
-const customWordsInput = required<HTMLTextAreaElement>('custom-words');
+const profileSelect = required<HTMLSelectElement>('profile');
+const profileNameInput = required<HTMLInputElement>('profile-name');
+const addProfileButton = required<HTMLButtonElement>('add-profile');
+const deleteProfileButton = required<HTMLButtonElement>('delete-profile');
+const lensList = required<HTMLDivElement>('lens-list');
+const addLensButton = required<HTMLButtonElement>('add-lens');
 const siteHeading = required<HTMLHeadingElement>('site-heading');
 const effectiveStatus = required<HTMLParagraphElement>('effective-status');
-const saveStatus = required<HTMLSpanElement>('save-status');
+const localSaveStatus = required<HTMLSpanElement>('local-save-status');
 
 let settings: SyncSettings;
+let localState: ExtensionLocalState;
 let hostname: string | null = null;
-let wordSaveTimer: number | null = null;
+let localSaveChain = Promise.resolve();
+let localSaveTimer: number | null = null;
 
 async function currentHostname() {
   const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -50,6 +64,10 @@ async function currentHostname() {
   }
 }
 
+function makeId(prefix: 'lens' | 'profile') {
+  return `${prefix}:${crypto.randomUUID()}`;
+}
+
 function renderEffectiveStatus() {
   if (!hostname) {
     siteHeading.textContent = 'This page is unavailable';
@@ -62,16 +80,165 @@ function renderEffectiveStatus() {
   siteModeSelect.disabled = false;
   siteModeSelect.value = siteModeFor(settings, hostname);
   const enabledHere = effectiveEnabled(settings, hostname);
-  effectiveStatus.textContent = enabledHere ? 'censoring is on here' : 'censoring is off here';
+  const profile = activeProfile(localState);
+  effectiveStatus.textContent = `${enabledHere ? 'censoring is on here' : 'censoring is off here'} · ${profile.name || 'Untitled profile'}`;
   effectiveStatus.dataset.enabled = enabledHere ? 'true' : 'false';
+}
+
+function renderProfiles() {
+  const profile = activeProfile(localState);
+  profileSelect.replaceChildren();
+
+  for (const candidate of localState.profiles) {
+    const option = document.createElement('option');
+    option.value = candidate.id;
+    option.textContent = candidate.name || 'Untitled profile';
+    profileSelect.append(option);
+  }
+
+  profileSelect.value = profile.id;
+  profileNameInput.value = profile.name;
+  deleteProfileButton.disabled = localState.profiles.length <= 1;
+}
+
+function replaceLens(
+  state: ExtensionLocalState,
+  lensId: string,
+  patch: Partial<Omit<ExtensionLens, 'id' | 'kind'>>
+): ExtensionLocalState {
+  return {
+    ...state,
+    lenses: state.lenses.map(lens =>
+      lens.id === lensId && lens.kind === 'terms' ? { ...lens, ...patch } : lens
+    ),
+  };
+}
+
+function removeLens(state: ExtensionLocalState, lensId: string): ExtensionLocalState {
+  return {
+    ...state,
+    lenses: state.lenses.filter(lens => lens.id !== lensId),
+    profiles: state.profiles.map(profile => ({
+      ...profile,
+      lensIds: profile.lensIds.filter(id => id !== lensId),
+    })),
+  };
+}
+
+function createLensToggle(lens: ExtensionLens, profile: ExtensionProfile) {
+  const label = document.createElement('label');
+  label.className = 'lens-toggle';
+
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.checked = profile.lensIds.includes(lens.id);
+  checkbox.setAttribute('aria-label', `Use ${lens.name} in ${profile.name}`);
+  checkbox.addEventListener('change', () => {
+    const nextIds = new Set(activeProfile(localState).lensIds);
+    if (checkbox.checked) nextIds.add(lens.id);
+    else nextIds.delete(lens.id);
+    void persistLocal(
+      updateActiveProfile(localState, { lensIds: Array.from(nextIds) })
+    );
+  });
+
+  const marker = document.createElement('span');
+  marker.textContent = checkbox.checked ? 'on' : 'off';
+
+  label.append(checkbox, marker);
+  return { checkbox, label };
+}
+
+function renderLenses() {
+  lensList.replaceChildren();
+  const profile = activeProfile(localState);
+
+  for (const lens of localState.lenses) {
+    const card = document.createElement('article');
+    card.className = 'lens-card';
+    card.dataset.lensKind = lens.kind;
+
+    const header = document.createElement('div');
+    header.className = 'lens-card-header';
+    const toggle = createLensToggle(lens, profile);
+    header.append(toggle.label);
+
+    if (lens.id === ENGLISH_PROFANITY_LENS_ID) {
+      const title = document.createElement('div');
+      title.className = 'lens-title';
+      const name = document.createElement('strong');
+      name.textContent = lens.name;
+      const detail = document.createElement('span');
+      detail.textContent = 'built-in English pack';
+      title.append(name, detail);
+      header.prepend(title);
+      card.append(header);
+    } else {
+      const nameInput = document.createElement('input');
+      nameInput.className = 'lens-name';
+      nameInput.value = lens.name;
+      nameInput.setAttribute('aria-label', 'Lens name');
+
+      const termsInput = document.createElement('textarea');
+      termsInput.rows = 3;
+      termsInput.value = lens.terms.join('\n');
+      termsInput.placeholder = 'Project Velvet\nClient Name\nspoiler phrase';
+      termsInput.spellcheck = false;
+      termsInput.setAttribute('aria-label', `${lens.name} terms`);
+
+      nameInput.addEventListener('input', () => {
+        const next = replaceLens(localState, lens.id, { name: nameInput.value });
+        toggle.checkbox.setAttribute(
+          'aria-label',
+          `Use ${nameInput.value || 'Untitled lens'} in ${activeProfile(next).name}`
+        );
+        termsInput.setAttribute(
+          'aria-label',
+          `${nameInput.value || 'Untitled lens'} terms`
+        );
+        scheduleLocal(next);
+      });
+      nameInput.addEventListener('change', () => void persistLocal(localState, false));
+
+      const deleteButton = document.createElement('button');
+      deleteButton.type = 'button';
+      deleteButton.className = 'danger-button';
+      deleteButton.textContent = 'remove';
+      deleteButton.addEventListener('click', () => {
+        void persistLocal(removeLens(localState, lens.id));
+      });
+
+      termsInput.addEventListener('input', () => {
+        scheduleLocal(
+          replaceLens(localState, lens.id, {
+            terms: normalizeCustomWords(termsInput.value.split('\n')),
+          })
+        );
+      });
+      termsInput.addEventListener('change', () => void persistLocal(localState, false));
+
+      header.prepend(nameInput);
+      header.append(deleteButton);
+      card.append(header, termsInput);
+    }
+
+    lensList.append(card);
+  }
+}
+
+function renderLocalState() {
+  const profile = activeProfile(localState);
+  renderProfiles();
+  appearanceSelect.value = profile.appearance;
+  coverageSelect.value = profile.coverage;
+  revealSelect.value = profile.reveal;
+  renderLenses();
+  renderEffectiveStatus();
 }
 
 function renderSettings() {
   enabledInput.checked = settings.enabled;
-  appearanceSelect.value = settings.appearance;
-  coverageSelect.value = settings.coverage;
-  revealSelect.value = settings.reveal;
-  renderEffectiveStatus();
+  renderLocalState();
 }
 
 async function persistSettings(next: SyncSettings) {
@@ -80,29 +247,37 @@ async function persistSettings(next: SyncSettings) {
   await saveSettings(settings);
 }
 
-function wordsFromTextarea() {
-  return normalizeCustomWords(customWordsInput.value.split('\n'));
+function enqueueLocalWrite(snapshot: ExtensionLocalState) {
+  localSaveStatus.textContent = 'saving…';
+  localSaveChain = localSaveChain
+    .then(() => saveLocalState(snapshot))
+    .then(() => {
+      if (localState === snapshot) localSaveStatus.textContent = 'saved';
+    })
+    .catch(() => {
+      localSaveStatus.textContent = 'save failed';
+    });
+  return localSaveChain;
 }
 
-async function persistWords() {
-  if (wordSaveTimer !== null) {
-    window.clearTimeout(wordSaveTimer);
-    wordSaveTimer = null;
+function persistLocal(next: ExtensionLocalState, rerender = true) {
+  if (localSaveTimer !== null) {
+    window.clearTimeout(localSaveTimer);
+    localSaveTimer = null;
   }
-
-  saveStatus.textContent = 'saving…';
-  try {
-    await saveCustomWords(wordsFromTextarea());
-    saveStatus.textContent = 'saved';
-  } catch {
-    saveStatus.textContent = 'save failed';
-  }
+  localState = next;
+  if (rerender) renderLocalState();
+  return enqueueLocalWrite(next);
 }
 
-function scheduleWordSave() {
-  if (wordSaveTimer !== null) window.clearTimeout(wordSaveTimer);
-  saveStatus.textContent = 'editing';
-  wordSaveTimer = window.setTimeout(() => void persistWords(), 250);
+function scheduleLocal(next: ExtensionLocalState) {
+  localState = next;
+  localSaveStatus.textContent = 'editing';
+  if (localSaveTimer !== null) window.clearTimeout(localSaveTimer);
+  localSaveTimer = window.setTimeout(() => {
+    localSaveTimer = null;
+    void enqueueLocalWrite(localState);
+  }, 250);
 }
 
 enabledInput.addEventListener('change', () => {
@@ -116,29 +291,96 @@ siteModeSelect.addEventListener('change', () => {
   );
 });
 
-appearanceSelect.addEventListener('change', () => {
-  void persistSettings({
-    ...settings,
-    appearance: appearanceSelect.value as ExtensionAppearance,
+profileSelect.addEventListener('change', () => {
+  void persistLocal(setActiveProfile(localState, profileSelect.value));
+});
+
+profileNameInput.addEventListener('input', () => {
+  const next = updateActiveProfile(localState, { name: profileNameInput.value });
+  const option = Array.from(profileSelect.options).find(
+    candidate => candidate.value === activeProfile(next).id
+  );
+  if (option) option.textContent = profileNameInput.value || 'Untitled profile';
+  localState = next;
+  renderEffectiveStatus();
+  scheduleLocal(next);
+});
+profileNameInput.addEventListener('change', () => void persistLocal(localState, false));
+
+addProfileButton.addEventListener('click', () => {
+  const source = activeProfile(localState);
+  const profile: ExtensionProfile = {
+    ...source,
+    id: makeId('profile'),
+    name: `Profile ${localState.profiles.length + 1}`,
+    lensIds: [...source.lensIds],
+  };
+  void persistLocal({
+    ...localState,
+    profiles: [...localState.profiles, profile],
+    activeProfileId: profile.id,
   });
+});
+
+deleteProfileButton.addEventListener('click', () => {
+  if (localState.profiles.length <= 1) return;
+  const active = activeProfile(localState);
+  const profiles = localState.profiles.filter(profile => profile.id !== active.id);
+  void persistLocal({
+    ...localState,
+    profiles,
+    activeProfileId: profiles[0]!.id,
+  });
+});
+
+appearanceSelect.addEventListener('change', () => {
+  void persistLocal(
+    updateActiveProfile(localState, {
+      appearance: appearanceSelect.value as ExtensionAppearance,
+    }),
+    false
+  );
 });
 
 coverageSelect.addEventListener('change', () => {
-  void persistSettings({
-    ...settings,
-    coverage: coverageSelect.value as ExtensionCoverage,
-  });
+  void persistLocal(
+    updateActiveProfile(localState, {
+      coverage: coverageSelect.value as ExtensionCoverage,
+    }),
+    false
+  );
 });
 
 revealSelect.addEventListener('change', () => {
-  void persistSettings({
-    ...settings,
-    reveal: revealSelect.value as ExtensionReveal,
-  });
+  void persistLocal(
+    updateActiveProfile(localState, {
+      reveal: revealSelect.value as ExtensionReveal,
+    }),
+    false
+  );
 });
 
-customWordsInput.addEventListener('input', scheduleWordSave);
-customWordsInput.addEventListener('change', () => void persistWords());
+addLensButton.addEventListener('click', () => {
+  const lens: ExtensionLens = {
+    id: makeId('lens'),
+    name: `Lens ${localState.lenses.filter(candidate => candidate.kind === 'terms').length + 1}`,
+    kind: 'terms',
+    terms: [],
+  };
+  const profile = activeProfile(localState);
+  const next = updateActiveProfile(
+    { ...localState, lenses: [...localState.lenses, lens] },
+    { lensIds: [...profile.lensIds, lens.id] }
+  );
+  void persistLocal(next);
+});
+
+window.addEventListener('pagehide', () => {
+  if (localSaveTimer === null) return;
+  window.clearTimeout(localSaveTimer);
+  localSaveTimer = null;
+  void enqueueLocalWrite(localState);
+});
 
 async function initialize() {
   const [state, activeHostname] = await Promise.all([
@@ -147,8 +389,8 @@ async function initialize() {
   ]);
 
   settings = state.settings;
+  localState = state.localState;
   hostname = activeHostname;
-  customWordsInput.value = state.customWords.join('\n');
   renderSettings();
 }
 

--- a/apps/extension/src/session.test.ts
+++ b/apps/extension/src/session.test.ts
@@ -1,57 +1,137 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_SETTINGS } from './config';
+import {
+  DEFAULT_SETTINGS,
+  createDefaultLocalState,
+  updateActiveProfile,
+  type ExtensionLens,
+  type ExtensionLocalState,
+} from './config';
 import {
   canReuseSemanticSession,
   presentationSettingsChanged,
+  type ExtensionSessionState,
 } from './session';
 
-describe('extension session classification', () => {
-  it('reuses semantic work for appearance and reveal changes', () => {
-    const next = {
-      ...DEFAULT_SETTINGS,
-      appearance: 'bar' as const,
-      reveal: 'click' as const,
-    };
+function session(
+  localState = createDefaultLocalState(),
+  settings = DEFAULT_SETTINGS
+): ExtensionSessionState {
+  return { settings, localState };
+}
 
-    expect(canReuseSemanticSession(DEFAULT_SETTINGS, next, 'example.com')).toBe(
-      true
+function withTermLens(
+  state: ExtensionLocalState,
+  lens: ExtensionLens,
+  active = true
+): ExtensionLocalState {
+  return updateActiveProfile(
+    { ...state, lenses: [...state.lenses, lens] },
+    active
+      ? { lensIds: [...state.profiles[0]!.lensIds, lens.id] }
+      : { lensIds: state.profiles[0]!.lensIds }
+  );
+}
+
+describe('extension session classification', () => {
+  it('reuses semantic work for active-profile appearance and reveal changes', () => {
+    const active = session();
+    const next = session(
+      updateActiveProfile(active.localState, {
+        appearance: 'bar',
+        reveal: 'click',
+      })
     );
-    expect(presentationSettingsChanged(DEFAULT_SETTINGS, next)).toBe(true);
+
+    expect(canReuseSemanticSession(active, next, 'example.com')).toBe(true);
+    expect(presentationSettingsChanged(active, next)).toBe(true);
   });
 
-  it('requires a semantic restart when coverage changes', () => {
-    const next = { ...DEFAULT_SETTINGS, coverage: 'full' as const };
+  it('requires a semantic restart when active-profile coverage changes', () => {
+    const active = session();
+    const next = session(
+      updateActiveProfile(active.localState, { coverage: 'full' })
+    );
 
-    expect(canReuseSemanticSession(DEFAULT_SETTINGS, next, 'example.com')).toBe(
+    expect(canReuseSemanticSession(active, next, 'example.com')).toBe(false);
+  });
+
+  it('requires a semantic restart when active lens terms change', () => {
+    const lens = {
+      id: 'lens:private',
+      name: 'Private',
+      kind: 'terms' as const,
+      terms: ['Mothbit'],
+    };
+    const activeLocal = withTermLens(createDefaultLocalState(), lens);
+    const nextLocal = {
+      ...activeLocal,
+      lenses: activeLocal.lenses.map(candidate =>
+        candidate.id === lens.id
+          ? { ...candidate, terms: ['Mothbit', 'Project Velvet'] }
+          : candidate
+      ),
+    };
+
+    expect(
+      canReuseSemanticSession(session(activeLocal), session(nextLocal), 'example.com')
+    ).toBe(false);
+  });
+
+  it('reuses semantic work when an inactive lens changes', () => {
+    const lens = {
+      id: 'lens:spoilers',
+      name: 'Spoilers',
+      kind: 'terms' as const,
+      terms: ['Rosebud'],
+    };
+    const activeLocal = withTermLens(createDefaultLocalState(), lens, false);
+    const nextLocal = {
+      ...activeLocal,
+      lenses: activeLocal.lenses.map(candidate =>
+        candidate.id === lens.id
+          ? { ...candidate, terms: ['Rosebud', 'Tyler Durden'] }
+          : candidate
+      ),
+    };
+
+    expect(
+      canReuseSemanticSession(session(activeLocal), session(nextLocal), 'example.com')
+    ).toBe(true);
+    expect(presentationSettingsChanged(session(activeLocal), session(nextLocal))).toBe(
       false
     );
   });
 
   it('cannot reuse an active session when the site becomes disabled', () => {
-    const next = { ...DEFAULT_SETTINGS, enabled: false };
+    const active = session();
+    const next = session(active.localState, { ...DEFAULT_SETTINGS, enabled: false });
 
-    expect(canReuseSemanticSession(DEFAULT_SETTINGS, next, 'example.com')).toBe(
-      false
-    );
+    expect(canReuseSemanticSession(active, next, 'example.com')).toBe(false);
   });
 
   it('can reuse when a site override keeps the current host enabled', () => {
-    const active = {
+    const settings = {
       ...DEFAULT_SETTINGS,
       enabled: false,
       siteOverrides: { 'example.com': 'on' as const },
     };
-    const next = { ...active, appearance: 'blur' as const };
+    const active = session(createDefaultLocalState(), settings);
+    const next = session(
+      updateActiveProfile(active.localState, { appearance: 'blur' }),
+      settings
+    );
 
     expect(canReuseSemanticSession(active, next, 'example.com')).toBe(true);
   });
 
-  it('skips presentation work when only unrelated settings change', () => {
-    const next = {
+  it('ignores unrelated site overrides for presentation work', () => {
+    const active = session();
+    const next = session(active.localState, {
       ...DEFAULT_SETTINGS,
       siteOverrides: { 'other.example': 'off' as const },
-    };
+    });
 
-    expect(presentationSettingsChanged(DEFAULT_SETTINGS, next)).toBe(false);
+    expect(canReuseSemanticSession(active, next, 'example.com')).toBe(true);
+    expect(presentationSettingsChanged(active, next)).toBe(false);
   });
 });

--- a/apps/extension/src/session.ts
+++ b/apps/extension/src/session.ts
@@ -1,20 +1,57 @@
-import { effectiveEnabled, type SyncSettings } from './config';
+import {
+  activeProfile,
+  effectiveEnabled,
+  profileTerms,
+  profileUsesEnglishProfanity,
+  type ExtensionLocalState,
+  type SyncSettings,
+} from './config';
+
+export type ExtensionSessionState = {
+  settings: SyncSettings;
+  localState: ExtensionLocalState;
+};
+
+function canonicalTerms(state: ExtensionLocalState) {
+  return profileTerms(state)
+    .map(term => term.toLowerCase())
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function sameTerms(left: readonly string[], right: readonly string[]) {
+  return (
+    left.length === right.length &&
+    left.every((term, index) => term === right[index])
+  );
+}
 
 export function canReuseSemanticSession(
-  active: SyncSettings,
-  next: SyncSettings,
+  active: ExtensionSessionState,
+  next: ExtensionSessionState,
   hostname: string
 ) {
+  const activeProfileValue = activeProfile(active.localState);
+  const nextProfileValue = activeProfile(next.localState);
+
   return (
-    active.coverage === next.coverage &&
-    effectiveEnabled(active, hostname) &&
-    effectiveEnabled(next, hostname)
+    activeProfileValue.coverage === nextProfileValue.coverage &&
+    profileUsesEnglishProfanity(active.localState) ===
+      profileUsesEnglishProfanity(next.localState) &&
+    sameTerms(canonicalTerms(active.localState), canonicalTerms(next.localState)) &&
+    effectiveEnabled(active.settings, hostname) &&
+    effectiveEnabled(next.settings, hostname)
   );
 }
 
 export function presentationSettingsChanged(
-  active: SyncSettings,
-  next: SyncSettings
+  active: ExtensionSessionState,
+  next: ExtensionSessionState
 ) {
-  return active.appearance !== next.appearance || active.reveal !== next.reveal;
+  const activeProfileValue = activeProfile(active.localState);
+  const nextProfileValue = activeProfile(next.localState);
+
+  return (
+    activeProfileValue.appearance !== nextProfileValue.appearance ||
+    activeProfileValue.reveal !== nextProfileValue.reveal
+  );
 }

--- a/apps/extension/src/storage.ts
+++ b/apps/extension/src/storage.ts
@@ -1,8 +1,12 @@
 import {
   CUSTOM_WORDS_KEY,
+  LOCAL_STATE_KEY,
   SYNC_SETTINGS_KEY,
+  createDefaultLocalState,
   normalizeCustomWords,
+  normalizeLocalState,
   normalizeSettings,
+  type ExtensionLocalState,
   type SyncSettings,
 } from './config';
 
@@ -26,11 +30,26 @@ export async function saveCustomWords(words: readonly string[]) {
   });
 }
 
+export async function saveLocalState(state: ExtensionLocalState) {
+  await chrome.storage.local.set({ [LOCAL_STATE_KEY]: state });
+}
+
 export async function loadExtensionState() {
-  const [settings, customWords] = await Promise.all([
-    loadSettings(),
-    loadCustomWords(),
+  const [syncStored, localStored] = await Promise.all([
+    chrome.storage.sync.get(SYNC_SETTINGS_KEY),
+    chrome.storage.local.get([LOCAL_STATE_KEY, CUSTOM_WORDS_KEY]),
   ]);
 
-  return { settings, customWords };
+  const settings = normalizeSettings(syncStored[SYNC_SETTINGS_KEY]);
+  const legacyCustomWords = normalizeCustomWords(localStored[CUSTOM_WORDS_KEY]);
+  const hasLocalState = localStored[LOCAL_STATE_KEY] !== undefined;
+  const localState = hasLocalState
+    ? normalizeLocalState(localStored[LOCAL_STATE_KEY], settings, legacyCustomWords)
+    : createDefaultLocalState(settings, legacyCustomWords);
+
+  if (!hasLocalState) {
+    await saveLocalState(localState);
+  }
+
+  return { settings, localState };
 }

--- a/tests/browser/browser.spec.ts
+++ b/tests/browser/browser.spec.ts
@@ -1,7 +1,31 @@
-import { chromium, expect, test } from '@playwright/test';
+import { chromium, expect, test, type BrowserContext } from '@playwright/test';
 import { resolve } from 'node:path';
 
 const extensionPath = resolve(process.cwd(), 'apps/extension/dist');
+
+async function loadedExtensionId(context: BrowserContext) {
+  const extensionsPage = await context.newPage();
+  await extensionsPage.goto('chrome://extensions/');
+  const items = extensionsPage.locator('extensions-item');
+  await expect.poll(() => items.count()).toBeGreaterThan(0);
+
+  const extensionId = await items.evaluateAll(elements => {
+    for (const element of elements) {
+      const item = element as HTMLElement & {
+        data?: { id?: string; name?: string };
+      };
+      const text = item.shadowRoot?.textContent ?? '';
+      if (item.data?.name === 'Scrawlix' || text.toLowerCase().includes('scrawlix')) {
+        return item.id || item.data?.id || '';
+      }
+    }
+    return '';
+  });
+
+  await extensionsPage.close();
+  if (!extensionId) throw new Error('Could not resolve the unpacked Scrawlix extension id.');
+  return extensionId;
+}
 
 test('demo controls drive real rendered coverage and reveal state', async ({ page }) => {
   await page.goto('http://127.0.0.1:4173');
@@ -56,6 +80,7 @@ test('built extension transforms initial and dynamic page text in Chromium', asy
     await expect(
       page.locator('#initial [data-scrawlix-cover]')
     ).toHaveText('uc');
+    await expect(page.locator('#private [data-scrawlix-dom-root]')).toHaveCount(0);
 
     await expect(page.locator('#code [data-scrawlix-dom-root]')).toHaveCount(0);
     await expect(page.locator('#editable [data-scrawlix-dom-root]')).toHaveCount(0);
@@ -79,6 +104,81 @@ test('built extension transforms initial and dynamic page text in Chromium', asy
     await page.locator('#native-link').click();
     await expect(page).toHaveURL('http://127.0.0.1:4174/clicked.html');
     await expect(page.locator('#clicked')).toHaveText('native link worked');
+  } finally {
+    await context.close();
+  }
+});
+
+test('built extension switches lens profiles and restores the live page', async ({}, testInfo) => {
+  const context = await chromium.launchPersistentContext(
+    testInfo.outputPath('extension-lens-profiles'),
+    {
+      channel: 'chromium',
+      headless: true,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+      ],
+    }
+  );
+
+  try {
+    const page = context.pages()[0] ?? (await context.newPage());
+    await page.goto('http://127.0.0.1:4174/fixture.html');
+    await expect(page.locator('#initial [data-scrawlix-dom-root]')).toHaveCount(1);
+    await expect(page.locator('#private [data-scrawlix-dom-root]')).toHaveCount(0);
+
+    const extensionId = await loadedExtensionId(context);
+    const popup = await context.newPage();
+    await popup.goto(`chrome-extension://${extensionId}/popup.html`);
+    const profilePicker = popup.locator('#profile');
+    await expect(profilePicker).toHaveValue('profile:everyday');
+
+    await popup.getByRole('button', { name: '+ lens' }).click();
+    let customLenses = popup.locator('.lens-card[data-lens-kind="terms"]');
+    await expect(customLenses).toHaveCount(1);
+    await customLenses.last().locator('.lens-name').fill('Private');
+    await customLenses.last().locator('textarea').fill('Mothbit');
+    await expect(popup.locator('#local-save-status')).toHaveText('saved');
+    await expect(page.locator('#private [data-scrawlix-dom-root]')).toHaveCount(1);
+
+    await popup.getByRole('button', { name: '+ lens' }).click();
+    customLenses = popup.locator('.lens-card[data-lens-kind="terms"]');
+    await expect(customLenses).toHaveCount(2);
+    await customLenses.last().locator('.lens-name').fill('Spoilers');
+    await customLenses.last().locator('textarea').fill('Rosebud');
+    await expect(popup.locator('#local-save-status')).toHaveText('saved');
+
+    await popup.getByRole('button', { name: 'new', exact: true }).click();
+    await popup.getByLabel('profile name').fill('Presentation');
+    await popup.getByLabel('appearance').selectOption('bar');
+    await popup.getByLabel('coverage').selectOption('full');
+    await popup.getByLabel('reveal').selectOption('never');
+
+    const profanityCard = popup.locator(
+      '.lens-card[data-lens-kind="english-profanity"]'
+    );
+    await profanityCard.locator('input[type="checkbox"]').uncheck();
+    await expect(popup.locator('#local-save-status')).toHaveText('saved');
+
+    await expect(page.locator('#initial [data-scrawlix-dom-root]')).toHaveCount(0);
+    await expect(page.locator('#initial')).toHaveText('well, fuck this');
+
+    const privateRoot = page.locator('#private [data-scrawlix-dom-root]');
+    await expect(privateRoot).toHaveCount(1);
+    await expect(privateRoot).toHaveAttribute('data-scrawlix-appearance', 'bar');
+    await expect(privateRoot).toHaveAttribute('data-scrawlix-reveal', 'never');
+    await expect(privateRoot.locator('[data-scrawlix-cover]')).toHaveText('Mothbit');
+
+    await profilePicker.selectOption({ label: 'Everyday' });
+    await expect(page.locator('#initial [data-scrawlix-dom-root]')).toHaveCount(1);
+    await expect(page.locator('#private [data-scrawlix-dom-root]')).toHaveCount(1);
+    await expect(page.locator('#private [data-scrawlix-dom-root]')).toHaveAttribute(
+      'data-scrawlix-appearance',
+      'scrawl'
+    );
+
+    await popup.close();
   } finally {
     await context.close();
   }

--- a/tests/browser/fixture-server.mjs
+++ b/tests/browser/fixture-server.mjs
@@ -9,6 +9,7 @@ const fixture = `<!doctype html>
   <body>
     <main>
       <p id="initial">well, fuck this</p>
+      <p id="private">Mothbit remains private</p>
       <p><code id="code">fuck</code></p>
       <div id="editable" contenteditable="true">fuck</div>
       <button id="native-button" type="button">fuck</button>


### PR DESCRIPTION
## What

Turns the extension's single custom-word bucket into a local lens/profile model while preserving the existing global + per-site enable policy.

- built-in **Profanity** lens plus any number of local term lenses
- profiles reference multiple active lenses
- each profile owns appearance, coverage, and reveal choices
- one-select profile switching in the popup
- create/rename/delete profiles
- create/edit/remove custom lenses and toggle them per profile
- legacy custom words + treatment migrate into an **Everyday** profile on first load
- profile/lens changes reuse the current restore-then-reconfigure DOM lifecycle
- term/name editing is debounced to avoid page restart churn
- unit coverage for migration/normalization/profile helpers
- real Chromium smoke that creates two lenses, creates a Presentation profile, disables profanity there, changes its treatment, and verifies the live page restores/re-renders when profiles switch

## Storage

`enabled` + sparse hostname overrides remain in `chrome.storage.sync`. Lens/profile state stays in `chrome.storage.local`, including the active profile id, because profile ids only make sense beside the local profiles they reference.

The old synced appearance/coverage/reveal values remain readable as migration seeds. The old custom-word key remains readable for first-run migration.

## Current-main compatibility

The branch was rebuilt as one clean commit on top of the release-hardening changes from #61 and #72. It uses the canonical `censorRuleFromTerms` and `englishStrongProfanityRules` exports and retains the compatibility/versioning changelog entries from main.

## Validation

CI is green on the current head:

- [x] workspace typecheck
- [x] unit tests
- [x] package + application builds
- [x] demo Chromium smoke
- [x] extension Chromium smoke
- [x] real built-popup lens/profile creation and live-page restore/re-render smoke
- [x] packed-package smoke, including React 18 and React 19 consumers

## Scope

No accounts, backend, marketplace, cross-device profile sync, or remote packs in this slice.

Closes #30