### PR TITLE
Prototype reversible redaction poetry in the demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added a Vercel-ready static deployment configuration.
 - Added a Manifest V3 Chromium extension under `apps/extension` with global/site preferences, five appearances, coverage/reveal controls, and local custom terms.
 - Added local extension lenses and named profiles, with per-profile treatment, legacy custom-term migration, semantic-session reuse, and atomic live-page profile switching.
+- Added a demo-local inverse-coverage / redaction-poetry experiment that preserves exact source text while selected terms survive the ink.
 
 ### Developer experience
 

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -1,4 +1,9 @@
-import { type CoveragePreset, type CoverageSelector } from '@scrawlix/core';
+import {
+  censorRuleFromTerms,
+  createScrawlix,
+  type CoveragePreset,
+  type CoverageSelector,
+} from '@scrawlix/core';
 import {
   englishStrongProfanityRules,
   englishVowelCoverage,
@@ -40,8 +45,116 @@ const specimens = [
   'Well, shit. That actually works.',
 ] as const;
 
+const defaultPoetryText =
+  'The quarterly committee reviewed ordinary numbers until desire, against all accounting procedure, fell through the margins and into heaven shortly before Tuesday. Everyone signed the report and went home.';
+
+const defaultPoetryTerms = ['desire', 'fell', 'through', 'heaven', 'Tuesday'];
+
+type PoetrySegment = {
+  text: string;
+  visible: boolean;
+};
+
 function selectorForCoverage(coverage: CoverageChoice): CoverageSelector {
   return coverage === 'vowel' ? englishVowelCoverage : coverage;
+}
+
+function normalizeTerms(value: string) {
+  const seen = new Set<string>();
+  const terms: string[] = [];
+
+  for (const line of value.split(/\n|,/)) {
+    const term = line.trim();
+    if (!term) continue;
+    const key = term.toLocaleLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    terms.push(term);
+  }
+
+  return terms;
+}
+
+function inverseSegments(text: string, terms: readonly string[]): PoetrySegment[] {
+  if (!text) return [];
+  if (terms.length === 0) return [{ text, visible: false }];
+
+  const rule = censorRuleFromTerms('redaction-poetry-visible', terms);
+  const matches = createScrawlix({ rules: [rule], coverage: 'full' }).find(text);
+  const ranges: Array<{ start: number; end: number }> = [];
+
+  for (const match of matches) {
+    const previous = ranges.at(-1);
+    if (previous && match.start <= previous.end) {
+      previous.end = Math.max(previous.end, match.end);
+    } else {
+      ranges.push({ start: match.start, end: match.end });
+    }
+  }
+
+  if (ranges.length === 0) return [{ text, visible: false }];
+
+  const segments: PoetrySegment[] = [];
+  let cursor = 0;
+
+  for (const range of ranges) {
+    if (range.start > cursor) {
+      segments.push({ text: text.slice(cursor, range.start), visible: false });
+    }
+    segments.push({ text: text.slice(range.start, range.end), visible: true });
+    cursor = range.end;
+  }
+
+  if (cursor < text.length) {
+    segments.push({ text: text.slice(cursor), visible: false });
+  }
+
+  return segments;
+}
+
+function RedactionPoem({
+  text,
+  terms,
+}: {
+  text: string;
+  terms: readonly string[];
+}) {
+  const [revealed, setRevealed] = useState(false);
+  const segments = useMemo(() => inverseSegments(text, terms), [text, terms]);
+
+  return (
+    <article
+      className="redaction-sheet"
+      data-redaction-poetry
+      data-redaction-revealed={revealed ? 'true' : 'false'}
+    >
+      <header className="redaction-header">
+        <span>CASE SC-034</span>
+        <strong>SELECTIVE DISCLOSURE</strong>
+        <span>{revealed ? 'SOURCE RESTORED' : 'DECLASSIFIED IN PART'}</span>
+      </header>
+
+      <span data-redaction-a11y>{text}</span>
+      <p aria-hidden="true" className="redaction-copy" data-redaction-visual>
+        {segments.map((segment, index) => (
+          <span
+            data-redaction-covered={segment.visible ? undefined : ''}
+            data-redaction-visible={segment.visible ? '' : undefined}
+            key={`${index}-${segment.text}`}
+          >
+            {segment.text}
+          </span>
+        ))}
+      </p>
+
+      <div className="redaction-footer">
+        <span>{terms.length} words spared</span>
+        <button onClick={() => setRevealed(value => !value)} type="button">
+          {revealed ? 'apply redaction' : 'restore source'}
+        </button>
+      </div>
+    </article>
+  );
 }
 
 function SegmentControl<T extends string>({
@@ -79,7 +192,15 @@ export function App() {
   const [coverage, setCoverage] = useState<CoverageChoice>('middle');
   const [reveal, setReveal] = useState<ScrawlixReveal>('hover');
   const [text, setText] = useState(defaultText);
+  const [poetryText, setPoetryText] = useState(defaultPoetryText);
+  const [poetryTermsText, setPoetryTermsText] = useState(
+    defaultPoetryTerms.join('\n')
+  );
   const coverageSelector = selectorForCoverage(coverage);
+  const poetryTerms = useMemo(
+    () => normalizeTerms(poetryTermsText),
+    [poetryTermsText]
+  );
 
   const code = useMemo(() => {
     const coverageLine =
@@ -238,9 +359,49 @@ export function App() {
         </p>
       </section>
 
+      <section className="poetry-section" aria-labelledby="poetry-title">
+        <div className="section-heading">
+          <p className="eyebrow">04 / misuse it</p>
+          <h2 id="poetry-title">Redact everything. Keep the accidental poem.</h2>
+          <p>
+            Pick the words allowed to survive. Scrawlix finds them; this demo covers
+            the complement and turns bureaucratic prose into blackout poetry.
+          </p>
+        </div>
+
+        <div className="poetry-lab">
+          <RedactionPoem text={poetryText} terms={poetryTerms} />
+
+          <div className="poetry-controls">
+            <label>
+              <span>source document</span>
+              <textarea
+                onChange={event => setPoetryText(event.target.value)}
+                rows={7}
+                spellCheck="true"
+                value={poetryText}
+              />
+            </label>
+            <label>
+              <span>words to spare</span>
+              <textarea
+                onChange={event => setPoetryTermsText(event.target.value)}
+                rows={6}
+                spellCheck="false"
+                value={poetryTermsText}
+              />
+            </label>
+            <p>
+              One word or phrase per line. The black ink is reversible presentation;
+              the exact source remains underneath for the restore button.
+            </p>
+          </div>
+        </div>
+      </section>
+
       <section className="code-section" aria-labelledby="code-title">
         <div>
-          <p className="eyebrow">04 / use it</p>
+          <p className="eyebrow">05 / use it</p>
           <h2 id="code-title">Pick the language. Pick the damage.</h2>
           <p>
             Matching rules live in explicit language or custom packs. The core stays

--- a/apps/demo/src/main.tsx
+++ b/apps/demo/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import '@scrawlix/react/styles.css';
 import { App } from './App';
 import './styles.css';
+import './poetry.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/apps/demo/src/poetry.css
+++ b/apps/demo/src/poetry.css
@@ -1,0 +1,222 @@
+.poetry-section {
+  padding: 86px 0;
+  border-bottom: 1px solid #171512;
+}
+
+.poetry-lab {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.55fr);
+  gap: 28px;
+  align-items: stretch;
+}
+
+.redaction-sheet {
+  position: relative;
+  min-height: 500px;
+  display: flex;
+  flex-direction: column;
+  border: 2px solid #171512;
+  background:
+    linear-gradient(rgba(23, 21, 18, 0.025) 1px, transparent 1px),
+    #e9e1d2;
+  background-size: 100% 24px;
+  padding: 22px;
+  box-shadow: 10px 10px 0 #171512;
+  transform: rotate(-0.22deg);
+}
+
+.redaction-header,
+.redaction-footer,
+.poetry-controls > label > span {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.redaction-header {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 18px;
+  padding-bottom: 13px;
+  border-bottom: 1px solid #171512;
+}
+
+.redaction-header strong {
+  font-size: 10px;
+  text-align: center;
+}
+
+.redaction-header span:last-child {
+  justify-self: end;
+  text-align: right;
+}
+
+.redaction-copy {
+  flex: 1;
+  margin: 0;
+  padding: clamp(44px, 7vw, 92px) clamp(8px, 3vw, 36px);
+  align-content: center;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(31px, 4.2vw, 62px);
+  line-height: 1.16;
+  letter-spacing: -0.035em;
+}
+
+[data-redaction-covered] {
+  color: transparent;
+  background:
+    repeating-linear-gradient(
+      -2deg,
+      #171512 0 0.11em,
+      #29251f 0.11em 0.18em,
+      #171512 0.18em 0.28em
+    )
+    center / 100% 0.78em no-repeat;
+  border-radius: 0.025em;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  text-shadow: none;
+  user-select: none;
+  transition: color 120ms ease, background 120ms ease;
+}
+
+[data-redaction-visible] {
+  font-style: italic;
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-thickness: 0.045em;
+  text-underline-offset: 0.12em;
+}
+
+.redaction-sheet[data-redaction-revealed='true'] [data-redaction-covered] {
+  color: inherit;
+  background: none;
+  user-select: text;
+}
+
+[data-redaction-a11y] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.redaction-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding-top: 13px;
+  border-top: 1px solid #171512;
+}
+
+.redaction-footer button {
+  border: 1px solid #171512;
+  border-radius: 0;
+  background: #171512;
+  color: #f2eee5;
+  padding: 9px 12px;
+  cursor: pointer;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+}
+
+.redaction-footer button:hover,
+.redaction-footer button:focus-visible {
+  background: transparent;
+  color: #171512;
+}
+
+.poetry-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 20px;
+  border: 1px solid #171512;
+  background: rgba(251, 248, 240, 0.7);
+}
+
+.poetry-controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.poetry-controls textarea {
+  width: 100%;
+  resize: vertical;
+  border: 1px solid #171512;
+  border-radius: 0;
+  background: #fbf8f0;
+  color: #171512;
+  padding: 12px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+.poetry-controls label:last-of-type textarea {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+}
+
+.poetry-controls p {
+  margin: auto 0 0;
+  padding-top: 16px;
+  border-top: 1px solid #171512;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-redaction-covered] {
+    transition: none;
+  }
+}
+
+@media (max-width: 1000px) {
+  .poetry-lab {
+    grid-template-columns: 1fr;
+  }
+
+  .redaction-sheet {
+    min-height: 420px;
+  }
+}
+
+@media (max-width: 620px) {
+  .redaction-sheet {
+    min-height: 360px;
+    padding: 14px;
+    box-shadow: 5px 5px 0 #171512;
+    transform: none;
+  }
+
+  .redaction-header {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .redaction-header strong {
+    display: none;
+  }
+
+  .redaction-copy {
+    padding: 38px 4px;
+    font-size: 31px;
+  }
+
+  .redaction-footer {
+    align-items: flex-start;
+  }
+}

--- a/tests/browser/poetry.spec.ts
+++ b/tests/browser/poetry.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+
+test('demo controls include reversible redaction poetry', async ({ page }) => {
+  await page.goto('http://127.0.0.1:4173');
+
+  const poem = page.locator('[data-redaction-poetry]');
+  const visible = poem.locator('[data-redaction-visible]');
+  const covered = poem.locator('[data-redaction-covered]');
+  const visual = poem.locator('[data-redaction-visual]');
+  const source = poem.locator('[data-redaction-a11y]');
+
+  await expect(poem).toBeVisible();
+  await expect(poem).toHaveAttribute('data-redaction-revealed', 'false');
+  await expect(visible).toHaveCount(5);
+  expect(await visible.allTextContents()).toEqual([
+    'desire',
+    'fell',
+    'through',
+    'heaven',
+    'Tuesday',
+  ]);
+  await expect.poll(() => covered.count()).toBeGreaterThan(0);
+
+  const originalSource = await source.textContent();
+  expect(originalSource).toBeTruthy();
+  await expect(visual).toHaveText(originalSource!);
+
+  const coveredStyle = await covered.first().evaluate(element => {
+    const style = getComputedStyle(element);
+    return { color: style.color, backgroundImage: style.backgroundImage };
+  });
+  expect(coveredStyle.color).toBe('rgba(0, 0, 0, 0)');
+  expect(coveredStyle.backgroundImage).not.toBe('none');
+
+  await poem.getByRole('button', { name: 'restore source' }).click();
+  await expect(poem).toHaveAttribute('data-redaction-revealed', 'true');
+  await expect(visual).toHaveText(originalSource!);
+
+  const restoredStyle = await covered.first().evaluate(element => {
+    const style = getComputedStyle(element);
+    return { color: style.color, backgroundImage: style.backgroundImage };
+  });
+  expect(restoredStyle.color).not.toBe('rgba(0, 0, 0, 0)');
+  expect(restoredStyle.backgroundImage).toBe('none');
+
+  await page.locator('.poetry-controls textarea').nth(1).fill('desire\nTuesday');
+  await expect(visible).toHaveCount(2);
+  expect(await visible.allTextContents()).toEqual(['desire', 'Tuesday']);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - window.innerWidth
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
+});


### PR DESCRIPTION
## What

Adds a deliberately demo-local inverse-coverage experiment:

- editable source document
- editable list of words/phrases to spare
- existing Scrawlix matching finds the selected terms
- the demo computes the complement locally and covers everything else
- covered source substrings remain in-flow for layout stability and exact restoration
- one accessible exact source copy mirrors the existing Scrawlix presentation philosophy
- **restore source / apply redaction** toggle
- classified-document visual treatment in a separate demo stylesheet
- responsive 390px layout

The default specimen turns bureaucratic prose into:

> desire / fell / through / heaven / Tuesday

## Product intent

This is a pressure test for censorship as an artistic medium. It intentionally avoids adding inverse coverage to `@scrawlix/core` until the interaction proves useful outside the demo.

## Validation

A new Chromium demo smoke verifies:

- the five selected terms survive in source order
- covered spans still reconstruct the exact source text
- covered text is visually inked via CSS
- restore makes that text visible again
- editing the spared-term list recomputes the poem
- narrow viewport has no horizontal overflow

Closes #34