### PR TITLE
Make canonical term matching grapheme-safe

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -11,6 +11,7 @@ Scrawlix publishes ESM and TypeScript declarations targeting modern JavaScript. 
 - RegExp lookbehind
 - Unicode property escapes
 - RegExp match indices (`d` flag)
+- `Intl.Segmenter` with grapheme segmentation
 
 For published-package execution in Node, **Node 18 and newer** is the supported baseline for core/rehype and SSR contexts that execute package code directly.
 
@@ -18,11 +19,21 @@ Repository CI and ordinary development verification use **Node 22**. The OIDC np
 
 For browsers, support is capability-based during pre-1.0: the consuming browser must support the features above. Scrawlix's browser CI exercises current Chromium. Add explicit Firefox/Safari version claims only alongside CI or targeted compatibility tests that enforce them.
 
+## Unicode normalization
+
+`censorRuleFromTerms()` uses NFC canonical normalization by default. Terms and source text are matched through an internal normalized shadow representation, while `find()` and `segment()` continue to report and render exact slices of the caller-owned source string.
+
+This makes canonically equivalent NFC/NFD spellings behave equivalently without rewriting source text. Callers that require exact-form literal behavior can pass `{ normalization: 'none' }` to `censorRuleFromTerms()`.
+
+Raw `RegExp` rules and custom matchers remain caller-defined matching algorithms. Core validates every produced full-match and semantic-target range against original-source grapheme boundaries before exposing it.
+
 ## Grapheme handling
 
-Scrawlix uses `Intl.Segmenter` when the runtime provides it so positional coverage works on extended grapheme clusters.
+Scrawlix uses `Intl.Segmenter` as its extended-grapheme implementation. Match ranges, semantic-target ranges, positional coverage, and exported `graphemeRanges()` all share that implementation.
 
-A fallback based on Unicode code points is used when `Intl.Segmenter` is unavailable. The fallback preserves source text and valid JavaScript string boundaries, but complex grapheme clusters can be treated as several positions. Applications that require grapheme-exact partial coverage should choose runtimes with `Intl.Segmenter` support or use `coverage: 'full'`.
+`Intl.Segmenter` is an explicit runtime requirement. Scrawlix does not fall back to code-point counting because a code-point fallback can split combining sequences, variation-selector emoji, emoji-modifier sequences, regional-indicator flags, and ZWJ sequences.
+
+Coverage callbacks may return arbitrary UTF-16 ranges inside a semantic target. Core sanitizes those ranges and expands their edges to the surrounding extended-grapheme boundaries before segmentation, so generated covered segments never split a grapheme.
 
 ## React
 

--- a/docs/language-packs.md
+++ b/docs/language-packs.md
@@ -36,6 +36,22 @@ const engine = createScrawlix({
 
 Scrawlix deliberately avoids automatic language detection. Applications know more about their content and can choose one pack, several packs, or caller-authored rules.
 
+## Canonical Unicode matching
+
+`censorRuleFromTerms()` normalizes both declared terms and an internal source shadow to NFC by default. Canonically equivalent spellings therefore match even when their UTF-16 lengths differ:
+
+```ts
+const rule = censorRuleFromTerms('cafe', ['café']);
+
+// Both match, while find() reports the exact original source slice.
+engine.find('café');
+engine.find('cafe\u0301');
+```
+
+The source string itself stays unchanged. Scrawlix builds the normalized shadow one extended grapheme at a time and maps every accepted shadow boundary back to the corresponding original-source boundary. `{ normalization: 'none' }` is available for rules that intentionally distinguish canonical forms.
+
+Raw regex rules and custom matchers keep their own matching policy. Core validates the ranges they produce and throws when a full match or semantic target cuts through an extended grapheme cluster.
+
 ## Boundaries
 
 `censorRuleFromTerms()` defaults to `boundary: 'word'`, using Unicode-aware lookarounds. Letters, numbers, combining marks, connector punctuation, ZWNJ, and ZWJ keep a candidate attached to surrounding text. This prevents a boundary from appearing inside many decomposed or connected Unicode sequences while still blocking ordinary substring false positives.
@@ -70,7 +86,7 @@ Coverage runs against `core`, while `find()` still reports the full match and bo
 
 ## Custom matcher escape hatch
 
-Regex remains the compact path for ordinary rules. A pack that needs normalization, locale-specific segmentation, a trie, or another matching algorithm can provide a custom matcher instead:
+Regex remains the compact path for ordinary rules. A pack that needs locale-specific segmentation, a trie, obfuscation handling, or another matching algorithm can provide a custom matcher instead:
 
 ```ts
 import type { CensorRule } from '@scrawlix/core';
@@ -95,9 +111,9 @@ const rule: CensorRule = {
 
 Matcher ranges are UTF-16 offsets into the exact original JavaScript source string. `start`/`end` identify the complete match. `targetStart`/`targetEnd` are optional; omit both to make the complete match the semantic target.
 
-Custom matchers may build normalized or otherwise transformed shadow text internally, but they remain responsible for mapping a detected span back to exact original-source offsets before yielding it. Core validates matcher output and rejects empty, out-of-bounds, partial-target, or target-outside-match ranges rather than clamping them.
+Custom matchers may build normalized or otherwise transformed shadow text internally, but they remain responsible for mapping a detected span back to exact original-source offsets before yielding it. Core validates matcher output and rejects empty, out-of-bounds, partial-target, target-outside-match, and grapheme-splitting ranges.
 
-Keep language-specific matching algorithms in their language packs. The custom matcher seam exists so core can execute source-ranged results without learning a language's morphology, segmentation, normalization, or evasion conventions.
+Keep language-specific matching algorithms in their language packs. The custom matcher seam exists so core can execute source-ranged results without learning a language's morphology, segmentation, or evasion conventions.
 
 ## Coverage helpers
 
@@ -110,9 +126,9 @@ Core coverage presets are positional and language-neutral:
 
 `full` is the default engine policy. Packs and consumers can choose a different policy explicitly.
 
-Language-specific character classes belong in packs. `@scrawlix/en`, for example, exports `englishVowelCoverage` as a `CoverageSelector` callback instead of teaching core what an English vowel is.
+Core exports `graphemeRanges()` as the shared extended-grapheme primitive. Language-specific character classes belong in packs, but pack coverage helpers should reuse those core ranges instead of carrying a second segmentation implementation. `@scrawlix/en`, for example, uses the core ranges inside `englishVowelCoverage`.
 
-A pack can export several named helpers without changing the core API.
+Coverage callbacks can return arbitrary UTF-16 offsets inside the semantic target. Core expands sanitized coverage edges to complete graphemes before producing covered segments.
 
 ## Corpora
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -37,12 +37,17 @@ import { censorRuleFromTerms, createScrawlix } from '@scrawlix/core';
 const privateTerms = censorRuleFromTerms('private', [
   'Project Velvet',
   'Mothbit',
+  'café',
 ]);
 
 const scrawlix = createScrawlix({ rules: [privateTerms] });
 ```
 
-`censorRuleFromTerms()` uses Unicode-aware word boundaries by default. Use `{ boundary: 'substring' }` deliberately for packs/scripts where adjacent letters are valid.
+`censorRuleFromTerms()` uses Unicode-aware word boundaries and NFC canonical equivalence by default. A term such as `café` therefore matches both NFC `café` and NFD `cafe\u0301`, while `find()` still returns the exact spelling and UTF-16 range from the original source.
+
+Use `{ boundary: 'substring' }` deliberately for packs/scripts where adjacent letters are valid. Use `{ normalization: 'none' }` when a rule intentionally distinguishes canonically equivalent source forms.
+
+Core requires `Intl.Segmenter` and exports `graphemeRanges()` so language-specific coverage helpers can share the same extended-grapheme boundaries as matching and segmentation.
 
 ## Public concepts
 
@@ -51,6 +56,8 @@ const scrawlix = createScrawlix({ rules: [privateTerms] });
 - `find(text)` returns semantic match metadata
 - `segment(text)` returns source-preserving covered/uncovered segments
 - generic coverage presets are `full`, `tail`, `middle`, and `inner`
+- literal/custom-term matching defaults to NFC canonical equivalence
+- every exposed match, target, and covered segment respects extended-grapheme boundaries
 
 Scrawlix deliberately has no built-in language or hidden profanity list. Callers select rules explicitly.
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,7 @@ export type CensorRulePack = {
 };
 
 export type WordBoundaryMode = 'word' | 'substring';
+export type UnicodeNormalization = 'none' | 'NFC';
 
 export type ScrawlixMatch = {
   ruleId: string;
@@ -113,6 +114,11 @@ type CoveredRange = {
   ruleIds: Set<string>;
 };
 
+type NormalizedShadow = {
+  value: string;
+  sourceOffsets: ReadonlyMap<number, number>;
+};
+
 const graphemeSegmenter =
   typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
     ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
@@ -153,23 +159,32 @@ function isMatcherRule(rule: CensorRule): rule is CensorMatcherRule {
   return rule.matcher !== undefined;
 }
 
-function graphemeRanges(value: string): RelativeRange[] {
+function requireGraphemeSegmenter() {
+  if (!graphemeSegmenter) {
+    throw new Error(
+      'Scrawlix requires Intl.Segmenter for grapheme-safe matching and coverage.'
+    );
+  }
+  return graphemeSegmenter;
+}
+
+/** Return extended-grapheme ranges as UTF-16 offsets into the original string. */
+export function graphemeRanges(value: string): RelativeRange[] {
   if (!value) return [];
 
-  if (graphemeSegmenter) {
-    return [...graphemeSegmenter.segment(value)].map(part => ({
-      start: part.index,
-      end: part.index + part.segment.length,
-    }));
-  }
+  return [...requireGraphemeSegmenter().segment(value)].map(part => ({
+    start: part.index,
+    end: part.index + part.segment.length,
+  }));
+}
 
-  const ranges: RelativeRange[] = [];
-  let cursor = 0;
-  for (const character of Array.from(value)) {
-    ranges.push({ start: cursor, end: cursor + character.length });
-    cursor += character.length;
+function graphemeBoundarySet(value: string) {
+  const boundaries = new Set<number>([0, value.length]);
+  for (const range of graphemeRanges(value)) {
+    boundaries.add(range.start);
+    boundaries.add(range.end);
   }
-  return ranges;
+  return boundaries;
 }
 
 function fullRange(value: string): RelativeRange[] {
@@ -227,9 +242,28 @@ function coverageForPreset(
   }
 }
 
+function alignCoverageRange(
+  value: string,
+  start: number,
+  end: number
+): RelativeRange | null {
+  const graphemes = graphemeRanges(value);
+  const first = graphemes.find(range => range.end > start);
+  if (!first) return null;
+
+  let last: RelativeRange | undefined;
+  for (const range of graphemes) {
+    if (range.start >= end) break;
+    last = range;
+  }
+  if (!last) return null;
+
+  return { start: first.start, end: last.end };
+}
+
 function sanitizeRanges(
   ranges: readonly RelativeRange[],
-  targetLength: number
+  targetText: string
 ): RelativeRange[] {
   return ranges
     .map(range => {
@@ -237,10 +271,16 @@ function sanitizeRanges(
         return null;
       }
 
-      const start = Math.max(0, Math.min(targetLength, Math.trunc(range.start)));
-      const end = Math.max(0, Math.min(targetLength, Math.trunc(range.end)));
+      const start = Math.max(
+        0,
+        Math.min(targetText.length, Math.trunc(range.start))
+      );
+      const end = Math.max(
+        0,
+        Math.min(targetText.length, Math.trunc(range.end))
+      );
       if (end <= start) return null;
-      return { start, end };
+      return alignCoverageRange(targetText, start, end);
     })
     .filter((range): range is RelativeRange => range !== null)
     .sort((left, right) => left.start - right.start || left.end - right.end);
@@ -248,6 +288,20 @@ function sanitizeRanges(
 
 function ruleIdentity(rule: CompiledRule) {
   return rule.packId ? `${rule.packId}:${rule.id}` : rule.id;
+}
+
+function assertGraphemeAlignedRange(
+  boundaries: ReadonlySet<number>,
+  rule: CompiledRule,
+  start: number,
+  end: number,
+  kind: 'match' | 'target'
+) {
+  if (!boundaries.has(start) || !boundaries.has(end)) {
+    throw new Error(
+      `Censor rule "${ruleIdentity(rule)}" produced a ${kind} range [${start}, ${end}) that splits an extended grapheme cluster.`
+    );
+  }
 }
 
 function scannedMatchFromRange(
@@ -291,7 +345,11 @@ function resolveTargetRange(match: RegExpExecArray, rule: CompiledRegexRule) {
   return { start: groupRange[0], end: groupRange[1] };
 }
 
-function scanRegexRule(text: string, rule: CompiledRegexRule): ScannedMatch[] {
+function scanRegexRule(
+  text: string,
+  rule: CompiledRegexRule,
+  boundaries: ReadonlySet<number>
+): ScannedMatch[] {
   const matches: ScannedMatch[] = [];
   rule.pattern.lastIndex = 0;
 
@@ -305,13 +363,29 @@ function scanRegexRule(text: string, rule: CompiledRegexRule): ScannedMatch[] {
         continue;
       }
 
+      const matchStart = rawMatch.index;
+      const matchEnd = rawMatch.index + rawMatch[0].length;
       const target = resolveTargetRange(rawMatch, rule);
+      assertGraphemeAlignedRange(
+        boundaries,
+        rule,
+        matchStart,
+        matchEnd,
+        'match'
+      );
+      assertGraphemeAlignedRange(
+        boundaries,
+        rule,
+        target.start,
+        target.end,
+        'target'
+      );
       matches.push(
         scannedMatchFromRange(
           text,
           rule,
-          rawMatch.index,
-          rawMatch.index + rawMatch[0].length,
+          matchStart,
+          matchEnd,
           target.start,
           target.end
         )
@@ -327,7 +401,8 @@ function scanRegexRule(text: string, rule: CompiledRegexRule): ScannedMatch[] {
 function validatedMatcherRange(
   textLength: number,
   rule: CensorMatcherRule,
-  range: CensorMatcherMatch
+  range: CensorMatcherMatch,
+  boundaries: ReadonlySet<number>
 ) {
   if (
     !Number.isInteger(range.start) ||
@@ -340,6 +415,8 @@ function validatedMatcherRange(
       `Censor rule "${ruleIdentity(rule)}" returned an invalid match range [${range.start}, ${range.end}) for source length ${textLength}.`
     );
   }
+
+  assertGraphemeAlignedRange(boundaries, rule, range.start, range.end, 'match');
 
   const hasTargetStart = range.targetStart !== undefined;
   const hasTargetEnd = range.targetEnd !== undefined;
@@ -372,6 +449,14 @@ function validatedMatcherRange(
     );
   }
 
+  assertGraphemeAlignedRange(
+    boundaries,
+    rule,
+    targetStart,
+    targetEnd,
+    'target'
+  );
+
   return {
     start: range.start,
     end: range.end,
@@ -380,11 +465,20 @@ function validatedMatcherRange(
   };
 }
 
-function scanMatcherRule(text: string, rule: CensorMatcherRule): ScannedMatch[] {
+function scanMatcherRule(
+  text: string,
+  rule: CensorMatcherRule,
+  boundaries: ReadonlySet<number>
+): ScannedMatch[] {
   const matches: ScannedMatch[] = [];
 
   for (const rawRange of rule.matcher.find(text)) {
-    const range = validatedMatcherRange(text.length, rule, rawRange);
+    const range = validatedMatcherRange(
+      text.length,
+      rule,
+      rawRange,
+      boundaries
+    );
     matches.push(
       scannedMatchFromRange(
         text,
@@ -401,10 +495,11 @@ function scanMatcherRule(text: string, rule: CensorMatcherRule): ScannedMatch[] 
 }
 
 function scan(text: string, rules: readonly CompiledRule[]): ScannedMatch[] {
+  const boundaries = graphemeBoundarySet(text);
   const matches = rules.flatMap(rule =>
     isMatcherRule(rule)
-      ? scanMatcherRule(text, rule)
-      : scanRegexRule(text, rule)
+      ? scanMatcherRule(text, rule, boundaries)
+      : scanRegexRule(text, rule, boundaries)
   );
 
   matches.sort(
@@ -441,7 +536,7 @@ function collectCoveredRanges(
       typeof selector === 'function'
         ? selector(context)
         : coverageForPreset(selector, match.targetText),
-      match.targetText.length
+      match.targetText
     );
 
     for (const relative of relativeRanges) {
@@ -514,6 +609,63 @@ function segmentFromRanges(text: string, ranges: readonly CoveredRange[]) {
   return segments;
 }
 
+function normalizedShadow(
+  value: string,
+  normalization: Exclude<UnicodeNormalization, 'none'>
+): NormalizedShadow {
+  let shadow = '';
+  const sourceOffsets = new Map<number, number>([[0, 0]]);
+
+  for (const range of graphemeRanges(value)) {
+    const shadowStart = shadow.length;
+    sourceOffsets.set(shadowStart, range.start);
+    shadow += value.slice(range.start, range.end).normalize(normalization);
+    sourceOffsets.set(shadow.length, range.end);
+  }
+
+  return { value: shadow, sourceOffsets };
+}
+
+function termPatternSource(
+  alternatives: readonly string[],
+  boundary: WordBoundaryMode
+) {
+  const source = `(?:${alternatives.map(escapeRegExp).join('|')})`;
+  return boundary === 'word'
+    ? `(?<![${wordContextClass}])${source}(?![${wordContextClass}])`
+    : source;
+}
+
+function normalizedTermMatcher(
+  patternSource: string,
+  caseSensitive: boolean,
+  normalization: Exclude<UnicodeNormalization, 'none'>
+): CensorMatcher {
+  return {
+    *find(text) {
+      const shadow = normalizedShadow(text, normalization);
+      const pattern = new RegExp(patternSource, caseSensitive ? 'gu' : 'giu');
+      let match: RegExpExecArray | null;
+
+      while ((match = pattern.exec(shadow.value)) !== null) {
+        if (!match[0]) {
+          pattern.lastIndex = advanceStringIndex(
+            shadow.value,
+            match.index,
+            pattern.unicode
+          );
+          continue;
+        }
+
+        const start = shadow.sourceOffsets.get(match.index);
+        const end = shadow.sourceOffsets.get(match.index + match[0].length);
+        if (start === undefined || end === undefined) continue;
+        yield { start, end };
+      }
+    },
+  };
+}
+
 export function censorRuleFromTerms(
   id: string,
   terms: readonly string[],
@@ -521,30 +673,40 @@ export function censorRuleFromTerms(
     caseSensitive = false,
     coverage,
     boundary = 'word',
+    normalization = 'NFC',
   }: {
     caseSensitive?: boolean;
     coverage?: CoverageSelector;
     boundary?: WordBoundaryMode;
+    normalization?: UnicodeNormalization;
   } = {}
 ): CensorRule {
-  const alternatives = [...new Set(terms.map(term => term.trim()).filter(Boolean))]
-    .sort((left, right) => right.length - left.length)
-    .map(escapeRegExp);
+  const preparedTerms = terms.map(term => term.trim()).filter(Boolean);
+  const alternatives = [
+    ...new Set(
+      preparedTerms.map(term =>
+        normalization === 'none' ? term : term.normalize(normalization)
+      )
+    ),
+  ].sort((left, right) => right.length - left.length);
 
   if (alternatives.length === 0) {
     throw new Error('A censor rule needs at least one non-empty term.');
   }
 
-  const source = `(?:${alternatives.join('|')})`;
-  const boundedSource =
-    boundary === 'word'
-      ? `(?<![${wordContextClass}])${source}(?![${wordContextClass}])`
-      : source;
+  const patternSource = termPatternSource(alternatives, boundary);
+  if (normalization === 'none') {
+    return {
+      id,
+      coverage,
+      pattern: new RegExp(patternSource, caseSensitive ? 'gu' : 'giu'),
+    };
+  }
 
   return {
     id,
     coverage,
-    pattern: new RegExp(boundedSource, caseSensitive ? 'gu' : 'giu'),
+    matcher: normalizedTermMatcher(patternSource, caseSensitive, normalization),
   };
 }
 

--- a/packages/core/src/unicode.test.ts
+++ b/packages/core/src/unicode.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import {
+  censorRuleFromTerms,
+  createScrawlix,
+  graphemeRanges,
+  type CensorMatcher,
+  type ScrawlixSegment,
+} from './index';
+
+function marked(segments: readonly ScrawlixSegment[]) {
+  return segments
+    .map(segment => (segment.covered ? `[${segment.text}]` : segment.text))
+    .join('');
+}
+
+describe('canonical Unicode matching', () => {
+  it('matches NFC and NFD terms while preserving exact source ranges', () => {
+    const nfd = 'cafe\u0301';
+    const upperNfd = 'CAFE\u0301';
+    const text = `caféteria ${nfd} CAFÉ ${upperNfd}`;
+    const engine = createScrawlix({
+      rules: [censorRuleFromTerms('cafe', ['café'])],
+      coverage: 'full',
+    });
+
+    const matches = engine.find(text);
+    expect(matches.map(match => match.text)).toEqual([nfd, 'CAFÉ', upperNfd]);
+    expect(matches.map(match => [match.start, match.end])).toEqual([
+      [text.indexOf(nfd), text.indexOf(nfd) + nfd.length],
+      [text.indexOf('CAFÉ'), text.indexOf('CAFÉ') + 'CAFÉ'.length],
+      [text.lastIndexOf(upperNfd), text.lastIndexOf(upperNfd) + upperNfd.length],
+    ]);
+    expect(marked(engine.segment(text))).toBe(
+      `caféteria [${nfd}] [CAFÉ] [${upperNfd}]`
+    );
+    expect(engine.segment(text).map(segment => segment.text).join('')).toBe(text);
+  });
+
+  it('can opt out of canonical normalization for exact-form term rules', () => {
+    const nfd = 'cafe\u0301';
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromTerms('cafe', ['café'], {
+          normalization: 'none',
+        }),
+      ],
+    });
+
+    expect(engine.find(nfd)).toEqual([]);
+    expect(engine.find('café')).toHaveLength(1);
+  });
+
+  it('keeps common extended grapheme sequences whole', () => {
+    const graphemes = [
+      'e\u0301',
+      '❤️',
+      '👍🏽',
+      '🇺🇸',
+      '👨‍👩‍👧‍👦',
+      'a\u200C',
+    ];
+    const text = graphemes.join('');
+
+    expect(
+      graphemeRanges(text).map(range => text.slice(range.start, range.end))
+    ).toEqual(graphemes);
+  });
+
+  it('rejects regex matches that split an extended grapheme cluster', () => {
+    const engine = createScrawlix({
+      rules: [{ id: 'split-match', pattern: /e/u }],
+    });
+
+    expect(() => engine.find('e\u0301')).toThrow(
+      'produced a match range [0, 1) that splits an extended grapheme cluster'
+    );
+  });
+
+  it('rejects semantic targets that split an extended grapheme cluster', () => {
+    const engine = createScrawlix({
+      rules: [
+        {
+          id: 'split-target',
+          pattern: /(?<core>e)\u0301/u,
+          target: { group: 'core' },
+        },
+      ],
+    });
+
+    expect(() => engine.find('e\u0301')).toThrow(
+      'produced a target range [0, 1) that splits an extended grapheme cluster'
+    );
+  });
+
+  it('rejects custom matcher ranges that split an extended grapheme cluster', () => {
+    const matcher: CensorMatcher = {
+      find() {
+        return [{ start: 0, end: 1 }];
+      },
+    };
+    const engine = createScrawlix({
+      rules: [{ id: 'split-custom', matcher }],
+    });
+
+    expect(() => engine.find('e\u0301')).toThrow(
+      'produced a match range [0, 1) that splits an extended grapheme cluster'
+    );
+  });
+
+  it('expands custom coverage ranges to whole graphemes', () => {
+    const nfd = 'e\u0301';
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromTerms('accent', ['é'], {
+          boundary: 'substring',
+          coverage: () => [{ start: 1, end: 2 }],
+        }),
+      ],
+    });
+
+    expect(marked(engine.segment(nfd))).toBe(`[${nfd}]`);
+  });
+});

--- a/packages/en/src/index.ts
+++ b/packages/en/src/index.ts
@@ -1,33 +1,9 @@
-import type {
-  CensorRule,
-  CensorRulePack,
-  CoverageSelector,
-  RelativeRange,
+import {
+  graphemeRanges,
+  type CensorRule,
+  type CensorRulePack,
+  type CoverageSelector,
 } from '@scrawlix/core';
-
-const graphemeSegmenter =
-  typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
-    ? new Intl.Segmenter('en', { granularity: 'grapheme' })
-    : null;
-
-function graphemeRanges(value: string): RelativeRange[] {
-  if (!value) return [];
-
-  if (graphemeSegmenter) {
-    return [...graphemeSegmenter.segment(value)].map(part => ({
-      start: part.index,
-      end: part.index + part.segment.length,
-    }));
-  }
-
-  const ranges: RelativeRange[] = [];
-  let cursor = 0;
-  for (const character of Array.from(value)) {
-    ranges.push({ start: cursor, end: cursor + character.length });
-    cursor += character.length;
-  }
-  return ranges;
-}
 
 /**
  * Covers orthographic English vowels (a/e/i/o/u) inside the semantic target.

--- a/packages/en/src/unicode.test.ts
+++ b/packages/en/src/unicode.test.ts
@@ -1,0 +1,26 @@
+import type { CoverageContext } from '@scrawlix/core';
+import { describe, expect, it } from 'vitest';
+import { englishVowelCoverage } from './index';
+
+describe('English Unicode coverage', () => {
+  it('treats a decomposed accented vowel as one grapheme', () => {
+    if (typeof englishVowelCoverage !== 'function') {
+      throw new Error('Expected English vowel coverage to be a callback.');
+    }
+
+    const targetText = 'u\u0301';
+    const context: CoverageContext = {
+      ruleId: 'test',
+      matchText: targetText,
+      targetText,
+      matchStart: 0,
+      matchEnd: targetText.length,
+      targetStart: 0,
+      targetEnd: targetText.length,
+    };
+
+    expect(englishVowelCoverage(context)).toEqual([
+      { start: 0, end: targetText.length },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
Implement the next Unicode slice from #35.

- make `censorRuleFromTerms()` use NFC canonical equivalence by default
- build the normalized source shadow one extended grapheme at a time and map matches back to exact original UTF-16 ranges
- add `{ normalization: 'none' }` for exact-form literal rules
- export core `graphemeRanges()` and reuse it from `@scrawlix/en`
- require `Intl.Segmenter` instead of falling back to code-point segmentation
- reject regex/custom matcher full-match and semantic-target ranges that split extended grapheme clusters
- expand sanitized custom coverage edges to whole graphemes
- add regressions for NFC/NFD accents, decomposed adjacency, combining marks, variation selectors, emoji modifiers, regional-indicator flags, ZWJ sequences, ZWNJ, and split-range failures
- document the normalization/source-preservation/runtime contract

## Source invariant
Matching may happen against NFC shadow text, but `find()` and `segment()` continue to expose exact slices of caller-owned source text. Canonically equivalent inputs can therefore have different UTF-16 lengths while reporting correct original ranges.

## Runtime decision
`Intl.Segmenter` is now an explicit core capability requirement. A code-point fallback cannot uphold the grapheme-boundary guarantee this API now makes.

Progress on #35
Related: #38, #36