### PR TITLE
Rebind extension observation after body replacement

### DIFF
--- a/apps/extension/src/content.ts
+++ b/apps/extension/src/content.ts
@@ -183,4 +183,17 @@ function startWhenReady() {
   else window.addEventListener('DOMContentLoaded', () => void restart(), { once: true });
 }
 
+function watchBodyLifecycle() {
+  let knownBody = document.body;
+  const observer = new MutationObserver(() => {
+    const nextBody = document.body;
+    if (nextBody === knownBody) return;
+    knownBody = nextBody;
+    void restart();
+  });
+
+  observer.observe(document.documentElement, { childList: true });
+}
+
+watchBodyLifecycle();
 startWhenReady();

--- a/tests/browser/browser.spec.ts
+++ b/tests/browser/browser.spec.ts
@@ -76,7 +76,18 @@ test('built extension transforms initial and dynamic page text in Chromium', asy
       page.locator('#dynamic-copy [data-scrawlix-cover]')
     ).toHaveText('uc');
 
-    await page.locator('#native-link').click();
+    await page.getByRole('button', { name: 'replace body' }).click();
+    await expect(
+      page.locator('#body-replacement [data-scrawlix-dom-root]')
+    ).toHaveCount(1);
+    await expect(
+      page.locator('#body-replacement [data-scrawlix-cover]')
+    ).toHaveText('uc');
+    await expect(
+      page.locator('#replacement-link [data-scrawlix-dom-root]')
+    ).toHaveCount(1);
+
+    await page.locator('#replacement-link').click();
     await expect(page).toHaveURL('http://127.0.0.1:4174/clicked.html');
     await expect(page.locator('#clicked')).toHaveText('native link worked');
   } finally {

--- a/tests/browser/fixture-server.mjs
+++ b/tests/browser/fixture-server.mjs
@@ -14,6 +14,7 @@ const fixture = `<!doctype html>
       <button id="native-button" type="button">fuck</button>
       <a id="native-link" href="/clicked.html">fuck</a>
       <button id="add-dynamic" type="button">add dynamic</button>
+      <button id="replace-body" type="button">replace body</button>
       <section id="dynamic-root"></section>
     </main>
     <script>
@@ -22,6 +23,12 @@ const fixture = `<!doctype html>
         paragraph.id = 'dynamic-copy';
         paragraph.textContent = 'dynamic fuck arrived';
         document.querySelector('#dynamic-root').append(paragraph);
+      });
+
+      document.querySelector('#replace-body').addEventListener('click', () => {
+        const replacement = document.createElement('body');
+        replacement.innerHTML = '<main><p id="body-replacement">replacement fuck text</p><a id="replacement-link" href="/clicked.html">fuck</a></main>';
+        document.body.replaceWith(replacement);
       });
     </script>
   </body>


### PR DESCRIPTION
Superseded by #99, which replayed this body-identity watcher against the profile-aware extension and landed with the real Chromium body-replacement regression.

Refs #54 and #23.