### PR TITLE
Execute packed-package runtime smoke assertions

### DIFF
--- a/fixtures/consumer/runtime.mjs
+++ b/fixtures/consumer/runtime.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { createScrawlix } from '@scrawlix/core';
+import { createDomScrawlix } from '@scrawlix/dom';
+import { englishStrongProfanityRules } from '@scrawlix/en';
+import { englishProfanityCorpus } from '@scrawlix/en/corpus';
+import { transformHast } from '@scrawlix/rehype';
+import { CensoredText } from '@scrawlix/react';
+
+const engine = createScrawlix({
+  rules: englishStrongProfanityRules,
+  coverage: 'middle',
+});
+
+const matches = engine.find('well, fuck');
+assert.equal(matches.length, 1);
+assert.equal(matches[0]?.targetText.toLowerCase(), 'fuck');
+assert.ok(englishProfanityCorpus.some(testCase => testCase.id === 'fuck-base'));
+
+const tree = {
+  type: 'root',
+  children: [
+    {
+      type: 'element',
+      tagName: 'p',
+      properties: {},
+      children: [{ type: 'text', value: 'well, fuck' }],
+    },
+  ],
+};
+
+transformHast(tree, {
+  rules: englishStrongProfanityRules,
+  coverage: 'middle',
+});
+
+const paragraph = tree.children[0];
+assert.equal(paragraph?.type, 'element');
+assert.ok(
+  paragraph.children.some(
+    child =>
+      child.type === 'element' &&
+      Object.prototype.hasOwnProperty.call(
+        child.properties ?? {},
+        'data-scrawlix-cover'
+      )
+  )
+);
+
+assert.equal(typeof CensoredText, 'function');
+assert.equal(typeof createDomScrawlix, 'function');
+
+console.log('Scrawlix packed-package runtime smoke passed.');

--- a/scripts/smoke-packages.mjs
+++ b/scripts/smoke-packages.mjs
@@ -88,6 +88,7 @@ try {
   writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
 
   run(['install', '--no-frozen-lockfile'], consumerDirectory);
+  run(['exec', 'node', 'runtime.mjs'], consumerDirectory);
   run(['typecheck'], consumerDirectory);
   run(['build'], consumerDirectory);
 


### PR DESCRIPTION
## What changed

- add a plain Node ESM runtime fixture to the external packed-package consumer
- execute it after installing the generated tarballs
- exercise current public exports from `@scrawlix/core`, `@scrawlix/en`, `@scrawlix/en/corpus`, `@scrawlix/rehype`, `@scrawlix/react`, and `@scrawlix/dom`
- keep the existing declaration/typecheck and Vite build checks after runtime execution

## Why

The packed consumer previously contained browser runtime assertions, but the package gate only typechecked and bundled them. This adds an execution step, catching JS/export/subpath failures that a successful bundle can hide.

This branch is based after #60/#61 and uses the renamed `englishStrongProfanityRules` public export.

Refs #18.