### PR TITLE
Expose typed React appearance custom properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ Current reveal modes: `hover`, `focus`, `click`, and `never`.
 
 The renderer exposes a namespaced presentation contract through `data-scrawlix-root`, `data-scrawlix-appearance`, `data-scrawlix-reveal`, `data-scrawlix-revealed`, `data-scrawlix-cover`, `data-scrawlix-rules`, and optional `data-scrawlix-mask` attributes. Preset styling can be tuned with CSS custom properties including `--scrawlix-ink`, `--scrawlix-surface`, `--scrawlix-bar-height`, `--scrawlix-blur-radius`, and `--scrawlix-mosaic-cell`.
 
+`CensoredText` accepts ordinary React styles plus those five Scrawlix variables through the exported `ScrawlixStyle` type. Inline JSX gets contextual typing, so custom-property tuning stays simple:
+
+```tsx
+<CensoredText
+  text="what the fuck"
+  rules={englishProfanityRules}
+  appearance="bar"
+  style={{
+    '--scrawlix-ink': 'rebeccapurple',
+    '--scrawlix-bar-height': '0.62em',
+  }}
+/>;
+```
+
+Root `className`, the namespaced data attributes, and these custom properties are the first styling escape hatches. Matching, source preservation, accessibility, and reveal behavior stay inside the renderer.
+
 ## Markdown / rehype
 
 `@scrawlix/rehype` walks HAST text nodes and marks covered ranges while leaving the source text intact:

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -3,7 +3,12 @@ import {
   type CensorRule,
   type CoverageSelector,
 } from '@scrawlix/core';
-import { useMemo, useState, type KeyboardEvent } from 'react';
+import {
+  useMemo,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+} from 'react';
 
 export type ScrawlixAppearance =
   | 'scrawl'
@@ -16,6 +21,16 @@ export type ScrawlixAppearance =
 
 export type ScrawlixReveal = 'hover' | 'focus' | 'click' | 'never';
 
+export type ScrawlixCustomProperty =
+  | '--scrawlix-ink'
+  | '--scrawlix-surface'
+  | '--scrawlix-bar-height'
+  | '--scrawlix-blur-radius'
+  | '--scrawlix-mosaic-cell';
+
+export type ScrawlixStyle = CSSProperties &
+  Partial<Record<ScrawlixCustomProperty, string | number>>;
+
 export type CensoredTextProps = {
   text: string;
   rules: readonly CensorRule[];
@@ -23,6 +38,7 @@ export type CensoredTextProps = {
   appearance?: ScrawlixAppearance;
   reveal?: ScrawlixReveal;
   className?: string;
+  style?: ScrawlixStyle;
   title?: string;
 };
 
@@ -57,6 +73,7 @@ export function CensoredText({
   appearance = 'scrawl',
   reveal = 'hover',
   className = '',
+  style,
   title = 'Censored text',
 }: CensoredTextProps) {
   const engine = useMemo(
@@ -86,6 +103,7 @@ export function CensoredText({
       data-scrawlix-appearance={appearance}
       data-scrawlix-reveal={reveal}
       data-scrawlix-revealed={revealed ? 'true' : 'false'}
+      style={style}
       tabIndex={interactive ? 0 : undefined}
       onClick={reveal === 'click' ? () => setRevealed(value => !value) : undefined}
       onKeyDown={onKeyDown}

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -29,7 +29,7 @@ export type ScrawlixCustomProperty =
   | '--scrawlix-mosaic-cell';
 
 export type ScrawlixStyle = CSSProperties &
-  Partial<Record<ScrawlixCustomProperty, string | number>>;
+  Partial<Record<ScrawlixCustomProperty, string>>;
 
 export type CensoredTextProps = {
   text: string;

--- a/packages/react/src/style.test.tsx
+++ b/packages/react/src/style.test.tsx
@@ -1,0 +1,46 @@
+/** @vitest-environment jsdom */
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CensoredText, type ScrawlixStyle } from './index';
+
+const mounted: Array<{ root: ReturnType<typeof createRoot>; container: HTMLDivElement }> = [];
+const rules = [{ id: 'fuck', pattern: /fuck/giu }] as const;
+
+afterEach(() => {
+  while (mounted.length > 0) {
+    const item = mounted.pop()!;
+    act(() => item.root.unmount());
+    item.container.remove();
+  }
+});
+
+describe('CensoredText styling', () => {
+  it('accepts ordinary React styles and typed Scrawlix custom properties', () => {
+    const style: ScrawlixStyle = {
+      fontSize: '24px',
+      '--scrawlix-ink': 'rebeccapurple',
+      '--scrawlix-surface': 'papayawhip',
+      '--scrawlix-bar-height': '0.6em',
+      '--scrawlix-blur-radius': '0.25em',
+      '--scrawlix-mosaic-cell': '0.4em',
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() => {
+      root.render(<CensoredText rules={rules} style={style} text="fuck" />);
+    });
+
+    const rendered = container.querySelector<HTMLElement>('[data-scrawlix-root]')!;
+    expect(rendered.style.fontSize).toBe('24px');
+    expect(rendered.style.getPropertyValue('--scrawlix-ink')).toBe('rebeccapurple');
+    expect(rendered.style.getPropertyValue('--scrawlix-surface')).toBe('papayawhip');
+    expect(rendered.style.getPropertyValue('--scrawlix-bar-height')).toBe('0.6em');
+    expect(rendered.style.getPropertyValue('--scrawlix-blur-radius')).toBe('0.25em');
+    expect(rendered.style.getPropertyValue('--scrawlix-mosaic-cell')).toBe('0.4em');
+  });
+});


### PR DESCRIPTION
## Summary

This is based on #37.

- add exported `ScrawlixCustomProperty` and `ScrawlixStyle` types
- add a `style?: ScrawlixStyle` prop to `CensoredText`
- preserve every ordinary React `CSSProperties` field
- contextually type the five public Scrawlix appearance knobs:
  - `--scrawlix-ink`
  - `--scrawlix-surface`
  - `--scrawlix-bar-height`
  - `--scrawlix-blur-radius`
  - `--scrawlix-mosaic-cell`
- type Scrawlix custom-property values as CSS strings, avoiding misleading TypeScript acceptance of unitless numbers for colors/lengths
- pass the style object directly to the existing root span
- add rendered regressions proving ordinary styles + every public Scrawlix variable reach the DOM
- document inline JSX usage without casts in the README

## Design choice

This keeps the first custom-styling API intentionally small. Root `className`, namespaced `data-scrawlix-*` attributes, and typed custom properties already cover a large family of house treatments while keeping source preservation, accessibility, matching, and reveal inside Scrawlix.

The public custom-property values are strings because every current knob is either a color or a CSS length. Callers can use values such as `'#2d0b0b'`, `'var(--brand-ink)'`, `'0'`, `'0.22em'`, or `'8px'` without TypeScript blessing invalid unitless length tokens.

A `renderCover(...)` escape hatch stays deferred until a real consumer demonstrates a visual treatment CSS cannot express safely.

Part of #42
Depends on #37