### PR TITLE
Execute packed-package runtime smoke assertions

### DIFF
--- a/fixtures/consumer/runtime.mjs
+++ b/fixtures/consumer/runtime.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { createScrawlix } from '@scrawlix/core';
+import { createDomScrawlix } from '@scrawlix/dom';
+import { englishProfanityRules } from '@scrawlix/en';
+import { englishProfanityCorpus } from '@scrawlix/en/corpus';
+import { transformHast } from '@scrawlix/rehype';
+import { CensoredText } from '@scrawlix/react';
+
+const engine = createScrawlix({
+  rules: englishProfanityRules,
+  coverage: 'middle',
+});
+
+const matches = engine.find('well, fuck');
+assert.equal(matches.length, 1);
+assert.equal(matches[0]?.targetText.toLowerCase(), 'fuck');
+assert.ok(englishProfanityCorpus.some(testCase => testCase.id === 'fuck-base'));
+
+const tree = {
+  type: 'root',
+  children: [
+    {
+      type: 'element',
+      tagName: 'p',
+      properties: {},
+      children: [{ type: 'text', value: 'well, fuck' }],
+    },
+  ],
+};
+
+transformHast(tree, {
+  rules: englishProfanityRules,
+  coverage: 'middle',
+});
+
+const paragraph = tree.children[0];
+assert.equal(paragraph?.type, 'element');
+assert.ok(
+  paragraph.children.some(
+    child =>
+      child.type === 'element' &&
+      Object.prototype.hasOwnProperty.call(
+        child.properties ?? {},
+        'data-scrawlix-cover'
+      )
+  )
+);
+
+assert.equal(typeof CensoredText, 'function');
+assert.equal(typeof createDomScrawlix, 'function');
+
+console.log('Scrawlix packed-package runtime smoke passed.');

--- a/scripts/smoke-packages.mjs
+++ b/scripts/smoke-packages.mjs
@@ -88,6 +88,7 @@ try {
   writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
 
   run(['install', '--no-frozen-lockfile'], consumerDirectory);
+  run(['exec', 'node', 'runtime.mjs'], consumerDirectory);
   run(['typecheck'], consumerDirectory);
   run(['build'], consumerDirectory);
 


### PR DESCRIPTION
## What changed

- add a plain Node ESM runtime fixture to the external packed-package consumer
- execute it after installing the generated tarballs
- exercise `@scrawlix/core`, `@scrawlix/en`, `@scrawlix/en/corpus`, `@scrawlix/rehype`, and runtime imports from the React/DOM packages
- keep the existing TypeScript and Vite build checks after the runtime smoke

## Why

The consumer already contained runtime assertions in `src/main.tsx`, but the package smoke only typechecked and bundled that file. Vite can successfully build code without executing its top-level assertions, so the release gate proved resolution/bundling while leaving runtime package failures invisible.

Refs #18.