### PR TITLE
Add a live censor treatment preview to the extension popup

### DIFF
--- a/apps/extension/popup.html
+++ b/apps/extension/popup.html
@@ -34,6 +34,19 @@
         </label>
       </section>
 
+      <section class="treatment-preview-card" aria-label="Live censor treatment preview">
+        <div class="preview-meta">
+          <p class="eyebrow">live treatment</p>
+          <span>motherfucker</span>
+        </div>
+        <div
+          id="treatment-preview"
+          class="treatment-preview"
+          role="img"
+          aria-label="Current censor style and coverage preview"
+        ></div>
+      </section>
+
       <section class="settings-grid" aria-label="Censor treatment">
         <label>
           <span>appearance</span>

--- a/apps/extension/src/popup.css
+++ b/apps/extension/src/popup.css
@@ -31,6 +31,7 @@ textarea {
 
 .masthead,
 .site-card,
+.treatment-preview-card,
 .settings-grid,
 .custom-words,
 footer {
@@ -68,7 +69,8 @@ footer {
 footer,
 .switch-row span,
 .settings-grid label > span,
-#save-status {
+#save-status,
+.preview-meta span {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
@@ -142,6 +144,45 @@ footer,
 
 .status-line[data-enabled='false']::before {
   content: '○ ';
+}
+
+.treatment-preview-card {
+  padding: 12px 0 14px;
+}
+
+.preview-meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 7px;
+}
+
+.preview-meta .eyebrow {
+  margin-bottom: 0;
+}
+
+.preview-meta span {
+  font-size: 7px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.38;
+}
+
+.treatment-preview {
+  --scrawlix-surface: #f8f3e7;
+  min-height: 66px;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  padding: 10px 12px;
+  border: 1px solid rgba(23, 21, 16, 0.52);
+  background: #f8f3e7;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 29px;
+  line-height: 1.05;
+  letter-spacing: -0.045em;
+  white-space: nowrap;
 }
 
 select,

--- a/apps/extension/src/popup.ts
+++ b/apps/extension/src/popup.ts
@@ -1,4 +1,5 @@
 import './popup.css';
+import './content.css';
 import {
   effectiveEnabled,
   normalizeCustomWords,
@@ -10,6 +11,7 @@ import {
   type SiteMode,
   type SyncSettings,
 } from './config';
+import { renderTreatmentPreview } from './preview';
 import {
   loadExtensionState,
   saveCustomWords,
@@ -31,6 +33,7 @@ const customWordsInput = required<HTMLTextAreaElement>('custom-words');
 const siteHeading = required<HTMLHeadingElement>('site-heading');
 const effectiveStatus = required<HTMLParagraphElement>('effective-status');
 const saveStatus = required<HTMLSpanElement>('save-status');
+const treatmentPreview = required<HTMLDivElement>('treatment-preview');
 
 let settings: SyncSettings;
 let hostname: string | null = null;
@@ -71,6 +74,10 @@ function renderSettings() {
   appearanceSelect.value = settings.appearance;
   coverageSelect.value = settings.coverage;
   revealSelect.value = settings.reveal;
+  renderTreatmentPreview(treatmentPreview, {
+    appearance: settings.appearance,
+    coverage: settings.coverage,
+  });
   renderEffectiveStatus();
 }
 

--- a/apps/extension/src/popup.ts
+++ b/apps/extension/src/popup.ts
@@ -1,5 +1,5 @@
-import './popup.css';
 import './content.css';
+import './popup.css';
 import {
   effectiveEnabled,
   normalizeCustomWords,

--- a/apps/extension/src/preview.test.ts
+++ b/apps/extension/src/preview.test.ts
@@ -1,0 +1,64 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { renderTreatmentPreview, TREATMENT_PREVIEW_TEXT } from './preview';
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+function previewRoot() {
+  const root = document.createElement('div');
+  document.body.append(root);
+  return root;
+}
+
+describe('popup treatment preview', () => {
+  it('uses the real semantic target and middle coverage', () => {
+    const root = previewRoot();
+
+    renderTreatmentPreview(root, {
+      appearance: 'scrawl',
+      coverage: 'middle',
+    });
+
+    const cover = root.querySelector<HTMLElement>('[data-scrawlix-cover]')!;
+    expect(root.textContent).toBe(TREATMENT_PREVIEW_TEXT);
+    expect(root.dataset.scrawlixAppearance).toBe('scrawl');
+    expect(root.dataset.scrawlixReveal).toBe('never');
+    expect(cover.textContent).toBe('uc');
+    expect(cover.dataset.scrawlixMask).toBeUndefined();
+  });
+
+  it('updates the same root for full mosaic coverage', () => {
+    const root = previewRoot();
+
+    renderTreatmentPreview(root, {
+      appearance: 'scrawl',
+      coverage: 'middle',
+    });
+    renderTreatmentPreview(root, {
+      appearance: 'mosaic',
+      coverage: 'full',
+    });
+
+    const covers = root.querySelectorAll<HTMLElement>('[data-scrawlix-cover]');
+    expect(covers).toHaveLength(1);
+    expect(root.dataset.scrawlixAppearance).toBe('mosaic');
+    expect(covers[0]!.textContent).toBe('fuck');
+    expect(root.textContent).toBe(TREATMENT_PREVIEW_TEXT);
+  });
+
+  it('reuses the extension symbol-mask semantics', () => {
+    const root = previewRoot();
+
+    renderTreatmentPreview(root, {
+      appearance: 'asterisk',
+      coverage: 'middle',
+    });
+
+    const cover = root.querySelector<HTMLElement>('[data-scrawlix-cover]')!;
+    expect(cover.textContent).toBe('uc');
+    expect(cover.dataset.scrawlixMask).toBe('**');
+  });
+});

--- a/apps/extension/src/preview.ts
+++ b/apps/extension/src/preview.ts
@@ -1,0 +1,48 @@
+import { createScrawlix } from '@scrawlix/core';
+import { englishProfanityRules } from '@scrawlix/en';
+import {
+  coverageSelector,
+  maskFor,
+  type ExtensionAppearance,
+  type ExtensionCoverage,
+} from './config';
+
+export const TREATMENT_PREVIEW_TEXT = 'motherfucker';
+
+export function renderTreatmentPreview(
+  root: HTMLElement,
+  {
+    appearance,
+    coverage,
+  }: {
+    appearance: ExtensionAppearance;
+    coverage: ExtensionCoverage;
+  }
+) {
+  const engine = createScrawlix({
+    rules: englishProfanityRules,
+    coverage: coverageSelector(coverage),
+  });
+  const segments = engine.segment(TREATMENT_PREVIEW_TEXT);
+
+  root.replaceChildren();
+  root.setAttribute('data-scrawlix-root', '');
+  root.dataset.scrawlixAppearance = appearance;
+  root.dataset.scrawlixReveal = 'never';
+  root.dataset.scrawlixRevealed = 'false';
+
+  for (const segment of segments) {
+    if (!segment.covered) {
+      root.append(document.createTextNode(segment.text));
+      continue;
+    }
+
+    const cover = document.createElement('span');
+    cover.setAttribute('data-scrawlix-cover', '');
+    cover.dataset.scrawlixRules = segment.ruleIds.join(',');
+    const mask = maskFor(segment.text, appearance);
+    if (mask) cover.dataset.scrawlixMask = mask;
+    cover.append(document.createTextNode(segment.text));
+    root.append(cover);
+  }
+}


### PR DESCRIPTION
## Summary

This is based on #37.

- add a compact live proof strip between site status and the treatment controls
- use `motherfucker` as the fixed specimen so coverage changes are immediately visible while appearance changes remain distinct
- render the preview from the real `@scrawlix/core` engine + English semantic-target rules
- reuse the extension's real `maskFor(...)` behavior for asterisk/grawlix
- import the exact same `content.css` into the popup bundle, so the preview and injected page treatment share one preset stylesheet
- load shared preset CSS before popup-local CSS so the proof strip can deliberately override `--scrawlix-surface` and whiteout reads as correction material on the popup's cream paper
- keep preview reveal fixed to `never`; the popup's Reveal selector remains an independent policy control
- update the preview synchronously whenever appearance or coverage changes
- preserve the popup's cream/serif/mono editorial language with a 66px proof strip
- add jsdom regressions for middle semantic coverage, full mosaic coverage, root reuse, and symbol-mask semantics

## Why

Appearance names such as `whiteout`, `mosaic`, and `grawlix` are much easier to choose when the popup shows their actual pixels. The preview also pressure-tests the shared presentation contract introduced by #37 instead of creating a popup-only facsimile.

The stylesheet import order is intentional: page/preset rules establish the shared treatment language first; popup-local rules then set the local paper surface and proof presentation.

Part of #51
Depends on #37