### PR TITLE
Harden grapheme masks and React reveal state

### DIFF
--- a/apps/extension/src/config.test.ts
+++ b/apps/extension/src/config.test.ts
@@ -59,10 +59,11 @@ describe('extension settings', () => {
     expect(coverageSelector('middle')).toBe('middle');
   });
 
-  it('generates symbol masks without rewriting source text', () => {
+  it('generates symbol masks by grapheme count without rewriting source text', () => {
     expect(maskFor('fuck', 'asterisk')).toBe('****');
     expect(maskFor('abcdef', 'grawlix')).toBe('@#$%&!');
-    expect(maskFor('🔥x', 'asterisk')).toBe('**');
+    expect(maskFor('e\u0301❤️👍🏽🇺🇸👨‍👩‍👧‍👦', 'asterisk')).toBe('*****');
+    expect(maskFor('e\u0301❤️👍🏽🇺🇸👨‍👩‍👧‍👦', 'grawlix')).toBe('@#$%&');
     expect(maskFor('fuck', 'bar')).toBe('');
   });
 });

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -46,6 +46,17 @@ const COVERAGES = new Set<ExtensionCoverage>([
   'vowel',
 ]);
 const REVEALS = new Set<ExtensionReveal>(['hover', 'focus', 'click', 'never']);
+const graphemeSegmenter =
+  typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
+    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    : null;
+
+function graphemeCount(value: string) {
+  if (graphemeSegmenter) {
+    return [...graphemeSegmenter.segment(value)].length;
+  }
+  return Array.from(value).length;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -132,7 +143,7 @@ export function coverageSelector(coverage: ExtensionCoverage): CoverageSelector 
 }
 
 export function maskFor(text: string, appearance: ExtensionAppearance) {
-  const length = Array.from(text).length;
+  const length = graphemeCount(text);
   if (appearance === 'asterisk') return '*'.repeat(length);
   if (appearance === 'grawlix') {
     const symbols = '@#$%&!';

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -27,6 +27,14 @@ function render(element: ReactElement) {
   return container;
 }
 
+function rerender(element: ReactElement) {
+  const mounted = mountedRoots.at(-1)!;
+  act(() => {
+    mounted.root.render(element);
+  });
+  return mounted.container;
+}
+
 afterEach(() => {
   while (mountedRoots.length > 0) {
     const mounted = mountedRoots.pop()!;
@@ -114,6 +122,56 @@ describe('CensoredText', () => {
 
     act(() => root.dispatchEvent(new MouseEvent('click', { bubbles: true })));
     expect(root.dataset.revealed).toBe('false');
+  });
+
+  it('conceals different censored text after a click-revealed value changes', () => {
+    const changingRules = [
+      { id: 'strong', pattern: /(?:fuck|shit)/giu },
+    ] as const;
+    const container = render(
+      <CensoredText reveal="click" rules={changingRules} text="fuck" />
+    );
+    let root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
+
+    act(() => root.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(root.dataset.revealed).toBe('true');
+
+    rerender(
+      <CensoredText reveal="click" rules={changingRules} text="shit" />
+    );
+    root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
+    expect(root.dataset.revealed).toBe('false');
+  });
+
+  it('does not revive reveal state across a safe-text transition', () => {
+    const container = render(
+      <CensoredText reveal="click" rules={rules} text="fuck" />
+    );
+    let root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
+
+    act(() => root.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(root.dataset.revealed).toBe('true');
+
+    rerender(<CensoredText reveal="click" rules={rules} text="safe" />);
+    expect(container.querySelector('[data-scrawlix-root]')).toBeNull();
+
+    rerender(<CensoredText reveal="click" rules={rules} text="fuck" />);
+    root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
+    expect(root.dataset.revealed).toBe('false');
+  });
+
+  it('preserves reveal state across an equivalent rerender', () => {
+    const container = render(
+      <CensoredText reveal="click" rules={rules} text="fuck" />
+    );
+    let root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
+
+    act(() => root.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(root.dataset.revealed).toBe('true');
+
+    rerender(<CensoredText reveal="click" rules={rules} text="fuck" />);
+    root = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
+    expect(root.dataset.revealed).toBe('true');
   });
 
   it.each(['Enter', ' '])('toggles click reveal with %j', key => {

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -154,18 +154,19 @@ describe('CensoredText', () => {
   });
 
   it('cycles grawlix symbols by covered grapheme count', () => {
-    const fullRule = [{ id: 'whole', pattern: /abcdef/giu }] as const;
+    const graphemeText = 'e\u0301❤️👍🏽🇺🇸👨‍👩‍👧‍👦';
+    const fullRule = [{ id: 'whole', pattern: /.+/u }] as const;
     const container = render(
       <CensoredText
         appearance="grawlix"
         coverage="full"
         rules={fullRule}
-        text="abcdef"
+        text={graphemeText}
       />
     );
 
     expect(
       container.querySelector<HTMLElement>('[data-scrawlix-mask]')?.textContent
-    ).toBe('@#$%&!');
+    ).toBe('@#$%&');
   });
 });

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -27,14 +27,26 @@ export type CensoredTextProps = {
 };
 
 const GRAWLIX = '@#$%&!';
+const graphemeSegmenter =
+  typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
+    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    : null;
+
+function graphemeCount(value: string) {
+  if (graphemeSegmenter) {
+    return [...graphemeSegmenter.segment(value)].length;
+  }
+  return Array.from(value).length;
+}
 
 function symbolsFor(text: string, appearance: ScrawlixAppearance) {
-  const characters = Array.from(text);
-  if (appearance === 'asterisk') return characters.map(() => '*').join('');
+  const length = graphemeCount(text);
+  if (appearance === 'asterisk') return '*'.repeat(length);
   if (appearance === 'grawlix') {
-    return characters
-      .map((_, index) => GRAWLIX[index % GRAWLIX.length])
-      .join('');
+    return Array.from(
+      { length },
+      (_, index) => GRAWLIX[index % GRAWLIX.length]
+    ).join('');
   }
   return text;
 }

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -26,6 +26,14 @@ export type CensoredTextProps = {
   title?: string;
 };
 
+type RevealState = {
+  text: string;
+  rules: readonly CensorRule[];
+  coverage: CoverageSelector;
+  reveal: ScrawlixReveal;
+  revealed: boolean;
+};
+
 const GRAWLIX = '@#$%&!';
 const graphemeSegmenter =
   typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
@@ -51,6 +59,21 @@ function symbolsFor(text: string, appearance: ScrawlixAppearance) {
   return text;
 }
 
+function sameRevealInputs(
+  state: RevealState,
+  text: string,
+  rules: readonly CensorRule[],
+  coverage: CoverageSelector,
+  reveal: ScrawlixReveal
+) {
+  return (
+    state.text === text &&
+    state.rules === rules &&
+    state.coverage === coverage &&
+    state.reveal === reveal
+  );
+}
+
 export function CensoredText({
   text,
   rules,
@@ -66,17 +89,47 @@ export function CensoredText({
   );
   const segments = engine.segment(text);
   const hasCoveredText = segments.some(segment => segment.covered);
-  const [revealed, setRevealed] = useState(false);
+  const [revealState, setRevealState] = useState<RevealState>(() => ({
+    text,
+    rules,
+    coverage,
+    reveal,
+    revealed: false,
+  }));
+  const sameInputs = sameRevealInputs(
+    revealState,
+    text,
+    rules,
+    coverage,
+    reveal
+  );
+  const revealed = sameInputs ? revealState.revealed : false;
+
+  if (!sameInputs) {
+    setRevealState({ text, rules, coverage, reveal, revealed: false });
+  }
 
   if (!hasCoveredText) return <>{text}</>;
 
   const interactive = reveal === 'focus' || reveal === 'click';
 
+  function toggleReveal() {
+    setRevealState(current => ({
+      text,
+      rules,
+      coverage,
+      reveal,
+      revealed: sameRevealInputs(current, text, rules, coverage, reveal)
+        ? !current.revealed
+        : true,
+    }));
+  }
+
   function onKeyDown(event: KeyboardEvent<HTMLSpanElement>) {
     if (reveal !== 'click') return;
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
-      setRevealed(value => !value);
+      toggleReveal();
     }
   }
 
@@ -87,7 +140,7 @@ export function CensoredText({
       data-reveal={reveal}
       data-revealed={revealed ? 'true' : 'false'}
       tabIndex={interactive ? 0 : undefined}
-      onClick={reveal === 'click' ? () => setRevealed(value => !value) : undefined}
+      onClick={reveal === 'click' ? toggleReveal : undefined}
       onKeyDown={onKeyDown}
     >
       <span data-scrawlix-a11y>{text}</span>


### PR DESCRIPTION
## What changed

- count React asterisk/grawlix masks with `Intl.Segmenter` grapheme clusters when available
- apply the same grapheme-count rule to extension masks
- preserve the code-point fallback for runtimes without `Intl.Segmenter`
- replace friendly Unicode cases with decomposed accent, variation-selector, skin-tone, flag, and family-ZWJ regressions
- reset React click-reveal state synchronously when `text`, `rules`, `coverage`, or reveal policy changes
- preserve reveal state across an equivalent rerender with the same censor inputs

## Why

Semantic coverage already works in grapheme clusters, while presentation counted code points. Multi-code-point graphemes could render too many masking symbols.

React reveal state also belonged to the component instance indefinitely, allowing different censored content to inherit a previous click reveal. The new state is tied to the current censor inputs and resets before changed content commits.

This stays deliberately local while core matcher work is active on `main`.

Refs #56.
Closes #65.