### PR TITLE
Add a live X-ray mode to the demo

### DIFF
--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -1,4 +1,9 @@
-import { type CoveragePreset, type CoverageSelector } from '@scrawlix/core';
+import {
+  createScrawlix,
+  type CoveragePreset,
+  type CoverageSelector,
+  type ScrawlixSegment,
+} from '@scrawlix/core';
 import {
   englishProfanityRules,
   englishVowelCoverage,
@@ -36,6 +41,7 @@ const revealScopes: readonly ScrawlixRevealScope[] = ['match', 'component'];
 
 const defaultText =
   'This fucking delightful little thing can censor shit without flattening every word into the same black rectangle.';
+const xrayText = 'motherfucker';
 
 const specimens = [
   'fuck',
@@ -78,11 +84,32 @@ function SegmentControl<T extends string>({
   );
 }
 
+function CoverageDiagram({
+  matchId,
+  segments,
+}: {
+  matchId: string;
+  segments: readonly ScrawlixSegment[];
+}) {
+  return (
+    <>
+      {segments.map(segment =>
+        segment.covered && segment.matchIds.includes(matchId) ? (
+          <mark key={`${segment.start}-${segment.end}`}>{segment.text}</mark>
+        ) : (
+          <span key={`${segment.start}-${segment.end}`}>{segment.text}</span>
+        )
+      )}
+    </>
+  );
+}
+
 export function App() {
   const [appearance, setAppearance] = useState<ScrawlixAppearance>('scrawl');
   const [coverage, setCoverage] = useState<CoverageChoice>('middle');
   const [reveal, setReveal] = useState<ScrawlixReveal>('hover');
   const [revealScope, setRevealScope] = useState<ScrawlixRevealScope>('match');
+  const [showXray, setShowXray] = useState(true);
   const [text, setText] = useState(defaultText);
   const coverageSelector = selectorForCoverage(coverage);
 
@@ -95,6 +122,23 @@ export function App() {
     return `import { englishProfanityRules${coverage === 'vowel' ? ', englishVowelCoverage' : ''} } from '@scrawlix/en';\nimport { CensoredText } from '@scrawlix/react';\n\n<CensoredText\n  text={copy}\n  rules={englishProfanityRules}\n${coverageLine}\n  appearance="${appearance}"\n  reveal="${reveal}"\n  revealScope="${revealScope}"\n/>`;
   }, [appearance, coverage, reveal, revealScope]);
 
+  const xrayEngine = useMemo(
+    () =>
+      createScrawlix({
+        rules: englishProfanityRules,
+        coverage: coverageSelector,
+      }),
+    [coverageSelector]
+  );
+  const xrayMatch = xrayEngine.find(xrayText)[0];
+  const xraySegments = xrayEngine.segment(xrayText);
+  const xrayCoveredSegments = xrayMatch
+    ? xraySegments.filter(
+        segment => segment.covered && segment.matchIds.includes(xrayMatch.matchId)
+      )
+    : [];
+  const targetStart = xrayMatch ? xrayMatch.targetStart - xrayMatch.start : 0;
+  const targetEnd = xrayMatch ? xrayMatch.targetEnd - xrayMatch.start : 0;
   const proofTarget = revealScope === 'match' ? 'a censored term' : 'the proof';
 
   return (
@@ -225,9 +269,84 @@ export function App() {
         </div>
       </section>
 
+      <section className="xray-section" aria-labelledby="xray-title">
+        <div className="xray-heading">
+          <div>
+            <p className="eyebrow">03 / x-ray</p>
+            <h2 id="xray-title">See the cut before the ink.</h2>
+          </div>
+          <button
+            aria-controls="xray-grid"
+            aria-expanded={showXray}
+            className={showXray ? 'xray-toggle is-active' : 'xray-toggle'}
+            onClick={() => setShowXray(value => !value)}
+            type="button"
+          >
+            x-ray {showXray ? 'on' : 'off'}
+          </button>
+        </div>
+
+        {showXray && xrayMatch && (
+          <div className="xray-grid" id="xray-grid">
+            <article className="xray-card" data-xray-stage="match">
+              <span className="xray-label">match</span>
+              <div className="xray-value">{xrayMatch.text}</div>
+              <small>
+                {xrayMatch.matchId} · {xrayMatch.start}–{xrayMatch.end}
+              </small>
+            </article>
+
+            <article className="xray-card" data-xray-stage="target">
+              <span className="xray-label">target</span>
+              <div className="xray-value xray-target">
+                <span>{xrayMatch.text.slice(0, targetStart)}</span>
+                <mark>{xrayMatch.targetText}</mark>
+                <span>{xrayMatch.text.slice(targetEnd)}</span>
+              </div>
+              <small>
+                semantic core · {xrayMatch.targetStart}–{xrayMatch.targetEnd}
+              </small>
+            </article>
+
+            <article className="xray-card" data-xray-stage="cover">
+              <span className="xray-label">cover</span>
+              <div className="xray-value xray-coverage">
+                <CoverageDiagram
+                  matchId={xrayMatch.matchId}
+                  segments={xraySegments}
+                />
+              </div>
+              <small>
+                {coverage} ·{' '}
+                {xrayCoveredSegments
+                  .map(segment => `${segment.start}–${segment.end}`)
+                  .join(', ')}
+              </small>
+            </article>
+
+            <article className="xray-card xray-output" data-xray-stage="output">
+              <span className="xray-label">output</span>
+              <div className="xray-value">
+                <CensoredText
+                  appearance={appearance}
+                  coverage={coverageSelector}
+                  reveal={reveal}
+                  revealScope={revealScope}
+                  rules={englishProfanityRules}
+                  text={xrayText}
+                />
+              </div>
+              <small>
+                {appearance} · {reveal}/{revealScope}
+              </small>
+            </article>
+          </div>
+        )}
+      </section>
+
       <section className="semantic-section" aria-labelledby="semantic-title">
         <div className="section-heading compact">
-          <p className="eyebrow">03 / the useful bit</p>
+          <p className="eyebrow">04 / the useful bit</p>
           <h2 id="semantic-title">Censor the swear, keep the sentence.</h2>
         </div>
         <div className="semantic-grid">
@@ -256,7 +375,7 @@ export function App() {
 
       <section className="code-section" aria-labelledby="code-title">
         <div>
-          <p className="eyebrow">04 / use it</p>
+          <p className="eyebrow">05 / use it</p>
           <h2 id="code-title">Pick the language. Pick the damage.</h2>
           <p>
             Matching rules live in explicit language or custom packs. The core stays

--- a/apps/demo/src/main.tsx
+++ b/apps/demo/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import '@scrawlix/react/styles.css';
 import { App } from './App';
 import './styles.css';
+import './xray.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/apps/demo/src/xray.css
+++ b/apps/demo/src/xray.css
@@ -1,0 +1,157 @@
+.xray-section {
+  padding: 86px 0;
+  border-bottom: 1px solid #171512;
+}
+
+.xray-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 32px;
+  margin-bottom: 34px;
+}
+
+.xray-heading .eyebrow {
+  margin-bottom: 20px;
+}
+
+.xray-heading h2 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(44px, 5.5vw, 82px);
+  font-weight: 400;
+  line-height: 0.92;
+  letter-spacing: -0.065em;
+}
+
+.xray-toggle {
+  flex: 0 0 auto;
+  border: 1px solid #171512;
+  background: transparent;
+  padding: 10px 13px;
+  cursor: pointer;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.xray-toggle:hover,
+.xray-toggle.is-active {
+  background: #171512;
+  color: #f2eee5;
+}
+
+.xray-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid #171512;
+  background: #fbf8f0;
+}
+
+.xray-card {
+  min-width: 0;
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 18px;
+  border-right: 1px solid #171512;
+}
+
+.xray-card:last-child {
+  border-right: 0;
+}
+
+.xray-label,
+.xray-card small {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  text-transform: uppercase;
+}
+
+.xray-label {
+  padding-bottom: 10px;
+  border-bottom: 1px solid #171512;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+}
+
+.xray-value {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(27px, 2.7vw, 44px);
+  line-height: 1.04;
+  letter-spacing: -0.04em;
+}
+
+.xray-value mark {
+  color: inherit;
+}
+
+.xray-target mark {
+  background: transparent;
+  border-bottom: 0.12em solid currentColor;
+}
+
+.xray-coverage mark {
+  background: #171512;
+  color: #f2eee5;
+  padding-inline: 0.03em;
+}
+
+.xray-output .xray-value {
+  font-size: clamp(27px, 2.5vw, 41px);
+}
+
+.xray-card small {
+  min-height: 2.4em;
+  font-size: 8px;
+  line-height: 1.35;
+  letter-spacing: 0.08em;
+}
+
+@media (max-width: 1000px) {
+  .xray-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .xray-card {
+    border-bottom: 1px solid #171512;
+  }
+
+  .xray-card:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .xray-card:nth-last-child(-n + 2) {
+    border-bottom: 0;
+  }
+}
+
+@media (max-width: 620px) {
+  .xray-heading {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .xray-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .xray-card,
+  .xray-card:nth-child(2n),
+  .xray-card:nth-last-child(-n + 2) {
+    border-right: 0;
+    border-bottom: 1px solid #171512;
+  }
+
+  .xray-card:last-child {
+    border-bottom: 0;
+  }
+}

--- a/packages/core/src/disclosure.test.ts
+++ b/packages/core/src/disclosure.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { createScrawlix, type CensorRule } from './index';
+
+describe('Scrawlix disclosure grouping', () => {
+  it('keeps every island of a match in one disclosure cluster when another rule overlaps one island', () => {
+    const primary: CensorRule = {
+      id: 'primary',
+      pattern: /abcdef/giu,
+      coverage: () => [
+        { start: 1, end: 2 },
+        { start: 4, end: 5 },
+      ],
+    };
+    const overlapping: CensorRule = {
+      id: 'overlap',
+      pattern: /bc/giu,
+      coverage: 'full',
+    };
+    const engine = createScrawlix({
+      rules: [primary, overlapping],
+      coverage: 'full',
+    });
+
+    const covered = engine.segment('abcdef').filter(segment => segment.covered);
+
+    expect(covered.map(segment => segment.text)).toEqual(['bc', 'e']);
+    expect(covered.map(segment => segment.revealId)).toEqual([
+      'g:1:5:m0+m1',
+      'g:1:5:m0+m1',
+    ]);
+    expect(covered.map(segment => segment.coverageEdge)).toEqual(['start', 'end']);
+    expect(new Set(covered[0]!.matchIds)).toEqual(new Set(['m0', 'm1']));
+    expect(covered[1]!.matchIds).toEqual(['m0']);
+  });
+
+  it('keeps independent match clusters independent', () => {
+    const engine = createScrawlix({
+      rules: [
+        { id: 'first', pattern: /abc/giu, coverage: 'full' },
+        { id: 'second', pattern: /xyz/giu, coverage: 'full' },
+      ],
+    });
+
+    const covered = engine.segment('abc xyz').filter(segment => segment.covered);
+    expect(covered.map(segment => segment.revealId)).toEqual(['m0', 'm1']);
+    expect(covered.map(segment => segment.coverageEdge)).toEqual(['solo', 'solo']);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -334,49 +334,84 @@ function mergeCoveredRanges(ranges: readonly CoveredRange[]) {
   return merged;
 }
 
-function revealIdForRange(range: CoveredRange) {
-  const matchIds = [...range.matchIds].sort();
-  if (matchIds.length === 1) return matchIds[0]!;
-  return `g:${range.start}:${range.end}:${matchIds.join('+')}`;
-}
-
-function addCoverageEdges(
+function addDisclosureMetadata(
   ranges: readonly CoveredRange[]
 ): PresentedCoveredRange[] {
-  const prepared = ranges.map(range => ({
-    ...range,
-    revealId: revealIdForRange(range),
-  }));
-  const groupIndexes = new Map<string, number[]>();
+  if (ranges.length === 0) return [];
 
-  prepared.forEach((range, index) => {
-    const indexes = groupIndexes.get(range.revealId) ?? [];
-    indexes.push(index);
-    groupIndexes.set(range.revealId, indexes);
+  const parents = ranges.map((_, index) => index);
+
+  function find(index: number): number {
+    const parent = parents[index]!;
+    if (parent === index) return index;
+    const root = find(parent);
+    parents[index] = root;
+    return root;
+  }
+
+  function union(left: number, right: number) {
+    const leftRoot = find(left);
+    const rightRoot = find(right);
+    if (leftRoot !== rightRoot) parents[rightRoot] = leftRoot;
+  }
+
+  const firstRangeByMatch = new Map<string, number>();
+  ranges.forEach((range, index) => {
+    for (const matchId of range.matchIds) {
+      const firstIndex = firstRangeByMatch.get(matchId);
+      if (firstIndex === undefined) firstRangeByMatch.set(matchId, index);
+      else union(firstIndex, index);
+    }
   });
 
+  const groupIndexes = new Map<number, number[]>();
+  ranges.forEach((_, index) => {
+    const root = find(index);
+    const indexes = groupIndexes.get(root) ?? [];
+    indexes.push(index);
+    groupIndexes.set(root, indexes);
+  });
+
+  const revealIds = new Map<number, string>();
   const edges = new Map<number, ScrawlixCoverageEdge>();
+
   for (const indexes of groupIndexes.values()) {
-    if (indexes.length === 1) {
-      edges.set(indexes[0]!, 'solo');
-      continue;
+    const matchIds = new Set<string>();
+    let start = Number.POSITIVE_INFINITY;
+    let end = Number.NEGATIVE_INFINITY;
+
+    for (const index of indexes) {
+      const range = ranges[index]!;
+      start = Math.min(start, range.start);
+      end = Math.max(end, range.end);
+      for (const matchId of range.matchIds) matchIds.add(matchId);
     }
 
+    const sortedMatchIds = [...matchIds].sort();
+    const revealId =
+      sortedMatchIds.length === 1
+        ? sortedMatchIds[0]!
+        : `g:${start}:${end}:${sortedMatchIds.join('+')}`;
+
     indexes.forEach((index, position) => {
+      revealIds.set(index, revealId);
       edges.set(
         index,
-        position === 0
-          ? 'start'
-          : position === indexes.length - 1
-            ? 'end'
-            : 'middle'
+        indexes.length === 1
+          ? 'solo'
+          : position === 0
+            ? 'start'
+            : position === indexes.length - 1
+              ? 'end'
+              : 'middle'
       );
     });
   }
 
-  return prepared.map((range, index) => ({
+  return ranges.map((range, index) => ({
     ...range,
-    coverageEdge: edges.get(index) ?? 'solo',
+    revealId: revealIds.get(index)!,
+    coverageEdge: edges.get(index)!,
   }));
 }
 
@@ -488,7 +523,7 @@ export function createScrawlix({
       }
 
       const matches = scan(text, compiledRules);
-      const coveredRanges = addCoverageEdges(
+      const coveredRanges = addDisclosureMetadata(
         mergeCoveredRanges(collectCoveredRanges(matches, coverage))
       );
       return segmentFromRanges(text, coveredRanges);

--- a/packages/react/src/control-isolation.test.tsx
+++ b/packages/react/src/control-isolation.test.tsx
@@ -1,0 +1,106 @@
+/** @vitest-environment jsdom */
+
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CensoredText } from './index';
+
+const rules = [{ id: 'fuck', pattern: /fuck/giu }] as const;
+const mountedRoots: Array<{ root: Root; container: HTMLDivElement }> = [];
+
+function render(element: ReactElement) {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+  mountedRoots.push({ root, container });
+  act(() => root.render(element));
+  return container;
+}
+
+afterEach(() => {
+  while (mountedRoots.length > 0) {
+    const mounted = mountedRoots.pop()!;
+    act(() => mounted.root.unmount());
+    mounted.container.remove();
+  }
+});
+
+describe('per-match reveal control isolation', () => {
+  it('does not bubble an internal control click into a clickable parent', () => {
+    const parentClick = vi.fn();
+    const container = render(
+      <div onClick={parentClick}>
+        <CensoredText
+          coverage="middle"
+          reveal="click"
+          revealScope="match"
+          rules={rules}
+          text="fuck"
+        />
+      </div>
+    );
+    const control = container.querySelector<HTMLButtonElement>(
+      '[data-scrawlix-control]'
+    )!;
+    const cover = container.querySelector<HTMLElement>('[data-scrawlix-cover]')!;
+
+    act(() => control.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+    expect(cover.dataset.scrawlixRevealed).toBe('true');
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it.each(['Enter', ' ', 'Escape'])('keeps %j inside the reveal control', key => {
+    const parentKeyDown = vi.fn();
+    const container = render(
+      <div onKeyDown={parentKeyDown}>
+        <CensoredText
+          coverage="middle"
+          reveal="click"
+          revealScope="match"
+          rules={rules}
+          text="fuck"
+        />
+      </div>
+    );
+    const control = container.querySelector<HTMLButtonElement>(
+      '[data-scrawlix-control]'
+    )!;
+
+    act(() =>
+      control.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          key,
+        })
+      )
+    );
+
+    expect(parentKeyDown).not.toHaveBeenCalled();
+  });
+
+  it('swallows focus-mode control activation without creating click reveal state', () => {
+    const parentClick = vi.fn();
+    const container = render(
+      <div onClick={parentClick}>
+        <CensoredText
+          coverage="middle"
+          reveal="focus"
+          revealScope="match"
+          rules={rules}
+          text="fuck"
+        />
+      </div>
+    );
+    const control = container.querySelector<HTMLButtonElement>(
+      '[data-scrawlix-control]'
+    )!;
+    const cover = container.querySelector<HTMLElement>('[data-scrawlix-cover]')!;
+
+    act(() => control.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+    expect(cover.dataset.scrawlixRevealed).toBe('false');
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -236,10 +236,21 @@ export function CensoredText({
     setFocusedRevealId(null);
   }
 
+  function onControlClick(
+    event: MouseEvent<HTMLButtonElement>,
+    revealId: string
+  ) {
+    event.stopPropagation();
+    if (reveal === 'click') toggleRevealId(revealId);
+  }
+
   function onControlKeyDown(
     event: KeyboardEvent<HTMLButtonElement>,
     revealId: string
   ) {
+    if (event.key === 'Enter' || event.key === ' ' || event.key === 'Escape') {
+      event.stopPropagation();
+    }
     if (event.key !== 'Escape') return;
     event.preventDefault();
     setRevealIdsState(current => {
@@ -295,9 +306,7 @@ export function CensoredText({
                 data-scrawlix-reveal-id={revealId}
                 key={revealId}
                 onBlur={onControlBlur}
-                onClick={
-                  reveal === 'click' ? () => toggleRevealId(revealId) : undefined
-                }
+                onClick={event => onControlClick(event, revealId)}
                 onFocus={() => onControlFocus(revealId)}
                 onKeyDown={event => onControlKeyDown(event, revealId)}
                 type="button"

--- a/tests/browser/browser.spec.ts
+++ b/tests/browser/browser.spec.ts
@@ -3,21 +3,36 @@ import { resolve } from 'node:path';
 
 const extensionPath = resolve(process.cwd(), 'apps/extension/dist');
 
-test('demo controls drive real rendered coverage and reveal state', async ({ page }) => {
+test('demo controls drive real rendered coverage, X-ray, and reveal state', async ({ page }) => {
   await page.goto('http://127.0.0.1:4173');
 
   const proof = page.locator('.proof-output [data-scrawlix-root]');
   const firstCover = proof.locator('[data-scrawlix-cover]').first();
+  const secondCover = proof.locator('[data-scrawlix-cover]').nth(1);
+  const xrayGrid = page.locator('#xray-grid');
+  const xrayCoverage = page.locator('[data-xray-stage="cover"] .xray-coverage mark');
 
   await expect(proof).toBeVisible();
   await expect(proof).toHaveAttribute('data-scrawlix-appearance', 'scrawl');
+  await expect(proof).toHaveAttribute('data-scrawlix-reveal-scope', 'match');
   await expect(firstCover).toHaveText('uc');
+
+  await expect(xrayGrid).toBeVisible();
+  await expect(page.locator('[data-xray-stage="match"] .xray-value')).toHaveText(
+    'motherfucker'
+  );
+  await expect(page.locator('[data-xray-stage="target"] mark')).toHaveText('fuck');
+  await expect(xrayCoverage).toHaveText('uc');
 
   await page.getByRole('button', { name: 'bar', exact: true }).click();
   await expect(proof).toHaveAttribute('data-scrawlix-appearance', 'bar');
+  await expect(
+    page.locator('[data-xray-stage="output"] [data-scrawlix-root]')
+  ).toHaveAttribute('data-scrawlix-appearance', 'bar');
 
   await page.getByRole('button', { name: 'full', exact: true }).click();
   await expect(firstCover).toHaveText('fuck');
+  await expect(xrayCoverage).toHaveText('fuck');
 
   for (const appearance of ['whiteout', 'mosaic', 'asterisk'] as const) {
     await page.getByRole('button', { name: appearance, exact: true }).click();
@@ -27,16 +42,31 @@ test('demo controls drive real rendered coverage and reveal state', async ({ pag
   await page.getByRole('button', { name: 'click', exact: true }).click();
   await expect(proof).toHaveAttribute('data-scrawlix-reveal', 'click');
   await expect(proof).toHaveAttribute('data-scrawlix-revealed', 'false');
+  await expect(firstCover).toHaveAttribute('data-scrawlix-revealed', 'false');
+  await expect(secondCover).toHaveAttribute('data-scrawlix-revealed', 'false');
 
   const beforeRevealBox = await firstCover.boundingBox();
-  await proof.click();
-  await expect(proof).toHaveAttribute('data-scrawlix-revealed', 'true');
+  await firstCover.click();
+  await expect(firstCover).toHaveAttribute('data-scrawlix-revealed', 'true');
+  await expect(secondCover).toHaveAttribute('data-scrawlix-revealed', 'false');
+  await expect(proof).toHaveAttribute('data-scrawlix-revealed', 'false');
   const afterRevealBox = await firstCover.boundingBox();
 
   if (!beforeRevealBox || !afterRevealBox) {
     throw new Error('Expected the first covered segment to have a layout box.');
   }
   expect(Math.abs(beforeRevealBox.width - afterRevealBox.width)).toBeLessThan(0.5);
+
+  await page.getByRole('button', { name: 'component', exact: true }).click();
+  await expect(proof).toHaveAttribute('data-scrawlix-reveal-scope', 'component');
+  await expect(proof).toHaveAttribute('data-scrawlix-revealed', 'false');
+  await proof.click();
+  await expect(proof).toHaveAttribute('data-scrawlix-revealed', 'true');
+
+  await page.getByRole('button', { name: 'x-ray on', exact: true }).click();
+  await expect(xrayGrid).toHaveCount(0);
+  await page.getByRole('button', { name: 'x-ray off', exact: true }).click();
+  await expect(xrayGrid).toBeVisible();
 
   await page.setViewportSize({ width: 390, height: 844 });
   const overflow = await page.evaluate(


### PR DESCRIPTION
## Summary

This is stacked on #62, which is stacked on #37.

- add a live X-ray section driven by the same core engine/options as the demo proof
- use `motherfucker` as the fixed teaching specimen because it exposes match → semantic target → partial coverage particularly clearly
- show four stages: MATCH, TARGET, COVER, OUTPUT
- show render-local match/target/covered offsets alongside the visual stages
- make COVER react to the live coverage selector
- make OUTPUT react to live appearance, reveal mode, and reveal scope
- add an explicit X-ray on/off control
- keep the visual treatment inside the demo's editorial proof-sheet language
- add responsive 4 → 2 → 1-column layouts
- extend Chromium smoke coverage for the X-ray stages, live coverage/appearance propagation, toggle behavior, match/component reveal scopes, and narrow layout

## Why this specimen

`motherfucker` lets the page show all four Scrawlix concerns in one word:

- the rule matches the compound
- the semantic target is `fuck`
- coverage selects within that target (`uc` under the default middle preset)
- appearance/reveal then operate on the selected range without changing matching

That communicates the library's core idea more quickly than prose alone.

Part of #28
Depends on #62 and #37