### PR TITLE
Release-gate the Next.js App Router adoption path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added keyboard reveal handling and a single-source accessibility contract with rendered regressions.
 - Added the public CSS subpath export.
 - Bound the supported peer range to React 18 and 19 and added packed external-consumer verification for both majors.
+- Documented and release-gated the Next.js App Router pattern: keep non-serializable rule packs inside an application-owned Client Component and pass serializable text from Server Components.
 
 ### Markdown
 
@@ -60,7 +61,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 ### Developer experience
 
 - Added compiled ESM/declaration artifacts for public packages.
-- Added external tarball consumer smoke tests as a CI release gate, with strict declaration checking and React 18/19 production builds.
+- Added external tarball consumer smoke tests as a CI release gate, with strict declaration checking, React 18/19 production builds, and a Next.js 16 App Router production build using the documented client-wrapper boundary.
 - Added package-local READMEs for every public package, exact install commands, a top-level integration chooser, a docs index, React CSS troubleshooting, Next.js client-boundary guidance, and clearer source/accessibility notes.
 - Added explicit runtime compatibility and pre-1.0 versioning/public-contract policies.
 - Aligned `README.md`, `AGENTS.md`, `llms.txt`, demo, extension, tests, and smoke consumers on the canonical pre-release public names and conservative defaults.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,23 @@ Current reveal modes: `never`, `hover`, `focus`, `click`.
 
 `CensoredText` is reversible presentation. It keeps one exact source copy available to assistive technology and marks the decorative visual tree `aria-hidden="true"`. Secrets or destructive redaction belong upstream; Scrawlix intentionally preserves caller-owned source text.
 
-The React entry is a Client Component, so Next.js App Router consumers can import it across a normal client boundary. Put the global stylesheet in the application’s global CSS path.
+### Next.js App Router
+
+`CensoredText` is a Client Component. Rule packs contain `RegExp` values and coverage policies can be functions, so keep rule selection inside a client boundary instead of passing a rule pack from a Server Component.
+
+```tsx
+// app/ScrawlixText.tsx
+'use client';
+
+import { englishStrongProfanityRules } from '@scrawlix/en';
+import { CensoredText } from '@scrawlix/react';
+
+export function ScrawlixText({ text }: { text: string }) {
+  return <CensoredText text={text} rules={englishStrongProfanityRules} />;
+}
+```
+
+Server Components can then pass ordinary serializable text to that wrapper. Import `@scrawlix/react/styles.css` from the root layout or your App Router global CSS entry. This exact boundary is production-built in the packed-package smoke suite.
 
 ## Core
 
@@ -213,7 +229,7 @@ pnpm build
 pnpm smoke:packages
 ```
 
-The packed-package smoke test installs real tarballs into a consumer outside the workspace graph, then typechecks and production-builds through public package exports.
+The packed-package smoke test installs real tarballs into external consumers, then typechecks and production-builds React 18, React 19, and Next.js App Router integrations through public package exports.
 
 ## Status
 

--- a/apps/demo/public/llms.txt
+++ b/apps/demo/public/llms.txt
@@ -34,6 +34,26 @@ import '@scrawlix/react/styles.css';
 
 React defaults: `coverage="full"`, `appearance="scrawl"`, `reveal="never"`. Add partial coverage or reveal props only when the application asks for them. The stylesheet import is required for built-in appearances and the visually-hidden accessibility copy. `CensoredText` preserves one exact source copy for assistive technology; it is reversible presentation, not destructive redaction.
 
+Next.js App Router rule:
+- `CensoredText` is a Client Component.
+- Scrawlix rules contain `RegExp` values and coverage selectors can be functions. Do not pass rule packs from a Server Component into `CensoredText` props.
+- Create a small application-owned `'use client'` wrapper that imports both the selected rule pack and `CensoredText`; let Server Components pass only serializable values such as `text`.
+- Import `@scrawlix/react/styles.css` from the root layout/global CSS path.
+- The packed-package smoke suite production-builds this exact App Router pattern.
+
+Canonical App Router wrapper:
+
+```tsx
+'use client';
+
+import { englishStrongProfanityRules } from '@scrawlix/en';
+import { CensoredText } from '@scrawlix/react';
+
+export function ScrawlixText({ text }: { text: string }) {
+  return <CensoredText text={text} rules={englishStrongProfanityRules} />;
+}
+```
+
 Core install:
 
 ```sh
@@ -99,6 +119,8 @@ The browser extension keeps browser state outside reusable packages. Global trea
 
 Use only documented public package exports. Maintainer guidance: https://github.com/teamleaderleo/scrawlix/blob/main/AGENTS.md
 Docs index: https://github.com/teamleaderleo/scrawlix/blob/main/docs/README.md
+Compatibility: https://github.com/teamleaderleo/scrawlix/blob/main/docs/compatibility.md
+Versioning: https://github.com/teamleaderleo/scrawlix/blob/main/docs/versioning.md
 Language packs: https://github.com/teamleaderleo/scrawlix/blob/main/docs/language-packs.md
 DOM lifecycle: https://github.com/teamleaderleo/scrawlix/blob/main/docs/dom.md
 Extension notes: https://github.com/teamleaderleo/scrawlix/blob/main/apps/extension/README.md

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -28,7 +28,11 @@ A fallback based on Unicode code points is used when `Intl.Segmenter` is unavail
 
 `@scrawlix/react` supports React **18 and 19**. The packed-package release gate installs, typechecks, and production-builds external consumers against both major versions.
 
-The React entry is a Client Component because interactive reveal uses React state. Next.js App Router users can import it across a normal client boundary. A dedicated Next.js consumer smoke remains tracked separately.
+The React entry is a Client Component because interactive reveal uses React state.
+
+For Next.js App Router, keep rule selection inside a local Client Component. Scrawlix rules contain `RegExp` values and coverage selectors can be functions, so they are unsuitable as Server-to-Client serialized props. The Server Component should pass ordinary serializable values such as the source `text` to an application-owned client wrapper that imports both the rule pack and `CensoredText`.
+
+The packed-package release gate also installs a Next.js 16 App Router fixture from tarballs and production-builds this exact boundary, including the public stylesheet import from the root layout.
 
 ## DOM
 
@@ -44,6 +48,6 @@ The semantic text contract remains in the generated markup. Consumers targeting 
 
 ## TypeScript
 
-Published packages include declarations and use ESM package exports. The external tarball consumer typechecks with `skipLibCheck: false`, so declaration dependencies and public export paths are verified before release.
+Published packages include declarations and use ESM package exports. External tarball consumers typecheck with `skipLibCheck: false`, so declaration dependencies and public export paths are verified before release.
 
 Consumer projects can use their own TypeScript configuration. The Scrawlix workspace itself uses `moduleResolution: "Bundler"`; that setting is not imposed on consumers.

--- a/fixtures/next-consumer/app/ScrawlixText.tsx
+++ b/fixtures/next-consumer/app/ScrawlixText.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { englishStrongProfanityRules } from '@scrawlix/en';
+import { CensoredText } from '@scrawlix/react';
+
+export function ScrawlixText({ text }: { text: string }) {
+  return <CensoredText text={text} rules={englishStrongProfanityRules} />;
+}

--- a/fixtures/next-consumer/app/layout.tsx
+++ b/fixtures/next-consumer/app/layout.tsx
@@ -1,0 +1,10 @@
+import '@scrawlix/react/styles.css';
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/fixtures/next-consumer/app/page.tsx
+++ b/fixtures/next-consumer/app/page.tsx
@@ -1,0 +1,12 @@
+import { ScrawlixText } from './ScrawlixText';
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Scrawlix Next.js smoke consumer</h1>
+      <p>
+        <ScrawlixText text="what the fuck" />
+      </p>
+    </main>
+  );
+}

--- a/fixtures/next-consumer/next-env.d.ts
+++ b/fixtures/next-consumer/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// This file mirrors the generated Next.js type references used by an App Router consumer.

--- a/fixtures/next-consumer/package.json
+++ b/fixtures/next-consumer/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "scrawlix-next-smoke-consumer",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "build": "next build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "16.3.3",
+    "react": "19",
+    "react-dom": "19"
+  },
+  "devDependencies": {
+    "@types/node": "22",
+    "@types/react": "19",
+    "@types/react-dom": "19",
+    "typescript": "^5.2.2"
+  }
+}

--- a/fixtures/next-consumer/tsconfig.json
+++ b/fixtures/next-consumer/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": false,
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,

--- a/fixtures/next-consumer/tsconfig.json
+++ b/fixtures/next-consumer/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": false,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -55,6 +55,40 @@ Passive `never`/`hover` modes stay outside the tab order. Keyboard-driven `focus
 
 ## Next.js App Router
 
-The package entry point is a Client Component because `CensoredText` uses React state for interactive reveal. Import it from Server Components as you would another client-boundary component. Put the global Scrawlix stylesheet in an App Router global CSS entry such as `app/globals.css`/`app/layout.tsx` according to your application's CSS setup.
+`CensoredText` is a Client Component because interactive reveal uses React state. Scrawlix rule packs contain `RegExp` values (and coverage policies can be functions), so keep the selected rules on the client side instead of passing them as props from a Server Component.
+
+A small application-owned wrapper is the clean boundary:
+
+```tsx
+// app/ScrawlixText.tsx
+'use client';
+
+import { englishStrongProfanityRules } from '@scrawlix/en';
+import { CensoredText } from '@scrawlix/react';
+
+export function ScrawlixText({ text }: { text: string }) {
+  return <CensoredText text={text} rules={englishStrongProfanityRules} />;
+}
+```
+
+Then a Server Component passes only serializable application data:
+
+```tsx
+// app/page.tsx
+import { ScrawlixText } from './ScrawlixText';
+
+export default function Page() {
+  return <ScrawlixText text="what the fuck" />;
+}
+```
+
+Import the global Scrawlix stylesheet from the root layout (or your existing App Router global CSS entry):
+
+```tsx
+// app/layout.tsx
+import '@scrawlix/react/styles.css';
+```
+
+The repository's packed-package smoke suite installs a real Next.js App Router fixture and production-builds this client-wrapper path, so the documented boundary is release-gated.
 
 See the repository README for core, rehype, and arbitrary-DOM paths.

--- a/scripts/smoke-packages.mjs
+++ b/scripts/smoke-packages.mjs
@@ -57,11 +57,26 @@ function packPackage(packageDirectory) {
 
 const asFileDependency = path => `file:${path.replaceAll('\\', '/')}`;
 
-function smokeConsumer({
-  label,
-  reactMajor,
-  tarballs,
-}) {
+function addPackedDependencies(packageJson, tarballs, packageNames) {
+  for (const packageName of packageNames) {
+    const tarballKey = {
+      '@scrawlix/core': 'core',
+      '@scrawlix/en': 'english',
+      '@scrawlix/react': 'react',
+      '@scrawlix/rehype': 'rehype',
+      '@scrawlix/dom': 'dom',
+    }[packageName];
+    packageJson.dependencies[packageName] = asFileDependency(tarballs[tarballKey]);
+  }
+
+  packageJson.pnpm = {
+    overrides: {
+      '@scrawlix/core': asFileDependency(tarballs.core),
+    },
+  };
+}
+
+function smokeConsumer({ label, reactMajor, tarballs }) {
   const consumerDirectory = join(temporaryRoot, `consumer-${label}`);
   cpSync(resolve(root, 'fixtures/consumer'), consumerDirectory, {
     recursive: true,
@@ -74,26 +89,45 @@ function smokeConsumer({
     ...packageJson.dependencies,
     react: reactMajor,
     'react-dom': reactMajor,
-    '@scrawlix/core': asFileDependency(tarballs.core),
-    '@scrawlix/en': asFileDependency(tarballs.english),
-    '@scrawlix/react': asFileDependency(tarballs.react),
-    '@scrawlix/rehype': asFileDependency(tarballs.rehype),
-    '@scrawlix/dom': asFileDependency(tarballs.dom),
   };
   packageJson.devDependencies = {
     ...packageJson.devDependencies,
     '@types/react': reactMajor,
     '@types/react-dom': reactMajor,
   };
-  packageJson.pnpm = {
-    overrides: {
-      '@scrawlix/core': asFileDependency(tarballs.core),
-    },
-  };
+  addPackedDependencies(packageJson, tarballs, [
+    '@scrawlix/core',
+    '@scrawlix/en',
+    '@scrawlix/react',
+    '@scrawlix/rehype',
+    '@scrawlix/dom',
+  ]);
 
   writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
 
   console.log(`\nSmoke consumer: React ${reactMajor}`);
+  run(['install', '--no-frozen-lockfile'], consumerDirectory);
+  run(['typecheck'], consumerDirectory);
+  run(['build'], consumerDirectory);
+}
+
+function smokeNextConsumer(tarballs) {
+  const consumerDirectory = join(temporaryRoot, 'consumer-next');
+  cpSync(resolve(root, 'fixtures/next-consumer'), consumerDirectory, {
+    recursive: true,
+  });
+
+  const packageJsonPath = join(consumerDirectory, 'package.json');
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  addPackedDependencies(packageJson, tarballs, [
+    '@scrawlix/core',
+    '@scrawlix/en',
+    '@scrawlix/react',
+  ]);
+
+  writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+
+  console.log('\nSmoke consumer: Next.js App Router');
   run(['install', '--no-frozen-lockfile'], consumerDirectory);
   run(['typecheck'], consumerDirectory);
   run(['build'], consumerDirectory);
@@ -110,9 +144,12 @@ try {
 
   smokeConsumer({ label: 'react-18', reactMajor: '18', tarballs });
   smokeConsumer({ label: 'react-19', reactMajor: '19', tarballs });
+  smokeNextConsumer(tarballs);
 
   passed = true;
-  console.log('Scrawlix packed-package smoke tests passed for React 18 and 19.');
+  console.log(
+    'Scrawlix packed-package smoke tests passed for React 18, React 19, and Next.js App Router.'
+  );
 } finally {
   if (passed) {
     rmSync(temporaryRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Finishes the remaining cold-start item from #44 with a real packed-package Next.js consumer.

### App Router contract
- add a Next.js 16.3.3 App Router smoke fixture
- import `@scrawlix/react/styles.css` from the root layout
- keep `englishStrongProfanityRules` inside an application-owned `'use client'` wrapper
- import that wrapper from a Server Component and pass only serializable `text`
- typecheck and production-build the fixture from packed `@scrawlix/core`, `@scrawlix/en`, and `@scrawlix/react` tarballs

### Docs / agents
- correct the React README and root README to explain why rules should stay inside the client boundary (`RegExp` / function values are not Server-to-Client props)
- teach the same rule in `llms.txt`
- update the compatibility contract and changelog

This deliberately tests the documented production path rather than only checking that the package contains a `'use client'` directive.

Closes #44.