### PR TITLE
Make host access optional and keep site policy local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,13 +95,13 @@ Presentation remains above the DOM adapter. Keep black bars, blur, grawlix masks
 
 `apps/extension` owns `chrome.storage`, hostname overrides, popup UI, manifest permissions, and injected presentation. Do not move those concerns into reusable packages.
 
-Small global preferences belong in `storage.sync`; custom terms currently live in `storage.local`. Host overrides are sparse tri-state policy: absence means inherit, explicit values are `on` or `off`. The master pause is independent from the default site-enabled policy and must win over every host override.
+Small general preferences belong in `storage.sync`; custom terms and hostname overrides belong in `storage.local`. Host overrides are sparse tri-state policy: absence means inherit, explicit values are `on` or `off`. The master pause is independent from the default site-enabled policy and must win over every host override.
 
 Storage changes should perform the minimum page work. Policy changes that leave the current page's effective state unchanged are no-ops; appearance/reveal changes may redecorate owned roots in place. When coverage or custom terms require a new controller, use `DomObservation.restore()` before the replacement controller starts so teardown/reconfigure remains atomic and exact source text returns first.
 
 Extension reveal interaction must avoid stealing native page controls. Generated roots inside links, buttons, inputs, or similar controls stay outside the extension's own focus/click-toggle path.
 
-Broad HTTP/HTTPS host access is a deliberate development choice for persistent automatic per-site behavior. Treat permission minimization as a store-release requirement and document any permission change alongside its UX tradeoff.
+HTTP/HTTPS host access is optional and user-granted. Keep dynamic content-script registration aligned with Chrome's currently granted origin patterns, and keep browser access separate from Scrawlix site policy in both code and UI. Removing access from the extension UI should restore the current page session immediately. Any permission expansion is a browser-product and store-review change that must include its UX and privacy rationale.
 
 ### Add corpus cases for learned linguistic behavior
 

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -29,40 +29,60 @@ To try it locally in Chromium:
 
 ## Preferences
 
-Small preferences live in `chrome.storage.sync`:
+Compact general preferences live in `chrome.storage.sync`:
 
 - master paused state
-- default site enabled state
+- default site behavior
 - appearance
 - coverage
 - reveal mode
+
+Local browser-profile state lives in `chrome.storage.local`:
+
 - sparse hostname overrides (`on` / `off`)
+- custom words and phrases
 
-Custom words and phrases live in `chrome.storage.local`. They can grow independently of the small synced preference object and stay local to the browser profile.
-
-The popup separates the master state from site policy. **Active** means site policy is allowed to apply; pausing Scrawlix disables it everywhere until the user resumes it. The default-site setting controls hosts without an explicit override.
+Older builds stored hostname overrides inside the synced settings object. The extension service worker migrates that legacy map to local storage and rewrites the synced item without hostnames.
 
 The popup exposes a tri-state site mode:
 
-- **default** — no hostname entry is stored; use the default-site setting
-- **always on** — hostname explicitly overrides the default-site setting
-- **always off** — hostname explicitly overrides the default-site setting
+- **default** — no hostname entry is stored
+- **always on** — hostname explicitly overrides the default site behavior
+- **always off** — hostname explicitly overrides the default site behavior
 
-The master pause always wins over site policy, including an **always on** hostname.
+The master pause remains a true kill switch and wins over every hostname override.
 
-Storage changes are observed by the content script and reconciled with the minimum page work. Appearance/reveal changes redecorate existing Scrawlix roots in place. Policy changes that leave the current page's effective enabled state unchanged are page no-ops. Coverage or custom-term changes restore exact source text with `observation.restore()` before a newly configured controller starts.
+## Browser access
+
+The store-facing manifest requests no HTTP/HTTPS host permission at install time. It declares broad HTTP/HTTPS patterns under `optional_host_permissions` and exposes two explicit runtime choices:
+
+- allow the current HTTP/HTTPS origin
+- allow all HTTP and HTTPS websites
+
+A small Manifest V3 service worker keeps one dynamic content-script registration aligned with the origins Chrome currently grants to Scrawlix. Dynamic registration persists across browser sessions. Removing browser access updates the registration; removing access from the popup also tells the current page session to restore its source text immediately.
+
+Browser access and Scrawlix policy are separate. A site can be configured `on` while Chrome access is still missing; the popup reports that state directly instead of claiming censorship is already active.
 
 ## Page lifecycle
 
 The content script:
 
 1. loads the English pack plus one compiled custom-word rule when custom terms exist
-2. creates one `@scrawlix/dom` controller for the current settings when the page is effectively enabled
+2. creates one `@scrawlix/dom` controller when the effective site policy is enabled
 3. observes `document.body`
 4. decorates only Scrawlix-generated roots with extension presentation metadata
-5. listens for storage changes and chooses among no-op, redecorate, stop, start, or atomic controller restart
+5. listens for sync/local preference changes and reconciles the minimum required work
+6. accepts extension messages to reconcile or restore the current page when browser access changes
 
-The DOM adapter watches mutation roots rather than rescanning the document after every page update.
+Preference reconciliation is incremental:
+
+- effective on -> off: restore and stop
+- effective off -> on: create/start a session
+- coverage/custom-term changes: restore and rebuild the controller
+- appearance/reveal changes: redecorate existing generated roots in place
+- unrelated host/default changes: no page DOM work
+
+The DOM adapter watches mutation roots instead of rescanning the complete document after every page update.
 
 ## Presentation
 
@@ -78,26 +98,29 @@ Asterisk/grawlix masks are presentation metadata on generated cover spans. The s
 
 Hover is the default reveal mode. Focus/click reveal makes a generated wrapper keyboard-focusable only when the wrapper is outside links, buttons, inputs, and other native interactive controls. Scrawlix avoids stealing those controls' interaction semantics.
 
-## Permissions
+## Permissions and privacy
 
-The development manifest requests:
+The manifest uses:
 
 - `storage` — persist preferences
-- `activeTab` — let the popup identify the current HTTP/HTTPS hostname after the user opens it
-- host access to HTTP and HTTPS pages — run the content script automatically on pages where Scrawlix may be enabled
+- `activeTab` — let the popup inspect and act on the current page after the user opens it
+- `scripting` — register/inject the local content script for user-granted origins
+- optional HTTP/HTTPS host access — granted at runtime by the user
 
-The extension has no background service worker and sends no browsing or page text to a server. Matching happens inside the page's content-script context using bundled Scrawlix packages.
+The extension has no Scrawlix-operated network dependency and sends no browsing or page text to a Scrawlix server. Matching happens inside the page's content-script context using bundled Scrawlix packages.
 
-Broad HTTP/HTTPS host access is a meaningful permission and should remain explicit in store-facing documentation. Before a store release, revisit whether optional host permissions or another activation model would deliver the desired persistent per-site behavior with a gentler permission prompt.
+See [`docs/extension-privacy.md`](../../docs/extension-privacy.md) for the current store-facing privacy statement.
 
 ## Build validation
 
 `pnpm --filter scrawlix-extension build` validates that:
 
 - the manifest is MV3
+- `background.js` exists
 - `content.js` exists
 - `content.css` exists
 - `popup.html` exists
-- every JS/CSS/popup path referenced by the manifest exists in `dist`
+- broad HTTP/HTTPS patterns remain optional instead of required host permissions
+- every directly referenced popup/background asset exists in `dist`
 
-Pure preference/mask behavior is covered by `src/config.test.ts`. The workspace browser smoke suite loads the built MV3 extension in real Chromium and covers initial/dynamic transformation plus key native-page exclusions; storage/popup policy E2E coverage continues under the browser-hardening work.
+Unit tests cover preference normalization/reconciliation, browser-access helpers, and the local-vs-sync storage split. The Chromium smoke build promotes optional host patterns only inside a temporary test copy of the manifest so CI can exercise the same service-worker registration and real content script without weakening the shipping manifest.

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -3,18 +3,13 @@
   "name": "Scrawlix",
   "description": "Programmable censorship for the web.",
   "version": "0.0.0",
-  "permissions": ["storage", "activeTab"],
-  "host_permissions": ["http://*/*", "https://*/*"],
+  "permissions": ["storage", "activeTab", "scripting"],
+  "optional_host_permissions": ["http://*/*", "https://*/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
   "action": {
     "default_popup": "popup.html",
     "default_title": "Scrawlix"
-  },
-  "content_scripts": [
-    {
-      "matches": ["http://*/*", "https://*/*"],
-      "js": ["content.js"],
-      "css": ["content.css"],
-      "run_at": "document_idle"
-    }
-  ]
+  }
 }

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && vite build -c vite.content.config.ts && vite build -c vite.popup.config.ts && node ../../scripts/copy-file.mjs manifest.json dist/manifest.json && node ../../scripts/copy-file.mjs src/content.css dist/content.css && node scripts/validate-build.mjs",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && vite build -c vite.content.config.ts && vite build -c vite.background.config.ts && vite build -c vite.popup.config.ts && node ../../scripts/copy-file.mjs manifest.json dist/manifest.json && node ../../scripts/copy-file.mjs src/content.css dist/content.css && node scripts/validate-build.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },

--- a/apps/extension/popup.html
+++ b/apps/extension/popup.html
@@ -35,6 +35,17 @@
         </label>
       </section>
 
+      <section class="access-card" aria-label="Browser access">
+        <div>
+          <p class="eyebrow">browser access</p>
+          <p id="access-status" class="access-status">checking…</p>
+        </div>
+        <div class="access-actions">
+          <button id="site-access" type="button">allow this site</button>
+          <button id="all-sites-access" type="button">allow all websites</button>
+        </div>
+      </section>
+
       <section class="settings-grid" aria-label="Censor treatment">
         <label>
           <span>default sites</span>

--- a/apps/extension/scripts/validate-build.mjs
+++ b/apps/extension/scripts/validate-build.mjs
@@ -4,7 +4,7 @@ import { resolve } from 'node:path';
 const dist = resolve(process.cwd(), 'dist');
 const manifestPath = resolve(dist, 'manifest.json');
 
-for (const file of ['manifest.json', 'content.js', 'content.css', 'popup.html']) {
+for (const file of ['manifest.json', 'background.js', 'content.js', 'content.css', 'popup.html']) {
   if (!existsSync(resolve(dist, file))) {
     throw new Error(`Extension build is missing ${file}.`);
   }
@@ -15,8 +15,20 @@ if (manifest.manifest_version !== 3) {
   throw new Error('Extension manifest must use Manifest V3.');
 }
 
+if ((manifest.host_permissions ?? []).length > 0) {
+  throw new Error('Store build must not request required HTTP/HTTPS host access.');
+}
+
+const optionalHosts = new Set(manifest.optional_host_permissions ?? []);
+for (const pattern of ['http://*/*', 'https://*/*']) {
+  if (!optionalHosts.has(pattern)) {
+    throw new Error(`Extension manifest is missing optional host pattern ${pattern}.`);
+  }
+}
+
 const referenced = [
   manifest.action?.default_popup,
+  manifest.background?.service_worker,
   ...(manifest.content_scripts ?? []).flatMap(entry => [
     ...(entry.js ?? []),
     ...(entry.css ?? []),

--- a/apps/extension/src/access.test.ts
+++ b/apps/extension/src/access.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ALL_HOST_PATTERNS,
+  contentScriptMatches,
+  originPatternForUrl,
+} from './access';
+
+describe('extension browser access helpers', () => {
+  it('turns an HTTP(S) page into the narrow origin permission pattern', () => {
+    expect(originPatternForUrl('https://Example.com/path?q=1')).toBe('https://example.com/*');
+    expect(originPatternForUrl('http://127.0.0.1:4174/fixture.html')).toBe(
+      'http://127.0.0.1:4174/*'
+    );
+    expect(originPatternForUrl('chrome://extensions')).toBeNull();
+  });
+
+  it('keeps only HTTP(S) permission origins for dynamic registration', () => {
+    expect(
+      contentScriptMatches([
+        'https://example.com/*',
+        'chrome://favicon/*',
+        'http://*/*',
+        'https://example.com/*',
+      ])
+    ).toEqual(['http://*/*', 'https://example.com/*']);
+  });
+
+  it('declares both web schemes for the explicit all-sites action', () => {
+    expect(ALL_HOST_PATTERNS).toEqual(['http://*/*', 'https://*/*']);
+  });
+});

--- a/apps/extension/src/access.ts
+++ b/apps/extension/src/access.ts
@@ -1,0 +1,104 @@
+export const CONTENT_SCRIPT_ID = 'scrawlix-page';
+export const ALL_HOST_PATTERNS = ['http://*/*', 'https://*/*'] as const;
+
+export type ScrawlixContentMessage =
+  | { type: 'scrawlix-reconcile' }
+  | { type: 'scrawlix-disable' };
+
+export function originPatternForUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    return `${url.protocol}//${url.host}/*`;
+  } catch {
+    return null;
+  }
+}
+
+export function contentScriptMatches(origins: readonly string[]) {
+  return [...new Set(origins.filter(origin => /^https?:\/\//.test(origin)))].sort();
+}
+
+export async function hasPersistentAccess(url: string) {
+  const origin = originPatternForUrl(url);
+  if (!origin) return false;
+  return chrome.permissions.contains({ origins: [origin] });
+}
+
+export async function hasAllHostsAccess() {
+  return chrome.permissions.contains({ origins: [...ALL_HOST_PATTERNS] });
+}
+
+export async function syncContentScriptRegistration() {
+  const permissions = await chrome.permissions.getAll();
+  const matches = contentScriptMatches(permissions.origins ?? []);
+  const existing = await chrome.scripting.getRegisteredContentScripts({
+    ids: [CONTENT_SCRIPT_ID],
+  });
+
+  if (matches.length === 0) {
+    if (existing.length > 0) {
+      await chrome.scripting.unregisterContentScripts({ ids: [CONTENT_SCRIPT_ID] });
+    }
+    return;
+  }
+
+  if (existing.length > 0) {
+    await chrome.scripting.updateContentScripts([
+      {
+        id: CONTENT_SCRIPT_ID,
+        matches,
+      },
+    ]);
+    return;
+  }
+
+  await chrome.scripting.registerContentScripts([
+    {
+      id: CONTENT_SCRIPT_ID,
+      matches,
+      js: ['content.js'],
+      css: ['content.css'],
+      runAt: 'document_idle',
+      persistAcrossSessions: true,
+    },
+  ]);
+}
+
+export async function requestHostAccess(origins: readonly string[]) {
+  const granted = await chrome.permissions.request({ origins: [...origins] });
+  if (granted) await syncContentScriptRegistration();
+  return granted;
+}
+
+export async function removeHostAccess(origins: readonly string[]) {
+  const removed = await chrome.permissions.remove({ origins: [...origins] });
+  if (removed) await syncContentScriptRegistration();
+  return removed;
+}
+
+async function sendContentMessage(tabId: number, message: ScrawlixContentMessage) {
+  try {
+    await chrome.tabs.sendMessage(tabId, message);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function activateTab(tabId: number) {
+  if (await sendContentMessage(tabId, { type: 'scrawlix-reconcile' })) return;
+
+  await chrome.scripting.insertCSS({
+    target: { tabId },
+    files: ['content.css'],
+  });
+  await chrome.scripting.executeScript({
+    target: { tabId },
+    files: ['content.js'],
+  });
+}
+
+export async function deactivateTab(tabId: number) {
+  await sendContentMessage(tabId, { type: 'scrawlix-disable' });
+}

--- a/apps/extension/src/access.ts
+++ b/apps/extension/src/access.ts
@@ -19,6 +19,19 @@ export function contentScriptMatches(origins: readonly string[]) {
   return [...new Set(origins.filter(origin => /^https?:\/\//.test(origin)))].sort();
 }
 
+function contentScriptRegistration(
+  matches: string[]
+): chrome.scripting.RegisteredContentScript {
+  return {
+    id: CONTENT_SCRIPT_ID,
+    matches,
+    js: ['content.js'],
+    css: ['content.css'],
+    runAt: 'document_idle',
+    persistAcrossSessions: true,
+  };
+}
+
 export async function hasPersistentAccess(url: string) {
   const origin = originPatternForUrl(url);
   if (!origin) return false;
@@ -43,26 +56,13 @@ export async function syncContentScriptRegistration() {
     return;
   }
 
+  const registration = contentScriptRegistration(matches);
   if (existing.length > 0) {
-    await chrome.scripting.updateContentScripts([
-      {
-        id: CONTENT_SCRIPT_ID,
-        matches,
-      },
-    ]);
+    await chrome.scripting.updateContentScripts([registration]);
     return;
   }
 
-  await chrome.scripting.registerContentScripts([
-    {
-      id: CONTENT_SCRIPT_ID,
-      matches,
-      js: ['content.js'],
-      css: ['content.css'],
-      runAt: 'document_idle',
-      persistAcrossSessions: true,
-    },
-  ]);
+  await chrome.scripting.registerContentScripts([registration]);
 }
 
 export async function requestHostAccess(origins: readonly string[]) {

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -1,0 +1,25 @@
+import { syncContentScriptRegistration } from './access';
+import { migrateSiteOverridesToLocal } from './storage';
+
+async function refreshBrowserState() {
+  await migrateSiteOverridesToLocal();
+  await syncContentScriptRegistration();
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  void refreshBrowserState();
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  void refreshBrowserState();
+});
+
+chrome.permissions.onAdded.addListener(() => {
+  void syncContentScriptRegistration();
+});
+
+chrome.permissions.onRemoved.addListener(() => {
+  void syncContentScriptRegistration();
+});
+
+void refreshBrowserState();

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -11,6 +11,7 @@ export type ExtensionAppearance =
 export type ExtensionCoverage = 'full' | 'tail' | 'middle' | 'inner' | 'vowel';
 export type ExtensionReveal = 'hover' | 'focus' | 'click' | 'never';
 export type SiteMode = 'inherit' | 'on' | 'off';
+export type SiteOverrides = Record<string, Exclude<SiteMode, 'inherit'>>;
 
 export type SyncSettings = {
   /** True master pause. When paused, no site override can enable Scrawlix. */
@@ -20,7 +21,8 @@ export type SyncSettings = {
   appearance: ExtensionAppearance;
   coverage: ExtensionCoverage;
   reveal: ExtensionReveal;
-  siteOverrides: Record<string, Exclude<SiteMode, 'inherit'>>;
+  /** Runtime-combined local site policy. This field is excluded from sync writes. */
+  siteOverrides: SiteOverrides;
 };
 
 export type ExtensionStateSnapshot = {
@@ -31,6 +33,7 @@ export type ExtensionStateSnapshot = {
 export type SessionAction = 'none' | 'start' | 'stop' | 'restart' | 'decorate';
 
 export const SYNC_SETTINGS_KEY = 'scrawlixSettings';
+export const SITE_OVERRIDES_KEY = 'scrawlixSiteOverrides';
 export const CUSTOM_WORDS_KEY = 'scrawlixCustomWords';
 
 export const DEFAULT_SETTINGS: SyncSettings = {
@@ -62,19 +65,23 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-export function normalizeSettings(value: unknown): SyncSettings {
-  if (!isRecord(value)) return { ...DEFAULT_SETTINGS, siteOverrides: {} };
+export function normalizeSiteOverrides(value: unknown): SiteOverrides {
+  const siteOverrides: SiteOverrides = {};
+  if (!isRecord(value)) return siteOverrides;
 
-  const siteOverrides: SyncSettings['siteOverrides'] = {};
-  if (isRecord(value.siteOverrides)) {
-    for (const [hostname, mode] of Object.entries(value.siteOverrides)) {
-      const normalizedHostname = hostname.trim().toLowerCase();
-      if (!normalizedHostname) continue;
-      if (mode === 'on' || mode === 'off') {
-        siteOverrides[normalizedHostname] = mode;
-      }
+  for (const [hostname, mode] of Object.entries(value)) {
+    const normalizedHostname = hostname.trim().toLowerCase();
+    if (!normalizedHostname) continue;
+    if (mode === 'on' || mode === 'off') {
+      siteOverrides[normalizedHostname] = mode;
     }
   }
+
+  return siteOverrides;
+}
+
+export function normalizeSettings(value: unknown): SyncSettings {
+  if (!isRecord(value)) return { ...DEFAULT_SETTINGS, siteOverrides: {} };
 
   return {
     paused: typeof value.paused === 'boolean' ? value.paused : DEFAULT_SETTINGS.paused,
@@ -88,7 +95,7 @@ export function normalizeSettings(value: unknown): SyncSettings {
     reveal: REVEALS.has(value.reveal as ExtensionReveal)
       ? (value.reveal as ExtensionReveal)
       : DEFAULT_SETTINGS.reveal,
-    siteOverrides,
+    siteOverrides: normalizeSiteOverrides(value.siteOverrides),
   };
 }
 

--- a/apps/extension/src/content.ts
+++ b/apps/extension/src/content.ts
@@ -1,8 +1,10 @@
 import { censorRuleFromWords, type CensorRule } from '@scrawlix/core';
 import { createDomScrawlix, type DomObservation } from '@scrawlix/dom';
 import { englishProfanityRules } from '@scrawlix/en';
+import type { ScrawlixContentMessage } from './access';
 import {
   CUSTOM_WORDS_KEY,
+  SITE_OVERRIDES_KEY,
   SYNC_SETTINGS_KEY,
   coverageSelector,
   maskFor,
@@ -168,9 +170,24 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
   const relevantSync =
     areaName === 'sync' && Object.prototype.hasOwnProperty.call(changes, SYNC_SETTINGS_KEY);
   const relevantLocal =
-    areaName === 'local' && Object.prototype.hasOwnProperty.call(changes, CUSTOM_WORDS_KEY);
+    areaName === 'local' &&
+    (Object.prototype.hasOwnProperty.call(changes, CUSTOM_WORDS_KEY) ||
+      Object.prototype.hasOwnProperty.call(changes, SITE_OVERRIDES_KEY));
 
   if (relevantSync || relevantLocal) void reconcile();
+});
+
+chrome.runtime.onMessage.addListener((message: ScrawlixContentMessage) => {
+  if (message?.type === 'scrawlix-disable') {
+    restartGeneration += 1;
+    activeState = null;
+    stopCurrentSession();
+    return;
+  }
+
+  if (message?.type === 'scrawlix-reconcile') {
+    void reconcile();
+  }
 });
 
 function startWhenReady() {

--- a/apps/extension/src/popup.css
+++ b/apps/extension/src/popup.css
@@ -31,6 +31,7 @@ textarea {
 
 .masthead,
 .site-card,
+.access-card,
 .settings-grid,
 .custom-words,
 footer {
@@ -64,11 +65,13 @@ footer {
 .tagline,
 .eyebrow,
 .status-line,
+.access-status,
 .hint,
 footer,
 .switch-row span,
 .settings-grid label > span,
-.save-status {
+.save-status,
+.access-actions button {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
@@ -155,6 +158,54 @@ footer,
 
 .status-line[data-enabled='false']::before {
   content: '○ ';
+}
+
+.access-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 132px;
+  gap: 12px;
+  align-items: center;
+  padding: 11px 0 12px;
+}
+
+.access-status {
+  margin: 0;
+  font-size: 9px;
+  line-height: 1.35;
+  opacity: 0.72;
+}
+
+.access-actions {
+  display: grid;
+  gap: 5px;
+}
+
+.access-actions button {
+  min-height: 28px;
+  padding: 5px 7px;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.28);
+  border: 1px solid rgba(23, 21, 16, 0.42);
+  font-size: 8px;
+  text-align: left;
+  text-transform: uppercase;
+  letter-spacing: 0.045em;
+  cursor: pointer;
+}
+
+.access-actions button:hover,
+.access-actions button:focus-visible {
+  border-color: #171510;
+}
+
+.access-actions button:focus-visible {
+  outline: 1px solid #171510;
+  outline-offset: 1px;
+}
+
+.access-actions button:disabled {
+  cursor: default;
+  opacity: 0.48;
 }
 
 select,

--- a/apps/extension/src/popup.ts
+++ b/apps/extension/src/popup.ts
@@ -1,5 +1,15 @@
 import './popup.css';
 import {
+  ALL_HOST_PATTERNS,
+  activateTab,
+  deactivateTab,
+  hasAllHostsAccess,
+  hasPersistentAccess,
+  originPatternForUrl,
+  removeHostAccess,
+  requestHostAccess,
+} from './access';
+import {
   effectiveEnabled,
   normalizeCustomWords,
   setSiteMode,
@@ -23,6 +33,13 @@ function required<T extends HTMLElement>(id: string): T {
   return element as T;
 }
 
+type ActivePage = {
+  tabId: number;
+  url: string;
+  hostname: string;
+  originPattern: string;
+};
+
 const activeInput = required<HTMLInputElement>('active');
 const defaultEnabledSelect = required<HTMLSelectElement>('default-enabled');
 const siteModeSelect = required<HTMLSelectElement>('site-mode');
@@ -32,30 +49,38 @@ const revealSelect = required<HTMLSelectElement>('reveal');
 const customWordsInput = required<HTMLTextAreaElement>('custom-words');
 const siteHeading = required<HTMLHeadingElement>('site-heading');
 const effectiveStatus = required<HTMLParagraphElement>('effective-status');
+const accessStatus = required<HTMLParagraphElement>('access-status');
+const siteAccessButton = required<HTMLButtonElement>('site-access');
+const allSitesAccessButton = required<HTMLButtonElement>('all-sites-access');
 const settingsStatus = required<HTMLSpanElement>('settings-status');
 const saveStatus = required<HTMLSpanElement>('save-status');
 
 let settings: SyncSettings;
-let hostname: string | null = null;
+let page: ActivePage | null = null;
+let persistentAccess = false;
+let allHostsAccess = false;
 let wordSaveTimer: number | null = null;
 let settingsSaveQueue = Promise.resolve();
 
-async function currentHostname() {
+async function currentPage(): Promise<ActivePage | null> {
   const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-  const url = tabs[0]?.url;
-  if (!url) return null;
+  const tab = tabs[0];
+  if (tab?.id === undefined || !tab.url) return null;
 
-  try {
-    const parsed = new URL(url);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
-    return parsed.hostname.toLowerCase();
-  } catch {
-    return null;
-  }
+  const originPattern = originPatternForUrl(tab.url);
+  if (!originPattern) return null;
+
+  const parsed = new URL(tab.url);
+  return {
+    tabId: tab.id,
+    url: tab.url,
+    hostname: parsed.hostname.toLowerCase(),
+    originPattern,
+  };
 }
 
 function renderEffectiveStatus() {
-  if (!hostname) {
+  if (!page) {
     siteHeading.textContent = 'This page is unavailable';
     effectiveStatus.textContent = 'Scrawlix runs on ordinary HTTP and HTTPS pages.';
     effectiveStatus.dataset.enabled = 'false';
@@ -63,16 +88,46 @@ function renderEffectiveStatus() {
     return;
   }
 
-  siteHeading.textContent = hostname;
+  siteHeading.textContent = page.hostname;
   siteModeSelect.disabled = false;
-  siteModeSelect.value = siteModeFor(settings, hostname);
-  const enabledHere = effectiveEnabled(settings, hostname);
+  siteModeSelect.value = siteModeFor(settings, page.hostname);
+  const enabledHere = effectiveEnabled(settings, page.hostname);
+
   if (settings.paused) {
     effectiveStatus.textContent = 'paused everywhere';
+  } else if (enabledHere && !persistentAccess) {
+    effectiveStatus.textContent = 'ready here · browser access needed';
   } else {
     effectiveStatus.textContent = enabledHere ? 'censoring is on here' : 'censoring is off here';
   }
-  effectiveStatus.dataset.enabled = enabledHere ? 'true' : 'false';
+  effectiveStatus.dataset.enabled = enabledHere && persistentAccess ? 'true' : 'false';
+}
+
+function renderAccess() {
+  if (!page) {
+    accessStatus.textContent = 'Unavailable on this page.';
+    siteAccessButton.disabled = true;
+    allSitesAccessButton.disabled = false;
+    allSitesAccessButton.textContent = allHostsAccess
+      ? 'remove all-sites access'
+      : 'allow all websites';
+    return;
+  }
+
+  if (allHostsAccess) accessStatus.textContent = 'Allowed on all HTTP and HTTPS websites.';
+  else if (persistentAccess) accessStatus.textContent = 'Allowed on this site.';
+  else accessStatus.textContent = 'Ask first on this site.';
+
+  siteAccessButton.disabled = allHostsAccess;
+  siteAccessButton.textContent = allHostsAccess
+    ? 'included in all sites'
+    : persistentAccess
+      ? 'remove site access'
+      : 'allow this site';
+  allSitesAccessButton.disabled = false;
+  allSitesAccessButton.textContent = allHostsAccess
+    ? 'remove all-sites access'
+    : 'allow all websites';
 }
 
 function renderSettings() {
@@ -82,6 +137,17 @@ function renderSettings() {
   coverageSelect.value = settings.coverage;
   revealSelect.value = settings.reveal;
   renderEffectiveStatus();
+  renderAccess();
+}
+
+async function refreshAccess() {
+  const checks = [hasAllHostsAccess()];
+  if (page) checks.push(hasPersistentAccess(page.url));
+
+  const [all, current = false] = await Promise.all(checks);
+  allHostsAccess = all;
+  persistentAccess = current;
+  renderSettings();
 }
 
 async function persistSettings(next: SyncSettings) {
@@ -143,9 +209,9 @@ defaultEnabledSelect.addEventListener('change', () => {
 });
 
 siteModeSelect.addEventListener('change', () => {
-  if (!hostname) return;
+  if (!page) return;
   void persistSettings(
-    setSiteMode(settings, hostname, siteModeSelect.value as SiteMode)
+    setSiteMode(settings, page.hostname, siteModeSelect.value as SiteMode)
   );
 });
 
@@ -170,19 +236,58 @@ revealSelect.addEventListener('change', () => {
   });
 });
 
+siteAccessButton.addEventListener('click', () => {
+  if (!page || allHostsAccess) return;
+
+  void (async () => {
+    accessStatus.textContent = persistentAccess ? 'removing access…' : 'requesting access…';
+    try {
+      if (persistentAccess) {
+        await deactivateTab(page.tabId);
+        await removeHostAccess([page.originPattern]);
+      } else {
+        const granted = await requestHostAccess([page.originPattern]);
+        if (granted) await activateTab(page.tabId);
+      }
+      await refreshAccess();
+    } catch {
+      accessStatus.textContent = 'Access change failed.';
+    }
+  })();
+});
+
+allSitesAccessButton.addEventListener('click', () => {
+  void (async () => {
+    accessStatus.textContent = allHostsAccess ? 'removing all-sites access…' : 'requesting all-sites access…';
+    try {
+      if (allHostsAccess) {
+        if (page) await deactivateTab(page.tabId);
+        await removeHostAccess(ALL_HOST_PATTERNS);
+        if (page && (await hasPersistentAccess(page.url))) await activateTab(page.tabId);
+      } else {
+        const granted = await requestHostAccess(ALL_HOST_PATTERNS);
+        if (granted && page) await activateTab(page.tabId);
+      }
+      await refreshAccess();
+    } catch {
+      accessStatus.textContent = 'Access change failed.';
+    }
+  })();
+});
+
 customWordsInput.addEventListener('input', scheduleWordSave);
 customWordsInput.addEventListener('change', () => void persistWords());
 
 async function initialize() {
-  const [state, activeHostname] = await Promise.all([
+  const [state, activePage] = await Promise.all([
     loadExtensionState(),
-    currentHostname(),
+    currentPage(),
   ]);
 
   settings = state.settings;
-  hostname = activeHostname;
+  page = activePage;
   customWordsInput.value = state.customWords.join('\n');
-  renderSettings();
+  await refreshAccess();
 }
 
 void initialize();

--- a/apps/extension/src/popup.ts
+++ b/apps/extension/src/popup.ts
@@ -150,6 +150,10 @@ async function refreshAccess() {
   renderSettings();
 }
 
+async function ensureCurrentPageRuntime() {
+  if (page && persistentAccess) await activateTab(page.tabId);
+}
+
 async function persistSettings(next: SyncSettings) {
   settings = next;
   renderSettings();
@@ -173,6 +177,7 @@ async function persistSettings(next: SyncSettings) {
 
   settingsSaveQueue = queued.catch(() => undefined);
   await queued.catch(() => undefined);
+  await ensureCurrentPageRuntime();
 }
 
 function wordsFromTextarea() {
@@ -189,6 +194,7 @@ async function persistWords() {
   try {
     await saveCustomWords(wordsFromTextarea());
     saveStatus.textContent = 'saved';
+    await ensureCurrentPageRuntime();
   } catch {
     saveStatus.textContent = 'save failed';
   }
@@ -288,6 +294,7 @@ async function initialize() {
   page = activePage;
   customWordsInput.value = state.customWords.join('\n');
   await refreshAccess();
+  await ensureCurrentPageRuntime();
 }
 
 void initialize();

--- a/apps/extension/src/storage.test.ts
+++ b/apps/extension/src/storage.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_SETTINGS, SITE_OVERRIDES_KEY, SYNC_SETTINGS_KEY } from './config';
+import { loadSettings, migrateSiteOverridesToLocal, saveSettings } from './storage';
+
+type Store = Record<string, unknown>;
+
+function storageArea(store: Store) {
+  return {
+    get: vi.fn(async (key: string) => ({ [key]: store[key] })),
+    set: vi.fn(async (value: Store) => {
+      Object.assign(store, value);
+    }),
+  };
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('extension storage split', () => {
+  it('keeps hostname overrides local while syncing compact preferences', async () => {
+    const syncStore: Store = {};
+    const localStore: Store = {};
+    const sync = storageArea(syncStore);
+    const local = storageArea(localStore);
+    vi.stubGlobal('chrome', { storage: { sync, local } });
+
+    await saveSettings({
+      ...DEFAULT_SETTINGS,
+      appearance: 'blur',
+      siteOverrides: { 'example.com': 'off' },
+    });
+
+    expect(localStore[SITE_OVERRIDES_KEY]).toEqual({ 'example.com': 'off' });
+    expect(syncStore[SYNC_SETTINGS_KEY]).toEqual({
+      paused: false,
+      enabled: true,
+      appearance: 'blur',
+      coverage: 'middle',
+      reveal: 'hover',
+    });
+  });
+
+  it('prefers the local hostname policy over legacy synced overrides', async () => {
+    const syncStore: Store = {
+      [SYNC_SETTINGS_KEY]: {
+        ...DEFAULT_SETTINGS,
+        siteOverrides: { 'legacy.example': 'on' },
+      },
+    };
+    const localStore: Store = {
+      [SITE_OVERRIDES_KEY]: { 'local.example': 'off' },
+    };
+    vi.stubGlobal('chrome', {
+      storage: {
+        sync: storageArea(syncStore),
+        local: storageArea(localStore),
+      },
+    });
+
+    const settings = await loadSettings();
+    expect(settings.siteOverrides).toEqual({ 'local.example': 'off' });
+  });
+
+  it('migrates legacy synced hostnames to local storage and scrubs the sync item', async () => {
+    const syncStore: Store = {
+      [SYNC_SETTINGS_KEY]: {
+        paused: false,
+        enabled: false,
+        appearance: 'bar',
+        coverage: 'full',
+        reveal: 'never',
+        siteOverrides: { 'Example.COM': 'on' },
+      },
+    };
+    const localStore: Store = {};
+    vi.stubGlobal('chrome', {
+      storage: {
+        sync: storageArea(syncStore),
+        local: storageArea(localStore),
+      },
+    });
+
+    await migrateSiteOverridesToLocal();
+
+    expect(localStore[SITE_OVERRIDES_KEY]).toEqual({ 'example.com': 'on' });
+    expect(syncStore[SYNC_SETTINGS_KEY]).toEqual({
+      paused: false,
+      enabled: false,
+      appearance: 'bar',
+      coverage: 'full',
+      reveal: 'never',
+    });
+  });
+});

--- a/apps/extension/src/storage.test.ts
+++ b/apps/extension/src/storage.test.ts
@@ -6,7 +6,9 @@ type Store = Record<string, unknown>;
 
 function storageArea(store: Store) {
   return {
-    get: vi.fn(async (key: string) => ({ [key]: store[key] })),
+    get: vi.fn(async (key: string) =>
+      Object.prototype.hasOwnProperty.call(store, key) ? { [key]: store[key] } : {}
+    ),
     set: vi.fn(async (value: Store) => {
       Object.assign(store, value);
     }),
@@ -90,6 +92,33 @@ describe('extension storage split', () => {
       appearance: 'bar',
       coverage: 'full',
       reveal: 'never',
+    });
+  });
+
+  it('preserves an intentionally empty local override map during migration', async () => {
+    const syncStore: Store = {
+      [SYNC_SETTINGS_KEY]: {
+        ...DEFAULT_SETTINGS,
+        siteOverrides: { 'legacy.example': 'on' },
+      },
+    };
+    const localStore: Store = { [SITE_OVERRIDES_KEY]: {} };
+    vi.stubGlobal('chrome', {
+      storage: {
+        sync: storageArea(syncStore),
+        local: storageArea(localStore),
+      },
+    });
+
+    await migrateSiteOverridesToLocal();
+
+    expect(localStore[SITE_OVERRIDES_KEY]).toEqual({});
+    expect(syncStore[SYNC_SETTINGS_KEY]).toEqual({
+      paused: false,
+      enabled: true,
+      appearance: 'scrawl',
+      coverage: 'middle',
+      reveal: 'hover',
     });
   });
 });

--- a/apps/extension/src/storage.ts
+++ b/apps/extension/src/storage.ts
@@ -1,18 +1,76 @@
 import {
   CUSTOM_WORDS_KEY,
+  SITE_OVERRIDES_KEY,
   SYNC_SETTINGS_KEY,
   normalizeCustomWords,
   normalizeSettings,
+  normalizeSiteOverrides,
+  type SiteOverrides,
   type SyncSettings,
 } from './config';
 
+function hasOwn(value: Record<string, unknown>, key: string) {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function compactSyncSettings(settings: SyncSettings) {
+  const { siteOverrides: _siteOverrides, ...syncSettings } = settings;
+  return syncSettings;
+}
+
 export async function loadSettings(): Promise<SyncSettings> {
-  const stored = await chrome.storage.sync.get(SYNC_SETTINGS_KEY);
-  return normalizeSettings(stored[SYNC_SETTINGS_KEY]);
+  const [storedSync, storedLocal] = await Promise.all([
+    chrome.storage.sync.get(SYNC_SETTINGS_KEY),
+    chrome.storage.local.get(SITE_OVERRIDES_KEY),
+  ]);
+
+  const settings = normalizeSettings(storedSync[SYNC_SETTINGS_KEY]);
+  const siteOverrides = hasOwn(storedLocal, SITE_OVERRIDES_KEY)
+    ? normalizeSiteOverrides(storedLocal[SITE_OVERRIDES_KEY])
+    : settings.siteOverrides;
+
+  return { ...settings, siteOverrides };
 }
 
 export async function saveSettings(settings: SyncSettings) {
-  await chrome.storage.sync.set({ [SYNC_SETTINGS_KEY]: settings });
+  await chrome.storage.local.set({
+    [SITE_OVERRIDES_KEY]: normalizeSiteOverrides(settings.siteOverrides),
+  });
+  await chrome.storage.sync.set({
+    [SYNC_SETTINGS_KEY]: compactSyncSettings(settings),
+  });
+}
+
+export async function migrateSiteOverridesToLocal() {
+  const [storedSync, storedLocal] = await Promise.all([
+    chrome.storage.sync.get(SYNC_SETTINGS_KEY),
+    chrome.storage.local.get(SITE_OVERRIDES_KEY),
+  ]);
+
+  const settings = normalizeSettings(storedSync[SYNC_SETTINGS_KEY]);
+  const localExists = hasOwn(storedLocal, SITE_OVERRIDES_KEY);
+
+  if (!localExists && Object.keys(settings.siteOverrides).length > 0) {
+    await chrome.storage.local.set({
+      [SITE_OVERRIDES_KEY]: settings.siteOverrides,
+    });
+  }
+
+  const rawSync = storedSync[SYNC_SETTINGS_KEY];
+  if (
+    typeof rawSync === 'object' &&
+    rawSync !== null &&
+    Object.prototype.hasOwnProperty.call(rawSync, 'siteOverrides')
+  ) {
+    await chrome.storage.sync.set({
+      [SYNC_SETTINGS_KEY]: compactSyncSettings(settings),
+    });
+  }
+}
+
+export async function loadSiteOverrides(): Promise<SiteOverrides> {
+  const stored = await chrome.storage.local.get(SITE_OVERRIDES_KEY);
+  return normalizeSiteOverrides(stored[SITE_OVERRIDES_KEY]);
 }
 
 export async function loadCustomWords(): Promise<string[]> {

--- a/apps/extension/vite.background.config.ts
+++ b/apps/extension/vite.background.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    outDir: 'dist',
+    sourcemap: true,
+    minify: false,
+    lib: {
+      entry: fileURLToPath(new URL('./src/background.ts', import.meta.url)),
+      name: 'ScrawlixBackground',
+      formats: ['iife'],
+      fileName: () => 'background.js',
+    },
+  },
+});

--- a/docs/extension-privacy.md
+++ b/docs/extension-privacy.md
@@ -1,0 +1,43 @@
+# Scrawlix browser extension privacy
+
+Last updated: 2026-08-27
+
+Scrawlix censors configured words and phrases directly inside webpages in the browser. Its extension code has no analytics, telemetry, advertising, account system, or Scrawlix-operated network service.
+
+## Data Scrawlix handles
+
+### Webpage text
+
+When Scrawlix has browser access to a site, the content script reads eligible text nodes in that page so the bundled matching engine can find configured terms and render the selected censor treatment. Page text is processed in the page's browser context. Scrawlix does not send page text to a Scrawlix server and does not persist page text in extension storage.
+
+### Current page address
+
+When the popup is opened, Scrawlix reads the active HTTP or HTTPS page address to show the current hostname, determine whether persistent browser access has been granted, and apply a site-specific on/off preference when the user chooses one.
+
+### Site preferences
+
+Explicit per-host `on` / `off` preferences are stored in `chrome.storage.local`. These hostname preferences stay in the local browser profile and are excluded from Scrawlix's `chrome.storage.sync` preference item.
+
+### Custom words and phrases
+
+User-entered custom terms are stored in `chrome.storage.local` and are used only by the local matching engine.
+
+### General preferences
+
+The master pause/default behavior, censor style, coverage, and reveal preference use `chrome.storage.sync`. Chrome may sync those compact preferences between browsers according to the user's Chrome Sync settings. Scrawlix excludes custom terms and hostname preferences from this synced item.
+
+### Browser site access
+
+Scrawlix declares HTTP and HTTPS access as optional host permissions. Users can grant access for the current origin or for all HTTP/HTTPS websites, and can remove that access again. Chrome stores and enforces those grants. Scrawlix dynamically registers its local content script only for currently granted HTTP/HTTPS patterns.
+
+## Sharing and transmission
+
+Scrawlix extension code does not transmit webpage text, browsing activity, custom terms, or hostname preferences to Scrawlix or third parties. General preferences may be handled by Chrome Sync when the user has browser sync enabled.
+
+## User controls
+
+Users can pause Scrawlix, disable it by default, override individual hostnames, remove browser site access, edit or delete custom terms, and clear extension storage through the browser's extension controls.
+
+## Chrome Web Store Limited Use
+
+Scrawlix's use of browser permissions and user data is limited to its user-facing censorship and preference features. The project intends to comply with the Chrome Web Store User Data Policy, including its Limited Use requirements.

--- a/tests/browser/browser.spec.ts
+++ b/tests/browser/browser.spec.ts
@@ -1,7 +1,20 @@
 import { chromium, expect, test } from '@playwright/test';
+import { cpSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const extensionPath = resolve(process.cwd(), 'apps/extension/dist');
+
+function extensionWithPregrantedHosts(outputPath: string) {
+  cpSync(extensionPath, outputPath, { recursive: true });
+
+  const manifestPath = resolve(outputPath, 'manifest.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  manifest.host_permissions = manifest.optional_host_permissions ?? [];
+  delete manifest.optional_host_permissions;
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  return outputPath;
+}
 
 test('demo controls drive real rendered coverage and reveal state', async ({ page }) => {
   await page.goto('http://127.0.0.1:4173');
@@ -33,20 +46,35 @@ test('demo controls drive real rendered coverage and reveal state', async ({ pag
   expect(overflow).toBeLessThanOrEqual(0);
 });
 
-test('built extension transforms initial and dynamic page text in Chromium', async ({}, testInfo) => {
+test('built extension registers granted hosts and transforms page text in Chromium', async ({}, testInfo) => {
+  const testExtensionPath = extensionWithPregrantedHosts(
+    testInfo.outputPath('extension-under-test')
+  );
   const context = await chromium.launchPersistentContext(
     testInfo.outputPath('extension-profile'),
     {
       channel: 'chromium',
       headless: true,
       args: [
-        `--disable-extensions-except=${extensionPath}`,
-        `--load-extension=${extensionPath}`,
+        `--disable-extensions-except=${testExtensionPath}`,
+        `--load-extension=${testExtensionPath}`,
       ],
     }
   );
 
   try {
+    const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
+    await expect
+      .poll(async () =>
+        worker.evaluate(async () => {
+          const scripts = await chrome.scripting.getRegisteredContentScripts({
+            ids: ['scrawlix-page'],
+          });
+          return scripts[0]?.matches?.sort() ?? [];
+        })
+      )
+      .toEqual(['http://*/*', 'https://*/*']);
+
     const page = context.pages()[0] ?? (await context.newPage());
     await page.goto('http://127.0.0.1:4174/fixture.html');
 


### PR DESCRIPTION
## What changed

- move HTTP/HTTPS access from required `host_permissions` to `optional_host_permissions`
- add `scripting` plus a small MV3 service worker
- keep one persisted dynamic content-script registration aligned with Chrome's currently granted HTTP/HTTPS origins
- add popup actions for **allow this site** / **allow all websites** and corresponding removal flows
- distinguish Scrawlix site policy from browser access in the current-site status
- restore the current page when access is removed and reconcile/inject immediately after access is granted
- move hostname overrides from `chrome.storage.sync` to `chrome.storage.local`
- migrate legacy synced hostname overrides locally and scrub them from the sync item
- add a build guard that rejects required broad host access
- add a store-facing privacy statement documenting local page-text processing and storage behavior
- retain real Chromium extension smoke by promoting optional origins only inside a temporary test manifest, then exercising the production service-worker/dynamic-registration path
- update maintainer invariants for optional access and local host policy

## Why this design

Chrome's current MV3 guidance supports requesting optional host origins from a user gesture and using dynamic content-script registrations when injection should depend on runtime choices. Persisted dynamic registrations survive browser sessions, so the worker only has to reconcile Chrome's granted-origin set when access changes.

Chrome Web Store policy also treats locally processed website content as user data and requires disclosure, so the privacy text explicitly describes local processing, local hostname/custom-term storage, and the compact preference data that may use Chrome Sync.

`activeTab` remains temporary, tab-specific access for the toolbar interaction; persistent browser-access status comes from `chrome.permissions`.

## Validation

CI is green on the final head:

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Chromium demo smoke
- Chromium extension smoke, including worker dynamic-registration assertion
- `pnpm smoke:packages`

## Stack

This PR is intentionally based on `copper/p0-extension-state` / #58 so reviewers see only the permission/privacy slice.

Progresses #50 and #23.