### PR TITLE
Add temporary page reveal and quick custom-term actions

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -63,6 +63,16 @@ A small Manifest V3 service worker keeps one dynamic content-script registration
 
 Browser access and Scrawlix policy are separate. A site can be configured `on` while Chrome access is still missing; the popup reports that state directly instead of claiming censorship is already active.
 
+Opening the popup on a persistently granted site also ensures the current page runtime is present. This covers pages that were already open when access changed and keeps the displayed current-site state aligned with the actual page.
+
+## Quick interactions
+
+The popup includes **reveal page · 10s**. This sends a session-only message to the current content script and adds one temporary data attribute to the document root. CSS reveals all Scrawlix-owned covered spans while the existing DOM controller and wrappers stay in place. The timer clears the attribute after ten seconds; it writes no preference state and does not rebuild the page session.
+
+The manifest also declares a `temporary-reveal` command with `Alt+Shift+R` as its suggested shortcut. The popup reads the browser's actual assigned shortcut at runtime because users can remap extension commands and Chrome may leave a conflicting suggestion unassigned.
+
+A selection-only context-menu action, **Add “selection” to Scrawlix**, normalizes whitespace and appends the selected phrase to the existing local custom-term list. Context-menu additions are capped at 200 Unicode code points to avoid turning an accidental huge selection into an oversized matching rule. The existing custom-term normalization handles case-insensitive deduplication.
+
 ## Page lifecycle
 
 The content script:
@@ -72,7 +82,7 @@ The content script:
 3. observes `document.body`
 4. decorates only Scrawlix-generated roots with extension presentation metadata
 5. listens for sync/local preference changes and reconciles the minimum required work
-6. accepts extension messages to reconcile or restore the current page when browser access changes
+6. accepts extension messages to reconcile, restore, or temporarily reveal the current page
 
 Preference reconciliation is incremental:
 
@@ -105,6 +115,7 @@ The manifest uses:
 - `storage` — persist preferences
 - `activeTab` — let the popup inspect and act on the current page after the user opens it
 - `scripting` — register/inject the local content script for user-granted origins
+- `contextMenus` — add selected page text to the local custom-term list after the user chooses the Scrawlix menu action
 - optional HTTP/HTTPS host access — granted at runtime by the user
 
 The extension has no Scrawlix-operated network dependency and sends no browsing or page text to a Scrawlix server. Matching happens inside the page's content-script context using bundled Scrawlix packages.
@@ -123,4 +134,4 @@ See [`docs/extension-privacy.md`](../../docs/extension-privacy.md) for the curre
 - broad HTTP/HTTPS patterns remain optional instead of required host permissions
 - every directly referenced popup/background asset exists in `dist`
 
-Unit tests cover preference normalization/reconciliation, browser-access helpers, and the local-vs-sync storage split. The Chromium smoke build promotes optional host patterns only inside a temporary test copy of the manifest so CI can exercise the same service-worker registration and real content script without weakening the shipping manifest.
+Unit tests cover preference normalization/reconciliation, browser-access helpers, local-vs-sync storage, and selection normalization. The Chromium smoke build promotes optional host patterns only inside a temporary test copy of the manifest so CI can exercise the same service-worker registration, real content script, and temporary page reveal without weakening the shipping manifest.

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "Scrawlix",
   "description": "Programmable censorship for the web.",
   "version": "0.0.0",
-  "permissions": ["storage", "activeTab", "scripting"],
+  "permissions": ["storage", "activeTab", "scripting", "contextMenus"],
   "optional_host_permissions": ["http://*/*", "https://*/*"],
   "background": {
     "service_worker": "background.js"
@@ -11,5 +11,13 @@
   "action": {
     "default_popup": "popup.html",
     "default_title": "Scrawlix"
+  },
+  "commands": {
+    "temporary-reveal": {
+      "suggested_key": {
+        "default": "Alt+Shift+R"
+      },
+      "description": "Reveal Scrawlix-covered text on the current page for 10 seconds"
+    }
   }
 }

--- a/apps/extension/popup.html
+++ b/apps/extension/popup.html
@@ -35,6 +35,14 @@
         </label>
       </section>
 
+      <section class="peek-card" aria-label="Temporary reveal">
+        <button id="reveal-page" type="button">reveal page · 10s</button>
+        <p class="peek-meta">
+          <kbd id="reveal-shortcut"></kbd>
+          <span id="reveal-status" aria-live="polite"></span>
+        </p>
+      </section>
+
       <section class="access-card" aria-label="Browser access">
         <div>
           <p class="eyebrow">browser access</p>

--- a/apps/extension/src/access.ts
+++ b/apps/extension/src/access.ts
@@ -1,9 +1,12 @@
+import { TEMPORARY_REVEAL_MS } from './actions';
+
 export const CONTENT_SCRIPT_ID = 'scrawlix-page';
 export const ALL_HOST_PATTERNS = ['http://*/*', 'https://*/*'] as const;
 
 export type ScrawlixContentMessage =
   | { type: 'scrawlix-reconcile' }
-  | { type: 'scrawlix-disable' };
+  | { type: 'scrawlix-disable' }
+  | { type: 'scrawlix-reveal-for'; durationMs: number };
 
 export function originPatternForUrl(value: string): string | null {
   try {
@@ -101,4 +104,14 @@ export async function activateTab(tabId: number) {
 
 export async function deactivateTab(tabId: number) {
   await sendContentMessage(tabId, { type: 'scrawlix-disable' });
+}
+
+export async function revealTabFor(
+  tabId: number,
+  durationMs = TEMPORARY_REVEAL_MS
+) {
+  return sendContentMessage(tabId, {
+    type: 'scrawlix-reveal-for',
+    durationMs,
+  });
 }

--- a/apps/extension/src/actions.test.ts
+++ b/apps/extension/src/actions.test.ts
@@ -12,7 +12,7 @@ describe('extension interaction helpers', () => {
     expect(customTermFromSelection(42)).toBeNull();
   });
 
-  it('caps context-menu additions at 200 visible characters', () => {
+  it('caps context-menu additions at 200 Unicode code points', () => {
     expect(customTermFromSelection('x'.repeat(200))).toBe('x'.repeat(200));
     expect(customTermFromSelection('x'.repeat(201))).toBeNull();
   });

--- a/apps/extension/src/actions.test.ts
+++ b/apps/extension/src/actions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { customTermFromSelection } from './actions';
+
+describe('extension interaction helpers', () => {
+  it('turns a multiline selection into one compact custom phrase', () => {
+    expect(customTermFromSelection('  Project\n\tVelvet  ')).toBe('Project Velvet');
+  });
+
+  it('rejects empty and non-string selections', () => {
+    expect(customTermFromSelection(' \n\t ')).toBeNull();
+    expect(customTermFromSelection(undefined)).toBeNull();
+    expect(customTermFromSelection(42)).toBeNull();
+  });
+
+  it('caps context-menu additions at 200 visible characters', () => {
+    expect(customTermFromSelection('x'.repeat(200))).toBe('x'.repeat(200));
+    expect(customTermFromSelection('x'.repeat(201))).toBeNull();
+  });
+});

--- a/apps/extension/src/actions.ts
+++ b/apps/extension/src/actions.ts
@@ -2,13 +2,13 @@ export const ADD_SELECTION_MENU_ID = 'scrawlix-add-selection';
 export const TEMPORARY_REVEAL_COMMAND = 'temporary-reveal';
 export const TEMPORARY_REVEAL_MS = 10_000;
 
-const MAX_CONTEXT_TERM_GRAPHEMES = 200;
+const MAX_CONTEXT_TERM_CODE_POINTS = 200;
 
 export function customTermFromSelection(value: unknown): string | null {
   if (typeof value !== 'string') return null;
 
   const term = value.trim().replace(/\s+/gu, ' ');
   if (!term) return null;
-  if (Array.from(term).length > MAX_CONTEXT_TERM_GRAPHEMES) return null;
+  if (Array.from(term).length > MAX_CONTEXT_TERM_CODE_POINTS) return null;
   return term;
 }

--- a/apps/extension/src/actions.ts
+++ b/apps/extension/src/actions.ts
@@ -1,0 +1,14 @@
+export const ADD_SELECTION_MENU_ID = 'scrawlix-add-selection';
+export const TEMPORARY_REVEAL_COMMAND = 'temporary-reveal';
+export const TEMPORARY_REVEAL_MS = 10_000;
+
+const MAX_CONTEXT_TERM_GRAPHEMES = 200;
+
+export function customTermFromSelection(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+
+  const term = value.trim().replace(/\s+/gu, ' ');
+  if (!term) return null;
+  if (Array.from(term).length > MAX_CONTEXT_TERM_GRAPHEMES) return null;
+  return term;
+}

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -1,12 +1,33 @@
-import { syncContentScriptRegistration } from './access';
-import { migrateSiteOverridesToLocal } from './storage';
+import { revealTabFor, syncContentScriptRegistration } from './access';
+import {
+  ADD_SELECTION_MENU_ID,
+  TEMPORARY_REVEAL_COMMAND,
+  customTermFromSelection,
+} from './actions';
+import {
+  loadCustomWords,
+  migrateSiteOverridesToLocal,
+  saveCustomWords,
+} from './storage';
 
 async function refreshBrowserState() {
   await migrateSiteOverridesToLocal();
   await syncContentScriptRegistration();
 }
 
+function installContextMenu() {
+  chrome.contextMenus.removeAll(() => {
+    chrome.contextMenus.create({
+      id: ADD_SELECTION_MENU_ID,
+      title: 'Add “%s” to Scrawlix',
+      contexts: ['selection'],
+      documentUrlPatterns: ['http://*/*', 'https://*/*'],
+    });
+  });
+}
+
 chrome.runtime.onInstalled.addListener(() => {
+  installContextMenu();
   void refreshBrowserState();
 });
 
@@ -20,6 +41,22 @@ chrome.permissions.onAdded.addListener(() => {
 
 chrome.permissions.onRemoved.addListener(() => {
   void syncContentScriptRegistration();
+});
+
+chrome.commands.onCommand.addListener((command, tab) => {
+  if (command !== TEMPORARY_REVEAL_COMMAND || tab?.id === undefined) return;
+  void revealTabFor(tab.id);
+});
+
+chrome.contextMenus.onClicked.addListener(info => {
+  if (info.menuItemId !== ADD_SELECTION_MENU_ID) return;
+  const term = customTermFromSelection(info.selectionText);
+  if (!term) return;
+
+  void (async () => {
+    const words = await loadCustomWords();
+    await saveCustomWords([...words, term]);
+  })();
 });
 
 void refreshBrowserState();

--- a/apps/extension/src/content.css
+++ b/apps/extension/src/content.css
@@ -65,7 +65,8 @@
 
 [data-scrawlix-dom-root][data-scrawlix-reveal='hover']:hover [data-scrawlix-cover],
 [data-scrawlix-dom-root][data-scrawlix-reveal='focus']:focus [data-scrawlix-cover],
-[data-scrawlix-dom-root][data-scrawlix-reveal='click'][data-scrawlix-revealed='true'] [data-scrawlix-cover] {
+[data-scrawlix-dom-root][data-scrawlix-reveal='click'][data-scrawlix-revealed='true'] [data-scrawlix-cover],
+html[data-scrawlix-page-revealed='true'] [data-scrawlix-dom-root] [data-scrawlix-cover] {
   -webkit-text-fill-color: currentColor;
   background: none;
   filter: none;
@@ -76,7 +77,8 @@
 
 [data-scrawlix-dom-root][data-scrawlix-reveal='hover']:hover [data-scrawlix-cover][data-scrawlix-mask]::after,
 [data-scrawlix-dom-root][data-scrawlix-reveal='focus']:focus [data-scrawlix-cover][data-scrawlix-mask]::after,
-[data-scrawlix-dom-root][data-scrawlix-reveal='click'][data-scrawlix-revealed='true'] [data-scrawlix-cover][data-scrawlix-mask]::after {
+[data-scrawlix-dom-root][data-scrawlix-reveal='click'][data-scrawlix-revealed='true'] [data-scrawlix-cover][data-scrawlix-mask]::after,
+html[data-scrawlix-page-revealed='true'] [data-scrawlix-dom-root] [data-scrawlix-cover][data-scrawlix-mask]::after {
   opacity: 0;
 }
 

--- a/apps/extension/src/content.ts
+++ b/apps/extension/src/content.ts
@@ -165,6 +165,11 @@ async function reconcile() {
   }
 }
 
+async function revealWhenReady(durationMs: number) {
+  if (observation === null) await reconcile();
+  if (observation !== null) revealPageFor(durationMs);
+}
+
 function clickRootFromEvent(event: Event) {
   if (pageIsTemporarilyRevealed()) return null;
 
@@ -220,7 +225,7 @@ chrome.runtime.onMessage.addListener((message: ScrawlixContentMessage) => {
   }
 
   if (message?.type === 'scrawlix-reveal-for') {
-    if (observation !== null) revealPageFor(message.durationMs);
+    void revealWhenReady(message.durationMs);
   }
 });
 

--- a/apps/extension/src/content.ts
+++ b/apps/extension/src/content.ts
@@ -16,11 +16,14 @@ import { loadExtensionState } from './storage';
 
 const INTERACTIVE_ANCESTOR =
   'a,button,input,select,textarea,summary,[role="button"],[role="link"]';
+const MIN_REVEAL_MS = 250;
+const MAX_REVEAL_MS = 60_000;
 
 let observation: DomObservation | null = null;
 let presentationObserver: MutationObserver | null = null;
 let activeState: ExtensionStateSnapshot | null = null;
 let restartGeneration = 0;
+let pageRevealTimer: number | null = null;
 
 function customRule(customWords: readonly string[]): CensorRule[] {
   if (customWords.length === 0) return [];
@@ -29,6 +32,28 @@ function customRule(customWords: readonly string[]): CensorRule[] {
 
 function canOwnInteraction(root: HTMLElement) {
   return root.closest(INTERACTIVE_ANCESTOR) === null;
+}
+
+function pageIsTemporarilyRevealed() {
+  return document.documentElement.dataset.scrawlixPageRevealed === 'true';
+}
+
+function clearPageReveal() {
+  if (pageRevealTimer !== null) {
+    window.clearTimeout(pageRevealTimer);
+    pageRevealTimer = null;
+  }
+  delete document.documentElement.dataset.scrawlixPageRevealed;
+}
+
+function revealPageFor(durationMs: number) {
+  const duration = Number.isFinite(durationMs)
+    ? Math.min(MAX_REVEAL_MS, Math.max(MIN_REVEAL_MS, durationMs))
+    : MIN_REVEAL_MS;
+
+  if (pageRevealTimer !== null) window.clearTimeout(pageRevealTimer);
+  document.documentElement.dataset.scrawlixPageRevealed = 'true';
+  pageRevealTimer = window.setTimeout(clearPageReveal, duration);
 }
 
 function decorateGeneratedRoot(root: HTMLElement, settings: SyncSettings) {
@@ -118,6 +143,7 @@ async function reconcile() {
 
   switch (action) {
     case 'stop':
+      clearPageReveal();
       stopCurrentSession();
       return;
 
@@ -140,6 +166,8 @@ async function reconcile() {
 }
 
 function clickRootFromEvent(event: Event) {
+  if (pageIsTemporarilyRevealed()) return null;
+
   const target = event.target;
   if (!(target instanceof Element)) return null;
   const root = target.closest<HTMLElement>(
@@ -181,12 +209,18 @@ chrome.runtime.onMessage.addListener((message: ScrawlixContentMessage) => {
   if (message?.type === 'scrawlix-disable') {
     restartGeneration += 1;
     activeState = null;
+    clearPageReveal();
     stopCurrentSession();
     return;
   }
 
   if (message?.type === 'scrawlix-reconcile') {
     void reconcile();
+    return;
+  }
+
+  if (message?.type === 'scrawlix-reveal-for') {
+    if (observation !== null) revealPageFor(message.durationMs);
   }
 });
 

--- a/apps/extension/src/popup.css
+++ b/apps/extension/src/popup.css
@@ -31,6 +31,7 @@ textarea {
 
 .masthead,
 .site-card,
+.peek-card,
 .access-card,
 .settings-grid,
 .custom-words,
@@ -66,12 +67,14 @@ footer {
 .eyebrow,
 .status-line,
 .access-status,
+.peek-meta,
 .hint,
 footer,
 .switch-row span,
 .settings-grid label > span,
 .save-status,
-.access-actions button {
+.access-actions button,
+.peek-card button {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
@@ -158,6 +161,59 @@ footer,
 
 .status-line[data-enabled='false']::before {
   content: '○ ';
+}
+
+.peek-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 0;
+}
+
+.peek-card button {
+  min-height: 34px;
+  padding: 7px 10px;
+  color: inherit;
+  background: #171510;
+  border: 1px solid #171510;
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.045em;
+  cursor: pointer;
+}
+
+.peek-card button:hover,
+.peek-card button:focus-visible {
+  box-shadow: inset 0 0 0 1px #f2eddf;
+}
+
+.peek-card button:focus-visible {
+  outline: 1px solid #171510;
+  outline-offset: 2px;
+}
+
+.peek-card button:disabled {
+  cursor: default;
+  opacity: 0.38;
+}
+
+.peek-meta {
+  display: grid;
+  justify-items: end;
+  gap: 4px;
+  margin: 0;
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.62;
+}
+
+.peek-meta kbd {
+  padding: 2px 4px;
+  border: 1px solid rgba(23, 21, 16, 0.42);
+  font: inherit;
 }
 
 .access-card {

--- a/apps/extension/src/popup.css
+++ b/apps/extension/src/popup.css
@@ -174,7 +174,7 @@ footer,
 .peek-card button {
   min-height: 34px;
   padding: 7px 10px;
-  color: inherit;
+  color: #f2eddf;
   background: #171510;
   border: 1px solid #171510;
   font-size: 9px;

--- a/apps/extension/src/popup.ts
+++ b/apps/extension/src/popup.ts
@@ -8,7 +8,9 @@ import {
   originPatternForUrl,
   removeHostAccess,
   requestHostAccess,
+  revealTabFor,
 } from './access';
+import { TEMPORARY_REVEAL_COMMAND } from './actions';
 import {
   effectiveEnabled,
   normalizeCustomWords,
@@ -46,6 +48,9 @@ const siteModeSelect = required<HTMLSelectElement>('site-mode');
 const appearanceSelect = required<HTMLSelectElement>('appearance');
 const coverageSelect = required<HTMLSelectElement>('coverage');
 const revealSelect = required<HTMLSelectElement>('reveal');
+const revealPageButton = required<HTMLButtonElement>('reveal-page');
+const revealShortcut = required<HTMLElement>('reveal-shortcut');
+const revealStatus = required<HTMLSpanElement>('reveal-status');
 const customWordsInput = required<HTMLTextAreaElement>('custom-words');
 const siteHeading = required<HTMLHeadingElement>('site-heading');
 const effectiveStatus = required<HTMLParagraphElement>('effective-status');
@@ -130,6 +135,11 @@ function renderAccess() {
     : 'allow all websites';
 }
 
+function renderRevealAction() {
+  const enabledHere = page ? effectiveEnabled(settings, page.hostname) : false;
+  revealPageButton.disabled = !page || !persistentAccess || !enabledHere;
+}
+
 function renderSettings() {
   activeInput.checked = !settings.paused;
   defaultEnabledSelect.value = settings.enabled ? 'on' : 'off';
@@ -138,6 +148,7 @@ function renderSettings() {
   revealSelect.value = settings.reveal;
   renderEffectiveStatus();
   renderAccess();
+  renderRevealAction();
 }
 
 async function refreshAccess() {
@@ -148,6 +159,18 @@ async function refreshAccess() {
   allHostsAccess = all;
   persistentAccess = current;
   renderSettings();
+}
+
+async function renderAssignedShortcut() {
+  const commands = await chrome.commands.getAll();
+  const command = commands.find(item => item.name === TEMPORARY_REVEAL_COMMAND);
+  const shortcut = command?.shortcut?.trim() ?? '';
+  revealShortcut.textContent = shortcut;
+  revealShortcut.hidden = shortcut.length === 0;
+}
+
+async function ensureCurrentPageRuntime() {
+  if (page && persistentAccess) await activateTab(page.tabId);
 }
 
 async function persistSettings(next: SyncSettings) {
@@ -173,6 +196,7 @@ async function persistSettings(next: SyncSettings) {
 
   settingsSaveQueue = queued.catch(() => undefined);
   await queued.catch(() => undefined);
+  await ensureCurrentPageRuntime();
 }
 
 function wordsFromTextarea() {
@@ -189,6 +213,7 @@ async function persistWords() {
   try {
     await saveCustomWords(wordsFromTextarea());
     saveStatus.textContent = 'saved';
+    await ensureCurrentPageRuntime();
   } catch {
     saveStatus.textContent = 'save failed';
   }
@@ -234,6 +259,24 @@ revealSelect.addEventListener('change', () => {
     ...settings,
     reveal: revealSelect.value as ExtensionReveal,
   });
+});
+
+revealPageButton.addEventListener('click', () => {
+  if (!page || revealPageButton.disabled) return;
+
+  void (async () => {
+    revealStatus.textContent = 'revealing…';
+    try {
+      let delivered = await revealTabFor(page.tabId);
+      if (!delivered) {
+        await activateTab(page.tabId);
+        delivered = await revealTabFor(page.tabId);
+      }
+      revealStatus.textContent = delivered ? 'visible for 10s' : 'page unavailable';
+    } catch {
+      revealStatus.textContent = 'reveal failed';
+    }
+  })();
 });
 
 siteAccessButton.addEventListener('click', () => {
@@ -287,7 +330,8 @@ async function initialize() {
   settings = state.settings;
   page = activePage;
   customWordsInput.value = state.customWords.join('\n');
-  await refreshAccess();
+  await Promise.all([refreshAccess(), renderAssignedShortcut()]);
+  await ensureCurrentPageRuntime();
 }
 
 void initialize();

--- a/docs/extension-privacy.md
+++ b/docs/extension-privacy.md
@@ -20,7 +20,7 @@ Explicit per-host `on` / `off` preferences are stored in `chrome.storage.local`.
 
 ### Custom words and phrases
 
-User-entered custom terms are stored in `chrome.storage.local` and are used only by the local matching engine.
+User-entered custom terms are stored in `chrome.storage.local` and are used only by the local matching engine. When the user explicitly chooses Scrawlix's selection context-menu action, the selected text is normalized into a custom term and stored through the same local custom-term list.
 
 ### General preferences
 
@@ -30,13 +30,17 @@ The master pause/default behavior, censor style, coverage, and reveal preference
 
 Scrawlix declares HTTP and HTTPS access as optional host permissions. Users can grant access for the current origin or for all HTTP/HTTPS websites, and can remove that access again. Chrome stores and enforces those grants. Scrawlix dynamically registers its local content script only for currently granted HTTP/HTTPS patterns.
 
+### Temporary page reveal
+
+The popup and keyboard command can reveal Scrawlix-covered text for ten seconds. This state exists only in the current page as a temporary data attribute and timer. It is not written to extension storage.
+
 ## Sharing and transmission
 
-Scrawlix extension code does not transmit webpage text, browsing activity, custom terms, or hostname preferences to Scrawlix or third parties. General preferences may be handled by Chrome Sync when the user has browser sync enabled.
+Scrawlix extension code does not transmit webpage text, browsing activity, custom terms, selected context-menu text, or hostname preferences to Scrawlix or third parties. General preferences may be handled by Chrome Sync when the user has browser sync enabled.
 
 ## User controls
 
-Users can pause Scrawlix, disable it by default, override individual hostnames, remove browser site access, edit or delete custom terms, and clear extension storage through the browser's extension controls.
+Users can pause Scrawlix, disable it by default, override individual hostnames, remove browser site access, temporarily reveal covered text, edit or delete custom terms, and clear extension storage through the browser's extension controls.
 
 ## Chrome Web Store Limited Use
 

--- a/tests/browser/browser.spec.ts
+++ b/tests/browser/browser.spec.ts
@@ -46,7 +46,7 @@ test('demo controls drive real rendered coverage and reveal state', async ({ pag
   expect(overflow).toBeLessThanOrEqual(0);
 });
 
-test('built extension registers granted hosts and transforms page text in Chromium', async ({}, testInfo) => {
+test('built extension registers granted hosts and handles page interaction in Chromium', async ({}, testInfo) => {
   const testExtensionPath = extensionWithPregrantedHosts(
     testInfo.outputPath('extension-under-test')
   );
@@ -78,9 +78,8 @@ test('built extension registers granted hosts and transforms page text in Chromi
     const page = context.pages()[0] ?? (await context.newPage());
     await page.goto('http://127.0.0.1:4174/fixture.html');
 
-    await expect(
-      page.locator('#initial [data-scrawlix-dom-root]')
-    ).toHaveCount(1);
+    const initialRoot = page.locator('#initial [data-scrawlix-dom-root]');
+    await expect(initialRoot).toHaveCount(1);
     await expect(
       page.locator('#initial [data-scrawlix-cover]')
     ).toHaveText('uc');
@@ -103,6 +102,27 @@ test('built extension registers granted hosts and transforms page text in Chromi
     await expect(
       page.locator('#dynamic-copy [data-scrawlix-cover]')
     ).toHaveText('uc');
+
+    // Temporary reveal changes presentation only. Owned censor DOM stays in place.
+    await worker.evaluate(async () => {
+      const tabs = await chrome.tabs.query({ url: 'http://127.0.0.1:4174/*' });
+      const tabId = tabs.find(tab => tab.url?.endsWith('/fixture.html'))?.id;
+      if (tabId === undefined) throw new Error('Fixture tab was unavailable.');
+      await chrome.tabs.sendMessage(tabId, {
+        type: 'scrawlix-reveal-for',
+        durationMs: 500,
+      });
+    });
+
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-scrawlix-page-revealed',
+      'true'
+    );
+    await expect(initialRoot).toHaveCount(1);
+    await expect
+      .poll(() => page.locator('html').getAttribute('data-scrawlix-page-revealed'))
+      .toBeNull();
+    await expect(initialRoot).toHaveCount(1);
 
     await page.locator('#native-link').click();
     await expect(page).toHaveURL('http://127.0.0.1:4174/clicked.html');


### PR DESCRIPTION
## What changed

- add a page-wide **reveal page · 10s** action to the popup
- keep temporary reveal session-only: one document data attribute + timer, with no storage write and no DOM-controller teardown
- preserve underlying click-reveal state while the page-wide reveal is active
- declare a `temporary-reveal` extension command with `Alt+Shift+R` as the suggested shortcut
- show the browser's actual assigned shortcut in the popup so remapping/collisions are represented truthfully
- add a selection-only context-menu action to save selected text as a local custom term
- normalize context-menu selections by trimming/collapsing whitespace and cap additions at 200 Unicode code points
- add `contextMenus` permission for that explicit user action
- update extension/privacy docs for temporary reveal and selected-text handling
- extend real Chromium smoke to prove temporary reveal expires while Scrawlix-owned DOM stays in place

## Product behavior

Temporary reveal is presentation-only. It keeps censor wrappers/observation live, avoids a page rescan, and suppresses click-toggle mutation while the whole page is temporarily visible.

The context-menu action writes through the existing `chrome.storage.local` custom-term path, so the content script receives the normal storage change and reconciles the matcher through the existing controller lifecycle.

## Research

Chrome's current Commands API supports standard extension commands with a suggested key and gives the active `Tab` to `commands.onCommand`; users can remap commands and a conflicting suggested shortcut may remain unassigned.

Chrome's Context Menus API exposes `selectionText`, supports `%s` in selection-menu titles, and is designed for service-worker `contextMenus.onClicked` handlers.

## Validation

CI is green on the final head:

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Chromium demo smoke
- Chromium extension smoke, including temporary reveal activation/expiry with owned DOM preserved
- `pnpm smoke:packages`

## Stack

This PR is based on the latest `copper/optional-host-access` / #74 head and includes its current-page runtime refinement as an explicit merge parent.

Progresses #51 and #23.