### PR TITLE
Move language corpora to validated JSON data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added `@scrawlix/en` with explicit English strong-profanity rules exported as `englishStrongProfanityRules` and `englishStrongProfanityPack`.
 - Added English-specific vowel coverage outside the neutral core.
 - Added positive and clean regression corpora, including false-positive traps.
-- Moved English corpus cases into typed JSON data with explicit profiles, tags, and exact full-match/semantic-target source offsets.
 - Hardened English word edges around combining marks, connector punctuation, ZWNJ, and ZWJ.
 
 ### React
@@ -38,7 +37,6 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added keyboard reveal handling and a single-source accessibility contract with rendered regressions.
 - Added the public CSS subpath export.
 - Bound the supported peer range to React 18 and 19 and added packed external-consumer verification for both majors.
-- Documented and release-gated the Next.js App Router pattern: keep non-serializable rule packs inside an application-owned Client Component and pass serializable text from Server Components.
 
 ### Markdown
 
@@ -62,8 +60,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 ### Developer experience
 
 - Added compiled ESM/declaration artifacts for public packages.
-- Added external tarball consumer smoke tests as a CI release gate, with strict declaration checking, React 18/19 production builds, and a Next.js 16 App Router production build using the documented client-wrapper boundary.
-- Added shared JSON Schema validation plus semantic source-range checks for language-pack corpora through `pnpm validate:corpora`.
+- Added external tarball consumer smoke tests as a CI release gate, with strict declaration checking and React 18/19 production builds.
 - Added package-local READMEs for every public package, exact install commands, a top-level integration chooser, a docs index, React CSS troubleshooting, Next.js client-boundary guidance, and clearer source/accessibility notes.
 - Added explicit runtime compatibility and pre-1.0 versioning/public-contract policies.
 - Aligned `README.md`, `AGENTS.md`, `llms.txt`, demo, extension, tests, and smoke consumers on the canonical pre-release public names and conservative defaults.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added keyboard reveal handling and a single-source accessibility contract with rendered regressions.
 - Added the public CSS subpath export.
 - Bound the supported peer range to React 18 and 19 and added packed external-consumer verification for both majors.
+- Documented and release-gated the Next.js App Router pattern: keep non-serializable rule packs inside an application-owned Client Component and pass serializable text from Server Components.
 
 ### Markdown
 
@@ -61,7 +62,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 ### Developer experience
 
 - Added compiled ESM/declaration artifacts for public packages.
-- Added external tarball consumer smoke tests as a CI release gate, with strict declaration checking and React 18/19 production builds.
+- Added external tarball consumer smoke tests as a CI release gate, with strict declaration checking, React 18/19 production builds, and a Next.js 16 App Router production build using the documented client-wrapper boundary.
 - Added shared JSON Schema validation plus semantic source-range checks for language-pack corpora through `pnpm validate:corpora`.
 - Added package-local READMEs for every public package, exact install commands, a top-level integration chooser, a docs index, React CSS troubleshooting, Next.js client-boundary guidance, and clearer source/accessibility notes.
 - Added explicit runtime compatibility and pre-1.0 versioning/public-contract policies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added `@scrawlix/en` with explicit English strong-profanity rules exported as `englishStrongProfanityRules` and `englishStrongProfanityPack`.
 - Added English-specific vowel coverage outside the neutral core.
 - Added positive and clean regression corpora, including false-positive traps.
+- Moved English corpus cases into typed JSON data with explicit profiles, tags, and exact full-match/semantic-target source offsets.
 - Hardened English word edges around combining marks, connector punctuation, ZWNJ, and ZWJ.
 
 ### React
@@ -61,6 +62,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 
 - Added compiled ESM/declaration artifacts for public packages.
 - Added external tarball consumer smoke tests as a CI release gate, with strict declaration checking and React 18/19 production builds.
+- Added shared JSON Schema validation plus semantic source-range checks for language-pack corpora through `pnpm validate:corpora`.
 - Added package-local READMEs for every public package, exact install commands, a top-level integration chooser, a docs index, React CSS troubleshooting, Next.js client-boundary guidance, and clearer source/accessibility notes.
 - Added explicit runtime compatibility and pre-1.0 versioning/public-contract policies.
 - Aligned `README.md`, `AGENTS.md`, `llms.txt`, demo, extension, tests, and smoke consumers on the canonical pre-release public names and conservative defaults.

--- a/docs/language-packs.md
+++ b/docs/language-packs.md
@@ -116,17 +116,29 @@ A pack can export several named helpers without changing the core API.
 
 ## Corpora
 
-Every language pack should grow a small, reviewable regression corpus alongside its rules. A useful corpus contains:
+Every language pack should grow a small, reviewable regression corpus alongside its rules. Corpus cases are ordinary JSON data under `src/corpus-data/`, validated by the shared `schemas/corpus.schema.json` contract.
 
-- positive matches
-- expected semantic targets
-- casing and punctuation variants
-- compounds and inflections
-- false-positive traps
-- Unicode context
-- dialect or severity cases when relevant
+Each case records:
 
-Keep corpus entries simple enough to add during a bug fix. The English pack exports its current corpus from `@scrawlix/en/corpus` and uses the same data directly in tests.
+- a stable case id
+- the exact source text
+- the matching profile under test
+- tags that explain why the case exists
+- expected full-match and semantic-target text
+- exact UTF-16 source offsets for every expected match
+- an optional human note
+
+The validator also checks facts JSON Schema cannot express conveniently: case ids stay unique within a pack, every range is non-empty and contained by the source, semantic targets sit inside their full matches, and slicing the source at the declared offsets reproduces the declared match text exactly.
+
+Run corpus validation with:
+
+```sh
+pnpm validate:corpora
+```
+
+The workspace test command runs that validation before package tests. `@scrawlix/en/corpus` remains the public JavaScript export; the English implementation imports the validated JSON so its tests and public corpus consume the same source data.
+
+Useful corpora contain positive matches, semantic targets, casing and punctuation variants, compounds and inflections, false-positive traps, Unicode context, and dialect or severity cases when relevant. Every matcher expansion should ideally arrive with the newly caught form plus plausible clean neighbors that could regress.
 
 A corpus is evidence about expected behavior, not a claim of linguistic completeness. Pack docs should say which dialect, register, severity band, and edge cases the pack intentionally covers.
 

--- a/fixtures/consumer/src/main.tsx
+++ b/fixtures/consumer/src/main.tsx
@@ -1,6 +1,7 @@
 import { createScrawlix } from '@scrawlix/core';
 import { createDomScrawlix } from '@scrawlix/dom';
 import { englishStrongProfanityRules } from '@scrawlix/en';
+import { englishProfanityCorpus } from '@scrawlix/en/corpus';
 import { transformHast } from '@scrawlix/rehype';
 import { CensoredText } from '@scrawlix/react';
 import '@scrawlix/react/styles.css';
@@ -15,6 +16,15 @@ const engine = createScrawlix({
 const matches = engine.find('well, fuck');
 if (matches.length !== 1 || matches[0]?.targetText.toLowerCase() !== 'fuck') {
   throw new Error('Scrawlix core/English package smoke assertion failed.');
+}
+
+const corpusCase = englishProfanityCorpus.find(entry => entry.id === 'fuck-base');
+if (
+  corpusCase?.text !== 'fuck' ||
+  corpusCase.matches[0]?.start !== 0 ||
+  corpusCase.matches[0]?.targetEnd !== 4
+) {
+  throw new Error('Scrawlix English corpus export smoke assertion failed.');
 }
 
 const tree: Parameters<typeof transformHast>[0] = {

--- a/package.json
+++ b/package.json
@@ -6,14 +6,16 @@
     "build:packages": "pnpm --filter @scrawlix/core build && pnpm --filter @scrawlix/en build && pnpm --filter @scrawlix/react build && pnpm --filter @scrawlix/rehype build && pnpm --filter @scrawlix/dom build",
     "dev": "pnpm --filter scrawlix-demo dev",
     "smoke:packages": "node scripts/smoke-packages.mjs",
-    "test": "pnpm build:packages && pnpm -r --if-present test",
+    "test": "pnpm validate:corpora && pnpm build:packages && pnpm -r --if-present test",
     "test:browser": "playwright test -c playwright.config.ts",
     "test:browser:demo": "playwright test -c playwright.config.ts -g \"demo controls\"",
     "test:browser:extension": "playwright test -c playwright.config.ts -g \"built extension\"",
-    "typecheck": "pnpm -r --if-present typecheck"
+    "typecheck": "pnpm -r --if-present typecheck",
+    "validate:corpora": "node scripts/validate-corpora.mjs"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",
+    "ajv": "^8.17.1",
     "typescript": "^5.2.2",
     "vitest": "^3.2.4"
   }

--- a/packages/en/src/corpus-data/clean.json
+++ b/packages/en/src/corpus-data/clean.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "scunthorpe",
+    "text": "Scunthorpe",
+    "profile": "canonical",
+    "tags": ["false-positive", "substring"],
+    "matches": []
+  },
+  {
+    "id": "shitake",
+    "text": "shitake mushrooms",
+    "profile": "canonical",
+    "tags": ["false-positive", "substring"],
+    "matches": []
+  },
+  {
+    "id": "classhole",
+    "text": "classhole",
+    "profile": "canonical",
+    "tags": ["false-positive", "substring"],
+    "matches": []
+  },
+  {
+    "id": "motherfuckerish",
+    "text": "motherfuckerish",
+    "profile": "canonical",
+    "tags": ["false-positive", "derivation"],
+    "matches": []
+  },
+  {
+    "id": "fuck-combining-mark-continuation",
+    "text": "fucḱ",
+    "profile": "canonical",
+    "tags": ["false-positive", "unicode", "combining-mark"],
+    "matches": []
+  },
+  {
+    "id": "shit-connector-continuation",
+    "text": "shit‿word",
+    "profile": "canonical",
+    "tags": ["false-positive", "unicode", "connector-punctuation"],
+    "matches": []
+  },
+  {
+    "id": "cunt-join-control-continuation",
+    "text": "cunt‍word",
+    "profile": "canonical",
+    "tags": ["false-positive", "unicode", "join-control"],
+    "matches": []
+  },
+  {
+    "id": "ordinary-prose",
+    "text": "a perfectly ordinary sentence",
+    "profile": "canonical",
+    "tags": ["clean-prose"],
+    "matches": []
+  }
+]

--- a/packages/en/src/corpus-data/profanity.json
+++ b/packages/en/src/corpus-data/profanity.json
@@ -1,0 +1,181 @@
+[
+  {
+    "id": "fuck-base",
+    "text": "fuck",
+    "profile": "canonical",
+    "tags": ["base"],
+    "matches": [
+      {
+        "ruleId": "fuck",
+        "text": "fuck",
+        "start": 0,
+        "end": 4,
+        "targetText": "fuck",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "fuck-uppercase-inflection",
+    "text": "FUCKING",
+    "profile": "canonical",
+    "tags": ["case", "inflection"],
+    "matches": [
+      {
+        "ruleId": "fuck",
+        "text": "FUCKING",
+        "start": 0,
+        "end": 7,
+        "targetText": "FUCK",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "fuck-mother-compound",
+    "text": "motherfucker",
+    "profile": "canonical",
+    "tags": ["compound", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "fuck",
+        "text": "motherfucker",
+        "start": 0,
+        "end": 12,
+        "targetText": "fuck",
+        "targetStart": 6,
+        "targetEnd": 10
+      }
+    ]
+  },
+  {
+    "id": "fuck-punctuation",
+    "text": "well, fuck!",
+    "profile": "canonical",
+    "tags": ["punctuation"],
+    "matches": [
+      {
+        "ruleId": "fuck",
+        "text": "fuck",
+        "start": 6,
+        "end": 10,
+        "targetText": "fuck",
+        "targetStart": 6,
+        "targetEnd": 10
+      }
+    ]
+  },
+  {
+    "id": "shit-bull-compound",
+    "text": "bullshit",
+    "profile": "canonical",
+    "tags": ["compound", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "shit",
+        "text": "bullshit",
+        "start": 0,
+        "end": 8,
+        "targetText": "shit",
+        "targetStart": 4,
+        "targetEnd": 8
+      }
+    ]
+  },
+  {
+    "id": "shit-inflection",
+    "text": "shitty",
+    "profile": "canonical",
+    "tags": ["inflection", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "shit",
+        "text": "shitty",
+        "start": 0,
+        "end": 6,
+        "targetText": "shit",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "bitch-plural",
+    "text": "bitches",
+    "profile": "canonical",
+    "tags": ["inflection", "plural", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "bitch",
+        "text": "bitches",
+        "start": 0,
+        "end": 7,
+        "targetText": "bitch",
+        "targetStart": 0,
+        "targetEnd": 5
+      }
+    ]
+  },
+  {
+    "id": "asshole-plural",
+    "text": "assholes",
+    "profile": "canonical",
+    "tags": ["inflection", "plural", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "asshole",
+        "text": "assholes",
+        "start": 0,
+        "end": 8,
+        "targetText": "asshole",
+        "targetStart": 0,
+        "targetEnd": 7
+      }
+    ]
+  },
+  {
+    "id": "cunt-plural",
+    "text": "cunts",
+    "profile": "canonical",
+    "tags": ["inflection", "plural", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "cunt",
+        "text": "cunts",
+        "start": 0,
+        "end": 5,
+        "targetText": "cunt",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "multiple-rules",
+    "text": "fuck this shit",
+    "profile": "canonical",
+    "tags": ["multiple-matches"],
+    "matches": [
+      {
+        "ruleId": "fuck",
+        "text": "fuck",
+        "start": 0,
+        "end": 4,
+        "targetText": "fuck",
+        "targetStart": 0,
+        "targetEnd": 4
+      },
+      {
+        "ruleId": "shit",
+        "text": "shit",
+        "start": 10,
+        "end": 14,
+        "targetText": "shit",
+        "targetStart": 10,
+        "targetEnd": 14
+      }
+    ]
+  }
+]

--- a/packages/en/src/corpus.ts
+++ b/packages/en/src/corpus.ts
@@ -1,87 +1,32 @@
+import cleanCorpus from './corpus-data/clean.json' with { type: 'json' };
+import profanityCorpus from './corpus-data/profanity.json' with { type: 'json' };
+
 export type EnglishCorpusMatch = {
   ruleId: string;
   text: string;
+  start: number;
+  end: number;
   targetText: string;
+  targetStart: number;
+  targetEnd: number;
 };
 
 export type EnglishCorpusCase = {
   id: string;
   text: string;
+  profile: string;
+  tags: readonly string[];
+  note?: string;
   matches: readonly EnglishCorpusMatch[];
 };
 
 /**
- * Small, reviewable regression corpus for the bundled English profanity rules.
- * Add a case whenever a bug report or rule change teaches us something durable.
+ * Reviewable regression data for the bundled English profanity rules.
+ * Source cases live in `src/corpus-data/*.json` and are validated against the
+ * shared corpus schema plus source-range invariants by `pnpm validate:corpora`.
  */
-export const englishProfanityCorpus: readonly EnglishCorpusCase[] = [
-  {
-    id: 'fuck-base',
-    text: 'fuck',
-    matches: [{ ruleId: 'fuck', text: 'fuck', targetText: 'fuck' }],
-  },
-  {
-    id: 'fuck-uppercase-inflection',
-    text: 'FUCKING',
-    matches: [{ ruleId: 'fuck', text: 'FUCKING', targetText: 'FUCK' }],
-  },
-  {
-    id: 'fuck-mother-compound',
-    text: 'motherfucker',
-    matches: [
-      { ruleId: 'fuck', text: 'motherfucker', targetText: 'fuck' },
-    ],
-  },
-  {
-    id: 'fuck-punctuation',
-    text: 'well, fuck!',
-    matches: [{ ruleId: 'fuck', text: 'fuck', targetText: 'fuck' }],
-  },
-  {
-    id: 'shit-bull-compound',
-    text: 'bullshit',
-    matches: [{ ruleId: 'shit', text: 'bullshit', targetText: 'shit' }],
-  },
-  {
-    id: 'shit-inflection',
-    text: 'shitty',
-    matches: [{ ruleId: 'shit', text: 'shitty', targetText: 'shit' }],
-  },
-  {
-    id: 'bitch-plural',
-    text: 'bitches',
-    matches: [{ ruleId: 'bitch', text: 'bitches', targetText: 'bitch' }],
-  },
-  {
-    id: 'asshole-plural',
-    text: 'assholes',
-    matches: [
-      { ruleId: 'asshole', text: 'assholes', targetText: 'asshole' },
-    ],
-  },
-  {
-    id: 'cunt-plural',
-    text: 'cunts',
-    matches: [{ ruleId: 'cunt', text: 'cunts', targetText: 'cunt' }],
-  },
-  {
-    id: 'multiple-rules',
-    text: 'fuck this shit',
-    matches: [
-      { ruleId: 'fuck', text: 'fuck', targetText: 'fuck' },
-      { ruleId: 'shit', text: 'shit', targetText: 'shit' },
-    ],
-  },
-] as const;
+export const englishProfanityCorpus: readonly EnglishCorpusCase[] =
+  profanityCorpus;
 
-/** Cases that contain suspicious substrings but should remain untouched. */
-export const englishCleanCorpus: readonly EnglishCorpusCase[] = [
-  { id: 'scunthorpe', text: 'Scunthorpe', matches: [] },
-  { id: 'shitake', text: 'shitake mushrooms', matches: [] },
-  { id: 'classhole', text: 'classhole', matches: [] },
-  { id: 'motherfuckerish', text: 'motherfuckerish', matches: [] },
-  { id: 'fuck-combining-mark-continuation', text: 'fuck\u0301', matches: [] },
-  { id: 'shit-connector-continuation', text: 'shit‿word', matches: [] },
-  { id: 'cunt-join-control-continuation', text: 'cunt\u200Dword', matches: [] },
-  { id: 'ordinary-prose', text: 'a perfectly ordinary sentence', matches: [] },
-] as const;
+/** Cases that contain suspicious substrings or boundaries but should stay clean. */
+export const englishCleanCorpus: readonly EnglishCorpusCase[] = cleanCorpus;

--- a/packages/en/src/index.test.ts
+++ b/packages/en/src/index.test.ts
@@ -23,7 +23,11 @@ describe('@scrawlix/en', () => {
     const matches = engine.find(corpusCase.text).map(match => ({
       ruleId: match.ruleId,
       text: match.text,
+      start: match.start,
+      end: match.end,
       targetText: match.targetText,
+      targetStart: match.targetStart,
+      targetEnd: match.targetEnd,
     }));
 
     expect(matches).toEqual(corpusCase.matches);

--- a/packages/en/tsconfig.json
+++ b/packages/en/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts"]
+  "compilerOptions": {
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.json"]
 }

--- a/schemas/corpus.schema.json
+++ b/schemas/corpus.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://scrawlix.dev/schemas/corpus.schema.json",
+  "title": "Scrawlix language-pack corpus",
+  "type": "array",
+  "items": {
+    "$ref": "#/$defs/case"
+  },
+  "$defs": {
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "text", "profile", "matches", "tags"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "text": {
+          "type": "string"
+        },
+        "profile": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1
+        },
+        "matches": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/match"
+          }
+        }
+      }
+    },
+    "match": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ruleId",
+        "text",
+        "start",
+        "end",
+        "targetText",
+        "targetStart",
+        "targetEnd"
+      ],
+      "properties": {
+        "ruleId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "text": {
+          "type": "string",
+          "minLength": 1
+        },
+        "start": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "end": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "targetText": {
+          "type": "string",
+          "minLength": 1
+        },
+        "targetStart": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "targetEnd": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate-corpora.mjs
+++ b/scripts/validate-corpora.mjs
@@ -1,0 +1,117 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const packagesRoot = path.join(root, 'packages');
+const schemaPath = path.join(root, 'schemas', 'corpus.schema.json');
+
+const readJson = async file => JSON.parse(await fs.readFile(file, 'utf8'));
+const exists = async file =>
+  fs
+    .access(file)
+    .then(() => true)
+    .catch(() => false);
+
+const schema = await readJson(schemaPath);
+const ajv = new Ajv2020({ allErrors: true, strict: true });
+const validate = ajv.compile(schema);
+const errors = [];
+let fileCount = 0;
+let caseCount = 0;
+
+for (const packageEntry of await fs.readdir(packagesRoot, { withFileTypes: true })) {
+  if (!packageEntry.isDirectory()) continue;
+
+  const corpusDir = path.join(
+    packagesRoot,
+    packageEntry.name,
+    'src',
+    'corpus-data'
+  );
+  if (!(await exists(corpusDir))) continue;
+
+  const ids = new Set();
+  const files = (await fs.readdir(corpusDir))
+    .filter(file => file.endsWith('.json'))
+    .sort();
+
+  for (const file of files) {
+    const absolute = path.join(corpusDir, file);
+    const relative = path.relative(root, absolute);
+    const corpus = await readJson(absolute);
+    fileCount += 1;
+
+    if (!validate(corpus)) {
+      for (const error of validate.errors ?? []) {
+        errors.push(
+          `${relative}${error.instancePath || '/'} ${error.message ?? 'is invalid'}`
+        );
+      }
+      continue;
+    }
+
+    for (const corpusCase of corpus) {
+      caseCount += 1;
+      const prefix = `${relative}:${corpusCase.id}`;
+
+      if (ids.has(corpusCase.id)) {
+        errors.push(
+          `${prefix} duplicates a corpus case id in @scrawlix/${packageEntry.name}`
+        );
+      }
+      ids.add(corpusCase.id);
+
+      for (const match of corpusCase.matches) {
+        if (match.end <= match.start) {
+          errors.push(`${prefix} match range must be non-empty`);
+          continue;
+        }
+        if (match.end > corpusCase.text.length) {
+          errors.push(
+            `${prefix} match end ${match.end} exceeds source length ${corpusCase.text.length}`
+          );
+          continue;
+        }
+        if (match.targetStart < match.start || match.targetEnd > match.end) {
+          errors.push(`${prefix} target range must be contained by its full match`);
+          continue;
+        }
+        if (match.targetEnd <= match.targetStart) {
+          errors.push(`${prefix} target range must be non-empty`);
+          continue;
+        }
+
+        const fullText = corpusCase.text.slice(match.start, match.end);
+        if (fullText !== match.text) {
+          errors.push(
+            `${prefix} source[${match.start}:${match.end}] is ${JSON.stringify(fullText)}, expected ${JSON.stringify(match.text)}`
+          );
+        }
+
+        const targetText = corpusCase.text.slice(
+          match.targetStart,
+          match.targetEnd
+        );
+        if (targetText !== match.targetText) {
+          errors.push(
+            `${prefix} source[${match.targetStart}:${match.targetEnd}] is ${JSON.stringify(targetText)}, expected target ${JSON.stringify(match.targetText)}`
+          );
+        }
+      }
+    }
+  }
+}
+
+if (fileCount === 0) {
+  errors.push('No corpus JSON files were discovered under packages/*/src/corpus-data/.');
+}
+
+if (errors.length > 0) {
+  console.error('Corpus validation failed:\n');
+  for (const error of errors) console.error(`- ${error}`);
+  process.exitCode = 1;
+} else {
+  console.log(`Validated ${caseCount} corpus cases across ${fileCount} files.`);
+}


### PR DESCRIPTION
## Summary
Make language-pack regression corpora easier for humans and coding agents to extend safely.

### Shared corpus contract
- add `schemas/corpus.schema.json` using JSON Schema 2020-12
- add `pnpm validate:corpora`
- run corpus validation before the workspace test suite
- validate unique case ids plus semantic source-range invariants that JSON Schema alone cannot express

### English corpus migration
- move positive and clean cases to `packages/en/src/corpus-data/*.json`
- keep the existing `@scrawlix/en/corpus` JavaScript/TypeScript export stable
- add `profile`, explanatory tags, and exact UTF-16 full-match/semantic-target offsets
- make English tests assert exact matcher offsets from the data

### Publication smoke
- make the external tarball consumer import `@scrawlix/en/corpus` and inspect an exported case, proving JSON data survives compile, pack, install, typecheck, and bundling

## Validation semantics
The validator checks:
- shared JSON Schema conformance
- unique case ids within each pack
- non-empty, in-bounds match ranges
- semantic targets contained by the full match
- exact `source.slice(start, end)` equality for full and target text

This is the first concrete slice of #52. Corpus diffing and offline false-positive mining remain follow-ups.

Progress on #52
Related: #33, #35, #38