### PR TITLE
Reuse extension sessions for presentation-only settings

### DIFF
--- a/apps/extension/src/content.ts
+++ b/apps/extension/src/content.ts
@@ -9,6 +9,10 @@ import {
   maskFor,
   type SyncSettings,
 } from './config';
+import {
+  canReuseSemanticSession,
+  presentationSettingsChanged,
+} from './session';
 import { loadExtensionState } from './storage';
 
 const INTERACTIVE_ANCESTOR =
@@ -17,7 +21,9 @@ const INTERACTIVE_ANCESTOR =
 let observation: DomObservation | null = null;
 let presentationObserver: MutationObserver | null = null;
 let activeSettings: SyncSettings | null = null;
+let activeBody: HTMLElement | null = null;
 let restartGeneration = 0;
+let semanticDirty = false;
 
 function customRule(customTerms: readonly string[]): CensorRule[] {
   if (customTerms.length === 0) return [];
@@ -63,7 +69,7 @@ function decorateSubtree(node: Node, settings: SyncSettings) {
   }
 }
 
-function startPresentationObserver(settings: SyncSettings) {
+function startPresentationObserver(root: HTMLElement, settings: SyncSettings) {
   const observer = new MutationObserver(records => {
     for (const record of records) {
       for (const added of Array.from(record.addedNodes)) {
@@ -72,8 +78,15 @@ function startPresentationObserver(settings: SyncSettings) {
     }
   });
 
-  observer.observe(document.body, { childList: true, subtree: true });
+  observer.observe(root, { childList: true, subtree: true });
   presentationObserver = observer;
+}
+
+function refreshPresentation(root: HTMLElement, settings: SyncSettings) {
+  presentationObserver?.disconnect();
+  presentationObserver = null;
+  decorateSubtree(root, settings);
+  startPresentationObserver(root, settings);
 }
 
 function stopCurrentSession() {
@@ -82,6 +95,7 @@ function stopCurrentSession() {
   observation?.restore();
   observation = null;
   activeSettings = null;
+  activeBody = null;
 }
 
 async function restart() {
@@ -89,10 +103,31 @@ async function restart() {
   const state = await loadExtensionState();
   if (generation !== restartGeneration) return;
 
+  const hostname = location.hostname.toLowerCase();
+  const body = document.body;
+  const previousSettings = activeSettings;
+
+  if (
+    body &&
+    observation &&
+    previousSettings &&
+    activeBody === body &&
+    !semanticDirty &&
+    canReuseSemanticSession(previousSettings, state.settings, hostname)
+  ) {
+    if (presentationSettingsChanged(previousSettings, state.settings)) {
+      refreshPresentation(body, state.settings);
+    }
+    activeSettings = state.settings;
+    return;
+  }
+
   stopCurrentSession();
 
-  const hostname = location.hostname.toLowerCase();
-  if (!document.body || !effectiveEnabled(state.settings, hostname)) return;
+  if (!body || !effectiveEnabled(state.settings, hostname)) {
+    semanticDirty = false;
+    return;
+  }
 
   const controller = createDomScrawlix({
     rules: [...englishStrongProfanityRules, ...customRule(state.customWords)],
@@ -100,9 +135,10 @@ async function restart() {
   });
 
   activeSettings = state.settings;
-  observation = controller.observe(document.body);
-  decorateSubtree(document.body, state.settings);
-  startPresentationObserver(state.settings);
+  activeBody = body;
+  observation = controller.observe(body);
+  refreshPresentation(body, state.settings);
+  semanticDirty = false;
 }
 
 function clickRootFromEvent(event: Event) {
@@ -138,6 +174,7 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
   const relevantLocal =
     areaName === 'local' && Object.prototype.hasOwnProperty.call(changes, CUSTOM_WORDS_KEY);
 
+  if (relevantLocal) semanticDirty = true;
   if (relevantSync || relevantLocal) void restart();
 });
 
@@ -147,5 +184,3 @@ function startWhenReady() {
 }
 
 startWhenReady();
-
-void activeSettings;

--- a/apps/extension/src/session.test.ts
+++ b/apps/extension/src/session.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_SETTINGS } from './config';
+import {
+  canReuseSemanticSession,
+  presentationSettingsChanged,
+} from './session';
+
+describe('extension session classification', () => {
+  it('reuses semantic work for appearance and reveal changes', () => {
+    const next = {
+      ...DEFAULT_SETTINGS,
+      appearance: 'bar' as const,
+      reveal: 'click' as const,
+    };
+
+    expect(canReuseSemanticSession(DEFAULT_SETTINGS, next, 'example.com')).toBe(
+      true
+    );
+    expect(presentationSettingsChanged(DEFAULT_SETTINGS, next)).toBe(true);
+  });
+
+  it('requires a semantic restart when coverage changes', () => {
+    const next = { ...DEFAULT_SETTINGS, coverage: 'full' as const };
+
+    expect(canReuseSemanticSession(DEFAULT_SETTINGS, next, 'example.com')).toBe(
+      false
+    );
+  });
+
+  it('cannot reuse an active session when the site becomes disabled', () => {
+    const next = { ...DEFAULT_SETTINGS, enabled: false };
+
+    expect(canReuseSemanticSession(DEFAULT_SETTINGS, next, 'example.com')).toBe(
+      false
+    );
+  });
+
+  it('can reuse when a site override keeps the current host enabled', () => {
+    const active = {
+      ...DEFAULT_SETTINGS,
+      enabled: false,
+      siteOverrides: { 'example.com': 'on' as const },
+    };
+    const next = { ...active, appearance: 'blur' as const };
+
+    expect(canReuseSemanticSession(active, next, 'example.com')).toBe(true);
+  });
+
+  it('skips presentation work when only unrelated settings change', () => {
+    const next = {
+      ...DEFAULT_SETTINGS,
+      siteOverrides: { 'other.example': 'off' as const },
+    };
+
+    expect(presentationSettingsChanged(DEFAULT_SETTINGS, next)).toBe(false);
+  });
+});

--- a/apps/extension/src/session.ts
+++ b/apps/extension/src/session.ts
@@ -1,0 +1,20 @@
+import { effectiveEnabled, type SyncSettings } from './config';
+
+export function canReuseSemanticSession(
+  active: SyncSettings,
+  next: SyncSettings,
+  hostname: string
+) {
+  return (
+    active.coverage === next.coverage &&
+    effectiveEnabled(active, hostname) &&
+    effectiveEnabled(next, hostname)
+  );
+}
+
+export function presentationSettingsChanged(
+  active: SyncSettings,
+  next: SyncSettings
+) {
+  return active.appearance !== next.appearance || active.reveal !== next.reveal;
+}


### PR DESCRIPTION
## What changed

- classify whether an active extension session can reuse its semantic DOM work
- appearance/reveal changes now redecorate existing Scrawlix wrappers in place instead of restoring and rescanning the page
- unrelated sync-setting changes can become zero-DOM-work updates when presentation is unchanged
- coverage changes and effective enable/disable transitions still rebuild/stop the semantic session
- track the currently observed body so a stale body can never qualify for session reuse
- keep a persistent semantic-dirty bit for local custom-term changes, so a near-simultaneous sync change cannot supersede the required semantic restart
- add focused classifier regressions for presentation, coverage, enablement, and per-site override cases

## Why

Changing `bar` to `blur` or `hover` to `click` does not change which text is censored. The previous path restored every wrapper, rebuilt the engine, walked `document.body`, and transformed everything again.

The new path makes presentation-only updates proportional to existing Scrawlix output and avoids regex/DOM discovery work entirely.

Refs #23 and #57.