### PR TITLE
Prototype progress-aware spoiler packs in the demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added a Manifest V3 Chromium extension under `apps/extension` with global/site preferences, five appearances, coverage/reveal controls, and local custom terms.
 - Added local extension lenses and named profiles, with per-profile treatment, legacy custom-term migration, semantic-session reuse, and atomic live-page profile switching.
 - Added a demo-local inverse-coverage / redaction-poetry experiment that preserves exact source text while selected terms survive the ink.
+- Added a fictional progress-aware spoiler pack demo where viewing progress activates only future-episode rules.
 
 ### Developer experience
 

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -14,6 +14,7 @@ import {
   type ScrawlixReveal,
 } from '@scrawlix/react';
 import { useMemo, useState } from 'react';
+import { SpoilerLab } from './SpoilerLab';
 
 const appearances: readonly ScrawlixAppearance[] = [
   'scrawl',
@@ -399,9 +400,11 @@ export function App() {
         </div>
       </section>
 
+      <SpoilerLab />
+
       <section className="code-section" aria-labelledby="code-title">
         <div>
-          <p className="eyebrow">05 / use it</p>
+          <p className="eyebrow">06 / use it</p>
           <h2 id="code-title">Pick the language. Pick the damage.</h2>
           <p>
             Matching rules live in explicit language or custom packs. The core stays

--- a/apps/demo/src/SpoilerLab.tsx
+++ b/apps/demo/src/SpoilerLab.tsx
@@ -1,0 +1,112 @@
+import { censorRuleFromTerms } from '@scrawlix/core';
+import { CensoredText } from '@scrawlix/react';
+import { useMemo, useState } from 'react';
+
+const episodeRules = [
+  { episode: 2, terms: ['the Glass Orchard'] },
+  { episode: 3, terms: ["the Ferryman is Mara's brother"] },
+  { episode: 4, terms: ['the red key opens the observatory'] },
+  { episode: 5, terms: ['Mara burns the north archive'] },
+] as const;
+
+const sampleRecap =
+  "The recap says Mara reaches the Glass Orchard, learns the Ferryman is Mara's brother, discovers the red key opens the observatory, and finally Mara burns the north archive.";
+
+const episodes = [1, 2, 3, 4, 5] as const;
+
+export function SpoilerLab() {
+  const [watchedThrough, setWatchedThrough] = useState(2);
+  const futureRules = episodeRules.filter(rule => rule.episode > watchedThrough);
+  const futureTerms = futureRules.flatMap(rule => [...rule.terms]);
+  const rules = useMemo(
+    () =>
+      futureTerms.length > 0
+        ? [censorRuleFromTerms('glass-orchard-future-spoilers', futureTerms)]
+        : [],
+    [futureTerms.join('\u0000')]
+  );
+
+  return (
+    <section className="spoiler-section" aria-labelledby="spoiler-title">
+      <div className="section-heading">
+        <p className="eyebrow">05 / progress-aware pack</p>
+        <h2 id="spoiler-title">Tell Scrawlix where you stopped watching.</h2>
+        <p>
+          A fictional pack tags spoiler phrases by episode. Your progress decides
+          which rules activate, so yesterday's spoiler becomes today's ordinary text.
+        </p>
+      </div>
+
+      <div
+        className="spoiler-lab"
+        data-hidden-count={futureRules.length}
+        data-spoiler-lab
+        data-watched-through={watchedThrough}
+      >
+        <aside className="spoiler-pack-card">
+          <p className="spoiler-kicker">fictional community pack</p>
+          <h3>The Glass Orchard</h3>
+          <p className="spoiler-pack-meta">5 episodes · 4 spoiler rules</p>
+
+          <div className="spoiler-episode-list" aria-label="Pack spoiler rules">
+            {episodeRules.map(rule => (
+              <div
+                data-future={rule.episode > watchedThrough ? 'true' : 'false'}
+                key={rule.episode}
+              >
+                <span>episode {rule.episode}</span>
+                <strong>
+                  {rule.episode > watchedThrough ? 'covered' : 'seen'}
+                </strong>
+              </div>
+            ))}
+          </div>
+        </aside>
+
+        <div className="spoiler-workbench">
+          <div className="spoiler-progress">
+            <div>
+              <span>watched through</span>
+              <strong>episode {watchedThrough}</strong>
+            </div>
+            <div className="spoiler-progress-buttons" role="group" aria-label="Watched through episode">
+              {episodes.map(episode => (
+                <button
+                  aria-pressed={episode === watchedThrough}
+                  className={episode === watchedThrough ? 'is-active' : ''}
+                  key={episode}
+                  onClick={() => setWatchedThrough(episode)}
+                  type="button"
+                >
+                  {episode}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="spoiler-output">
+            <p className="spoiler-output-label">
+              recap feed · {futureRules.length} future spoiler{futureRules.length === 1 ? '' : 's'} covered
+            </p>
+            <div className="spoiler-copy">
+              <CensoredText
+                appearance="blur"
+                coverage="full"
+                key={watchedThrough}
+                reveal="click"
+                rules={rules}
+                text={sampleRecap}
+                title="Future spoiler"
+              />
+            </div>
+            <p className="spoiler-hint">
+              {futureRules.length > 0
+                ? 'click the recap to reveal future spoilers'
+                : 'caught up — the whole recap is visible'}
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/demo/src/main.tsx
+++ b/apps/demo/src/main.tsx
@@ -4,6 +4,7 @@ import '@scrawlix/react/styles.css';
 import { App } from './App';
 import './styles.css';
 import './poetry.css';
+import './spoilers.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/apps/demo/src/spoilers.css
+++ b/apps/demo/src/spoilers.css
@@ -1,0 +1,225 @@
+.spoiler-section {
+  padding: 86px 0;
+  border-bottom: 1px solid #171512;
+}
+
+.spoiler-lab {
+  display: grid;
+  grid-template-columns: minmax(250px, 0.36fr) minmax(0, 1fr);
+  border: 1px solid #171512;
+  background: rgba(251, 248, 240, 0.62);
+}
+
+.spoiler-pack-card {
+  padding: 22px;
+  border-right: 1px solid #171512;
+  background: #171512;
+  color: #f2eee5;
+}
+
+.spoiler-kicker,
+.spoiler-pack-meta,
+.spoiler-episode-list,
+.spoiler-progress,
+.spoiler-output-label,
+.spoiler-hint {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.spoiler-kicker {
+  margin: 0 0 28px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.64;
+}
+
+.spoiler-pack-card h3 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(34px, 3.4vw, 54px);
+  font-weight: 400;
+  line-height: 0.92;
+  letter-spacing: -0.055em;
+}
+
+.spoiler-pack-meta {
+  margin: 16px 0 28px;
+  font-size: 9px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  opacity: 0.66;
+}
+
+.spoiler-episode-list {
+  border-top: 1px solid rgba(242, 238, 229, 0.34);
+}
+
+.spoiler-episode-list > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 11px 0;
+  border-bottom: 1px solid rgba(242, 238, 229, 0.22);
+  font-size: 9px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.spoiler-episode-list > div[data-future='false'] {
+  opacity: 0.38;
+}
+
+.spoiler-episode-list strong {
+  font-size: 8px;
+}
+
+.spoiler-workbench {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.spoiler-progress {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 16px 18px;
+  border-bottom: 1px solid #171512;
+}
+
+.spoiler-progress > div:first-child {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 9px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.spoiler-progress > div:first-child span {
+  opacity: 0.55;
+}
+
+.spoiler-progress-buttons {
+  display: flex;
+  gap: 5px;
+}
+
+.spoiler-progress-buttons button {
+  width: 34px;
+  height: 34px;
+  border: 1px solid #171512;
+  border-radius: 50%;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+}
+
+.spoiler-progress-buttons button:hover,
+.spoiler-progress-buttons button:focus-visible,
+.spoiler-progress-buttons button.is-active {
+  background: #171512;
+  color: #f2eee5;
+}
+
+.spoiler-output {
+  flex: 1;
+  min-height: 390px;
+  display: flex;
+  flex-direction: column;
+  padding: 18px;
+}
+
+.spoiler-output-label,
+.spoiler-hint {
+  margin: 0;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.spoiler-output-label {
+  padding-bottom: 13px;
+  border-bottom: 1px solid #171512;
+}
+
+.spoiler-copy {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  padding: 38px clamp(4px, 2vw, 22px);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(27px, 3.3vw, 48px);
+  line-height: 1.15;
+  letter-spacing: -0.035em;
+}
+
+.spoiler-hint {
+  padding-top: 13px;
+  border-top: 1px solid #171512;
+  opacity: 0.62;
+}
+
+@media (max-width: 900px) {
+  .spoiler-lab {
+    grid-template-columns: 1fr;
+  }
+
+  .spoiler-pack-card {
+    border-right: 0;
+    border-bottom: 1px solid #171512;
+  }
+
+  .spoiler-episode-list {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  .spoiler-episode-list > div {
+    border-right: 1px solid rgba(242, 238, 229, 0.22);
+    padding-right: 8px;
+  }
+
+  .spoiler-episode-list > div:last-child {
+    border-right: 0;
+  }
+}
+
+@media (max-width: 620px) {
+  .spoiler-progress {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .spoiler-progress-buttons {
+    width: 100%;
+  }
+
+  .spoiler-progress-buttons button {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .spoiler-episode-list {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .spoiler-episode-list > div:nth-child(even) {
+    border-right: 0;
+  }
+
+  .spoiler-output {
+    min-height: 330px;
+    padding: 14px;
+  }
+
+  .spoiler-copy {
+    font-size: 29px;
+  }
+}

--- a/tests/browser/spoilers.spec.ts
+++ b/tests/browser/spoilers.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+
+test('demo controls activate spoiler rules from viewing progress', async ({ page }) => {
+  await page.goto('http://127.0.0.1:4173');
+
+  const lab = page.locator('[data-spoiler-lab]');
+  const output = lab.locator('.spoiler-output');
+  const root = output.locator('[data-scrawlix-root]');
+  const covers = output.locator('[data-scrawlix-cover]');
+
+  await expect(lab).toBeVisible();
+  await expect(lab).toHaveAttribute('data-watched-through', '2');
+  await expect(lab).toHaveAttribute('data-hidden-count', '3');
+  await expect(covers).toHaveCount(3);
+  expect(await covers.allTextContents()).toEqual([
+    "the Ferryman is Mara's brother",
+    'the red key opens the observatory',
+    'Mara burns the north archive',
+  ]);
+  await expect(root).toHaveAttribute('data-reveal', 'click');
+  await expect(root).toHaveAttribute('data-revealed', 'false');
+
+  await root.click();
+  await expect(root).toHaveAttribute('data-revealed', 'true');
+
+  await lab.getByRole('button', { name: '4', exact: true }).click();
+  await expect(lab).toHaveAttribute('data-watched-through', '4');
+  await expect(lab).toHaveAttribute('data-hidden-count', '1');
+  await expect(covers).toHaveCount(1);
+  await expect(covers).toHaveText('Mara burns the north archive');
+  await expect(root).toHaveAttribute('data-revealed', 'false');
+
+  await lab.getByRole('button', { name: '5', exact: true }).click();
+  await expect(lab).toHaveAttribute('data-watched-through', '5');
+  await expect(lab).toHaveAttribute('data-hidden-count', '0');
+  await expect(output.locator('[data-scrawlix-root]')).toHaveCount(0);
+  await expect(output).toContainText('Mara burns the north archive');
+
+  await lab.getByRole('button', { name: '1', exact: true }).click();
+  await expect(lab).toHaveAttribute('data-hidden-count', '4');
+  await expect(output.locator('[data-scrawlix-cover]')).toHaveCount(4);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - window.innerWidth
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
+});


### PR DESCRIPTION
## What

Adds a fictional serialized-show spoiler pack to the demo:

- pack rules carry an episode number beside their terms
- the user chooses `watched through episode N`
- only rules from later episodes are compiled into the active Scrawlix matcher
- future spoilers use full blur coverage with click reveal
- changing progress remounts the reveal wrapper so previously revealed future text returns to covered state
- reaching the final episode produces zero active rules and ordinary uncensored recap text

The fictional pack is **The Glass Orchard**. Its content is deliberately invented so the demo never spoils a real show.

## Product intent

This proves the progress-aware pack idea while keeping entertainment-specific concepts outside `@scrawlix/core`. If the interaction survives contact with real pack authoring, progress metadata can later inform the richer pack contract tracked in #33 and extension lenses/profiles from #30.

## Validation

A Chromium demo smoke verifies:

- default progress hides episodes 3–5
- click reveal works
- moving to episode 4 leaves only episode 5 covered and resets reveal state
- episode 5 activates zero spoiler rules
- moving back to episode 1 activates all four future rules
- narrow layout stays inside a 390px viewport

Closes #32