### PR TITLE
Lock release compatibility and versioning contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ A change in one layer should rarely require logic in another.
 - `apps/demo` — public interactive proof sheet and integration consumer
 - `apps/extension` — Manifest V3 application: browser state, popup UI, and injected presentation
 - `fixtures/consumer` — external packed-package smoke consumer
-- `docs` — design, adoption, and extension guidance
+- `docs` — design, adoption, compatibility, versioning, and extension guidance
 
 Scrapbook adoption remains tracked separately as a real-consumer integration.
 
@@ -44,6 +44,8 @@ Use these names in code, docs, examples, and agent-generated changes:
 
 Core defaults to `coverage: 'full'`. React defaults to `appearance="scrawl"` and `reveal="never"`. Partial coverage and reveal behavior are deliberate caller choices.
 
+The reusable packages use named runtime exports as the canonical API. `@scrawlix/rehype` and `@scrawlix/dom` do not carry duplicate default exports.
+
 Do not invent convenience packages, automatic English selection, compatibility aliases, or alternate spellings for the public API.
 
 ## Commands
@@ -58,7 +60,9 @@ pnpm build
 pnpm smoke:packages
 ```
 
-The demo and extension builds are part of the workspace build. The package smoke test installs packed tarballs into a consumer outside the workspace dependency graph and typechecks published declarations with library checking enabled.
+Repository CI uses Node 22. The demo and extension builds are part of the workspace build. The package smoke test installs packed tarballs into consumers outside the workspace dependency graph, typechecks published declarations with library checking enabled, and production-builds against React 18 and React 19.
+
+Published runtime compatibility and workspace-tooling expectations live in `docs/compatibility.md`. Release classification and public-contract rules live in `docs/versioning.md`.
 
 ## Invariants
 
@@ -160,7 +164,9 @@ Ask whether the behavior is language-neutral. Generic positional coverage may li
 
 ## Public API discipline
 
-Scrawlix is pre-release, so breaking changes are still possible. Use that freedom to remove surprising defaults and awkward names before publication. Once packages are published, classify 0.x changes deliberately and use explicit deprecation paths when compatibility aliases become necessary.
+Scrawlix is pre-release, so breaking changes are still possible. Use that freedom to remove surprising defaults and awkward names before publication. `docs/versioning.md` defines how 0.x releases classify fixes, additions, language-pack scope changes, and intentional breaks.
+
+The documented package exports, rule ids, option defaults, adapter data attributes, ignore attributes, and React CSS/render attributes are public contracts. Keep application-only browser-extension state private unless a document explicitly promotes it to a public contract.
 
 Packed-package smoke tests are a release gate: external consumers must receive compiled JavaScript, declarations, CSS exports, and valid package metadata rather than workspace-only source imports. Every new public package belongs in `scripts/smoke-packages.mjs` and `fixtures/consumer`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,17 +36,20 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added a React Client Component boundary for hook-based reveal behavior.
 - Added keyboard reveal handling and a single-source accessibility contract with rendered regressions.
 - Added the public CSS subpath export.
+- Bound the supported peer range to React 18 and 19 and added packed external-consumer verification for both majors.
 
 ### Markdown
 
 - Added `@scrawlix/rehype` for source-preserving HAST text transformation.
 - Added default code/script/style-like exclusions, application ignore hooks, and idempotency.
+- Kept `rehypeScrawlix` / `transformHast` as the canonical named exports without a duplicate default export before publication.
 
 ### DOM
 
 - Added `@scrawlix/dom` for arbitrary webpages.
 - Added TreeWalker-based text discovery, exact controller-owned restoration, safe editable/form/code exclusions, and mutation-local observation.
 - Added atomic observed restore for extension/site disable flows.
+- Kept `createDomScrawlix` as the canonical named entry without a duplicate default export before publication.
 
 ### Applications
 
@@ -57,7 +60,8 @@ Scrawlix is in pre-release development. Until the first package version is chose
 ### Developer experience
 
 - Added compiled ESM/declaration artifacts for public packages.
-- Added an external tarball consumer smoke test as a CI release gate and enabled strict checking of published declaration dependencies in that consumer.
+- Added external tarball consumer smoke tests as a CI release gate, with strict declaration checking and React 18/19 production builds.
 - Added package-local READMEs for every public package, exact install commands, a top-level integration chooser, a docs index, React CSS troubleshooting, Next.js client-boundary guidance, and clearer source/accessibility notes.
+- Added explicit runtime compatibility and pre-1.0 versioning/public-contract policies.
 - Aligned `README.md`, `AGENTS.md`, `llms.txt`, demo, extension, tests, and smoke consumers on the canonical pre-release public names and conservative defaults.
 - Added `docs/releasing.md`, language-pack docs, DOM lifecycle docs, extension docs, and the first-release runbook.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@ Start with the repository README for installation and the shortest path for your
 
 ## Recipes and design notes
 
+- [`compatibility.md`](./compatibility.md) — JavaScript/browser capabilities, Node baseline, React majors, grapheme fallback, DOM/CSS/TypeScript expectations
+- [`versioning.md`](./versioning.md) — synchronized release train, 0.x semver policy, public data/CSS contracts, and deprecation rules
 - [`language-packs.md`](./language-packs.md) — author and compose language/rule packs, semantic targets, boundaries, coverage helpers, and corpora
 - [`dom.md`](./dom.md) — arbitrary-page DOM application, observation, exclusions, and exact restoration
 - [`releasing.md`](./releasing.md) — first-release gates, package verification, registry checks, and publication sequence

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,47 @@
+# Runtime compatibility
+
+Scrawlix publishes ESM and TypeScript declarations targeting modern JavaScript. The compatibility contract is intentionally explicit so consumers can decide whether their runtime/build target fits before installation.
+
+## JavaScript runtime requirements
+
+`@scrawlix/core` and packages built on it rely on:
+
+- ES modules
+- ES2022-era JavaScript such as `Array.prototype.at()` and `String.prototype.replaceAll()`
+- RegExp lookbehind
+- Unicode property escapes
+- RegExp match indices (`d` flag)
+
+Node **18 and newer** is the supported Node baseline for development, SSR/build tooling, and direct core/rehype execution.
+
+For browsers, support is capability-based during pre-1.0: the consuming browser must support the features above. Scrawlix's browser CI exercises current Chromium. Add explicit Firefox/Safari version claims only alongside CI or targeted compatibility tests that enforce them.
+
+## Grapheme handling
+
+Scrawlix uses `Intl.Segmenter` when the runtime provides it so positional coverage works on extended grapheme clusters.
+
+A fallback based on Unicode code points is used when `Intl.Segmenter` is unavailable. The fallback preserves source text and valid JavaScript string boundaries, but complex grapheme clusters can be treated as several positions. Applications that require grapheme-exact partial coverage should choose runtimes with `Intl.Segmenter` support or use `coverage: 'full'`.
+
+## React
+
+`@scrawlix/react` supports React **18 and 19**. The packed-package release gate installs, typechecks, and production-builds external consumers against both major versions.
+
+The React entry is a Client Component because interactive reveal uses React state. Next.js App Router users can import it across a normal client boundary. A dedicated Next.js consumer smoke remains tracked separately.
+
+## DOM
+
+`@scrawlix/dom` requires browser DOM APIs for the operations it performs. Observation additionally requires `MutationObserver`; calling `observe()` in an environment without it throws a descriptive error.
+
+Server-side DOM implementations can use `apply()`/`restore()` when they provide the DOM APIs used by the adapter. Observation depends on the root document's `defaultView.MutationObserver`.
+
+## CSS
+
+The built-in React appearances live in `@scrawlix/react/styles.css` and use modern CSS features, including `color-mix()` for scrawl ink treatment.
+
+The semantic text contract remains in the generated markup. Consumers targeting older CSS engines can supply their own styles against the documented data attributes or choose a build/post-processing strategy appropriate to their browser matrix.
+
+## TypeScript
+
+Published packages include declarations and use ESM package exports. The external tarball consumer typechecks with `skipLibCheck: false`, so declaration dependencies and public export paths are verified before release.
+
+Consumer projects can use their own TypeScript configuration. The Scrawlix workspace itself uses `moduleResolution: "Bundler"`; that setting is not imposed on consumers.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -12,7 +12,9 @@ Scrawlix publishes ESM and TypeScript declarations targeting modern JavaScript. 
 - Unicode property escapes
 - RegExp match indices (`d` flag)
 
-Node **18 and newer** is the supported Node baseline for development, SSR/build tooling, and direct core/rehype execution.
+For published-package execution in Node, **Node 18 and newer** is the supported baseline for core/rehype and SSR contexts that execute package code directly.
+
+Repository development and release verification use **Node 22**. The workspace includes current build/test tools with their own Node requirements, so contributors should follow the CI/toolchain baseline instead of treating the package-runtime minimum as the repository-development minimum.
 
 For browsers, support is capability-based during pre-1.0: the consuming browser must support the features above. Scrawlix's browser CI exercises current Chromium. Add explicit Firefox/Safari version claims only alongside CI or targeted compatibility tests that enforce them.
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,98 @@
+# Versioning policy
+
+Scrawlix treats the five public packages as one release train until there is a concrete reason to version them independently:
+
+- `@scrawlix/core`
+- `@scrawlix/en`
+- `@scrawlix/react`
+- `@scrawlix/rehype`
+- `@scrawlix/dom`
+
+All five receive the same version in a release.
+
+## Before 1.0
+
+Pre-1.0 still gets a compatibility policy. The leading zero gives Scrawlix room to refine the API; it does not make every release equally disruptive.
+
+### Patch releases (`0.x.Y`)
+
+Use a patch for a correction that preserves the documented public contract, including:
+
+- matcher or coverage bugs that restore documented behavior
+- source-preservation, accessibility, lifecycle, or rendering regressions
+- false-positive / false-negative fixes that bring an existing language-pack rule back to its documented scope
+- performance improvements with equivalent observable behavior
+- documentation and packaging fixes that do not change supported imports
+
+A corpus correction can therefore be a patch when the corpus demonstrates an existing rule behaving incorrectly.
+
+### Minor releases (`0.X.0`)
+
+Use a minor for additive features and every intentional breaking public change during 0.x, including:
+
+- new exports, coverage helpers, appearances, reveal modes, adapters, or package subpaths
+- expanding a language pack's intended vocabulary/severity scope so previously clean text is deliberately matched
+- changing default behavior
+- renaming/removing exports or package subpaths
+- changing a public rule id
+- changing/removing documented data attributes, ignore attributes, CSS hooks, or lifecycle behavior
+- raising a supported runtime/framework baseline
+
+Every breaking 0.x minor should call the break out explicitly in the changelog/release notes with the replacement usage.
+
+## At and after 1.0
+
+Use standard semantic versioning:
+
+- **patch** — compatible fixes
+- **minor** — backwards-compatible additions
+- **major** — breaking public-contract changes
+
+Language-pack scope expansion remains a minor because it deliberately changes which input is matched. A correction to already documented scope remains a patch.
+
+## Public contracts
+
+The following are public once documented or shipped in a stable package export:
+
+### JavaScript / TypeScript
+
+- package names and exported subpaths
+- named runtime exports
+- exported TypeScript types and their documented fields
+- default option behavior
+- rule ids in bundled language packs
+- `CensorRulePack.id` and match `packId` provenance semantics
+
+### React
+
+The built-in appearance/reveal values and the generated attributes used by the public stylesheet are part of the rendering contract:
+
+- `data-scrawlix-root`
+- `data-scrawlix-a11y`
+- `data-scrawlix-visual`
+- `data-scrawlix-cover`
+- `data-appearance`
+- `data-rules`
+- `data-scrawlix-mask`
+- `data-scrawlix-source`
+- `data-reveal`
+- `data-revealed`
+
+Callers may use these for documented styling/integration. Rename/remove them with the versioning treatment above.
+
+### Rehype and DOM adapters
+
+These semantic attributes are public adapter output/input contracts:
+
+- `data-scrawlix-cover`
+- `data-scrawlix-rules`
+- `data-scrawlix-ignore`
+- `data-scrawlix-dom-root` (`@scrawlix/dom`)
+
+The browser extension's own storage keys, popup markup, and application-only presentation attributes remain application internals unless separately documented as public.
+
+## Deprecations
+
+Before publication, prefer one canonical name over aliases. After users can depend on a published name, use an additive deprecation period when a practical compatibility bridge exists.
+
+Keep deprecated aliases out of examples, package READMEs, `llms.txt`, and generated snippets so new code converges on the replacement API.

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -345,5 +345,3 @@ export function createDomScrawlix(
 
   return { apply, restore, observe };
 }
-
-export default createDomScrawlix;

--- a/packages/rehype/src/index.ts
+++ b/packages/rehype/src/index.ts
@@ -141,5 +141,3 @@ export function rehypeScrawlix(options: RehypeScrawlixOptions) {
     transformParent(tree, prepared);
   };
 }
-
-export default rehypeScrawlix;

--- a/scripts/smoke-packages.mjs
+++ b/scripts/smoke-packages.mjs
@@ -16,7 +16,6 @@ const root = process.cwd();
 const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
 const temporaryRoot = mkdtempSync(join(tmpdir(), 'scrawlix-smoke-'));
 const packDirectory = join(temporaryRoot, 'packs');
-const consumerDirectory = join(temporaryRoot, 'consumer');
 let passed = false;
 
 mkdirSync(packDirectory, { recursive: true });
@@ -56,43 +55,64 @@ function packPackage(packageDirectory) {
   return join(packDirectory, created[0]);
 }
 
-try {
-  const coreTarball = packPackage('packages/core');
-  const englishTarball = packPackage('packages/en');
-  const reactTarball = packPackage('packages/react');
-  const rehypeTarball = packPackage('packages/rehype');
-  const domTarball = packPackage('packages/dom');
+const asFileDependency = path => `file:${path.replaceAll('\\', '/')}`;
 
+function smokeConsumer({
+  label,
+  reactMajor,
+  tarballs,
+}) {
+  const consumerDirectory = join(temporaryRoot, `consumer-${label}`);
   cpSync(resolve(root, 'fixtures/consumer'), consumerDirectory, {
     recursive: true,
   });
 
   const packageJsonPath = join(consumerDirectory, 'package.json');
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
-  const asFileDependency = path => `file:${path.replaceAll('\\', '/')}`;
 
   packageJson.dependencies = {
     ...packageJson.dependencies,
-    '@scrawlix/core': asFileDependency(coreTarball),
-    '@scrawlix/en': asFileDependency(englishTarball),
-    '@scrawlix/react': asFileDependency(reactTarball),
-    '@scrawlix/rehype': asFileDependency(rehypeTarball),
-    '@scrawlix/dom': asFileDependency(domTarball),
+    react: reactMajor,
+    'react-dom': reactMajor,
+    '@scrawlix/core': asFileDependency(tarballs.core),
+    '@scrawlix/en': asFileDependency(tarballs.english),
+    '@scrawlix/react': asFileDependency(tarballs.react),
+    '@scrawlix/rehype': asFileDependency(tarballs.rehype),
+    '@scrawlix/dom': asFileDependency(tarballs.dom),
+  };
+  packageJson.devDependencies = {
+    ...packageJson.devDependencies,
+    '@types/react': reactMajor,
+    '@types/react-dom': reactMajor,
   };
   packageJson.pnpm = {
     overrides: {
-      '@scrawlix/core': asFileDependency(coreTarball),
+      '@scrawlix/core': asFileDependency(tarballs.core),
     },
   };
 
   writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
 
+  console.log(`\nSmoke consumer: React ${reactMajor}`);
   run(['install', '--no-frozen-lockfile'], consumerDirectory);
   run(['typecheck'], consumerDirectory);
   run(['build'], consumerDirectory);
+}
+
+try {
+  const tarballs = {
+    core: packPackage('packages/core'),
+    english: packPackage('packages/en'),
+    react: packPackage('packages/react'),
+    rehype: packPackage('packages/rehype'),
+    dom: packPackage('packages/dom'),
+  };
+
+  smokeConsumer({ label: 'react-18', reactMajor: '18', tarballs });
+  smokeConsumer({ label: 'react-19', reactMajor: '19', tarballs });
 
   passed = true;
-  console.log('Scrawlix packed-package smoke test passed.');
+  console.log('Scrawlix packed-package smoke tests passed for React 18 and 19.');
 } finally {
   if (passed) {
     rmSync(temporaryRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Finishes the cheap/high-value compatibility work from #46 before the first npm release.

### Compatibility gates
- run packed external consumers against React 18 and React 19
- keep `skipLibCheck: false` and production-build both consumers
- document Node/package runtime vs repository-tooling baselines
- document browser capability requirements and the `Intl.Segmenter` fallback contract

### Public API contracts
- remove the duplicate default export from `@scrawlix/dom`
- remove the duplicate default export from `@scrawlix/rehype`
- keep the documented named entries as the only canonical imports
- define the public React/rehype/DOM data attributes and CSS hooks

### Versioning
- add a concrete 0.x patch/minor policy
- classify language-pack scope expansion vs corpus bug fixes
- define breaking treatment for rule IDs, defaults, subpaths, data/CSS contracts, and runtime baselines
- document post-1.0 standard semver and deprecation expectations

Progresses #46. The dedicated Next.js App Router smoke remains tracked in #44; reproducible installs / OIDC publication remain #45.