### PR TITLE
Define privacy and output semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added local extension lenses and named profiles, with per-profile treatment, legacy custom-term migration, semantic-session reuse, and atomic live-page profile switching.
 - Added a demo-local inverse-coverage / redaction-poetry experiment that preserves exact source text while selected terms survive the ink.
 - Added a fictional progress-aware spoiler pack demo where viewing progress activates only future-episode rules.
+- Added an output-semantics lab contrasting reversible pixel coverage, retained source/accessibility output, and a demo-local sanitized export string.
 
 ### Developer experience
 
@@ -67,6 +68,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added external tarball consumer smoke tests as a CI release gate, with strict declaration checking, React 18/19 production builds, and a Next.js 16 App Router production build using the documented client-wrapper boundary.
 - Added package-local READMEs for every public package, exact install commands, a top-level integration chooser, a docs index, React CSS troubleshooting, Next.js client-boundary guidance, and clearer source/accessibility notes.
 - Added explicit runtime compatibility and pre-1.0 versioning/public-contract policies.
+- Added explicit privacy/output vocabulary for visual covers, presentation/screenshot guarantees, assistive-tech concealment, and sanitized export.
 - Aligned `README.md`, `AGENTS.md`, `llms.txt`, demo, extension, tests, and smoke consumers on the canonical pre-release public names and conservative defaults.
 - Committed a pnpm 10.34.5 lockfile, pinned the workspace package manager, and switched CI to frozen installs.
 - Added a synchronized release-version gate plus a manual GitHub OIDC publication workflow with dry-run default, registry preflight checks, dependency-order publishing, provenance, and no long-lived npm write token.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Current reveal modes: `never`, `hover`, `focus`, `click`.
 
 `@scrawlix/react/styles.css` is required for the built-in treatments and the visually-hidden accessibility copy. If text appears duplicated or visibly uncensored, check that import first.
 
-`CensoredText` is reversible presentation. It keeps one exact source copy available to assistive technology and marks the decorative visual tree `aria-hidden="true"`. Secrets or destructive redaction belong upstream; Scrawlix intentionally preserves caller-owned source text.
+`CensoredText` is reversible presentation. It keeps one exact source copy available to assistive technology and marks the decorative visual tree `aria-hidden="true"`. Secrets or destructive redaction belong upstream; Scrawlix intentionally preserves caller-owned source text. See [`docs/privacy-and-output.md`](docs/privacy-and-output.md) for presentation, screenshot, assistive-technology, and sanitized-export guarantees.
 
 ### Next.js App Router
 

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -14,6 +14,7 @@ import {
   type ScrawlixReveal,
 } from '@scrawlix/react';
 import { useMemo, useState } from 'react';
+import { PrivacyLab } from './PrivacyLab';
 import { SpoilerLab } from './SpoilerLab';
 
 const appearances: readonly ScrawlixAppearance[] = [
@@ -401,10 +402,11 @@ export function App() {
       </section>
 
       <SpoilerLab />
+      <PrivacyLab />
 
       <section className="code-section" aria-labelledby="code-title">
         <div>
-          <p className="eyebrow">06 / use it</p>
+          <p className="eyebrow">07 / use it</p>
           <h2 id="code-title">Pick the language. Pick the damage.</h2>
           <p>
             Matching rules live in explicit language or custom packs. The core stays

--- a/apps/demo/src/PrivacyLab.tsx
+++ b/apps/demo/src/PrivacyLab.tsx
@@ -1,0 +1,115 @@
+import { censorRuleFromTerms, createScrawlix } from '@scrawlix/core';
+import { CensoredText } from '@scrawlix/react';
+import { useMemo, useState } from 'react';
+
+const privateText = 'Project Velvet ships Friday to Acme Widgets.';
+const privateTerms = ['Project Velvet', 'Acme Widgets'] as const;
+const privateRules = [censorRuleFromTerms('privacy-lab', privateTerms)];
+
+function sanitizeText(text: string, replacement: string) {
+  const engine = createScrawlix({ rules: privateRules, coverage: 'full' });
+  return engine
+    .segment(text)
+    .map(segment => (segment.covered ? replacement : segment.text))
+    .join('');
+}
+
+export function PrivacyLab() {
+  const [replacement, setReplacement] = useState('[REDACTED]');
+  const sanitized = useMemo(
+    () => sanitizeText(privateText, replacement),
+    [replacement]
+  );
+
+  return (
+    <section className="privacy-section" aria-labelledby="privacy-title">
+      <div className="section-heading">
+        <p className="eyebrow">06 / output contract</p>
+        <h2 id="privacy-title">A black bar has an audience.</h2>
+        <p>
+          The same covered sentence can mean different things to pixels, assistive
+          technology, the DOM, and an exported artifact. Scrawlix should say which
+          promise it is making every time.
+        </p>
+      </div>
+
+      <div className="privacy-lab" data-privacy-lab>
+        <div className="privacy-source-card">
+          <p className="privacy-kicker">private source</p>
+          <p>{privateText}</p>
+          <div className="privacy-term-list">
+            {privateTerms.map(term => (
+              <span key={term}>{term}</span>
+            ))}
+          </div>
+        </div>
+
+        <div className="privacy-channel-grid">
+          <article className="privacy-channel privacy-channel-screen">
+            <header>
+              <span>01</span>
+              <strong>presentation pixels</strong>
+              <em>covered</em>
+            </header>
+            <div className="privacy-channel-value" data-privacy-pixels>
+              <CensoredText
+                appearance="bar"
+                coverage="full"
+                reveal="never"
+                rules={privateRules}
+                text={privateText}
+                title="Private term"
+              />
+            </div>
+            <p>Useful for a projector, recording, or screenshot when pixels are the boundary.</p>
+          </article>
+
+          <article className="privacy-channel">
+            <header>
+              <span>02</span>
+              <strong>assistive tech</strong>
+              <em>source retained</em>
+            </header>
+            <code className="privacy-channel-value" data-privacy-a11y>
+              {privateText}
+            </code>
+            <p>Current React rendering intentionally keeps one exact accessible source copy.</p>
+          </article>
+
+          <article className="privacy-channel">
+            <header>
+              <span>03</span>
+              <strong>DOM / source</strong>
+              <em>source retained</em>
+            </header>
+            <code className="privacy-channel-value" data-privacy-dom>
+              {privateText}
+            </code>
+            <p>Reversible presentation needs the original string so it can restore or reveal it.</p>
+          </article>
+
+          <article className="privacy-channel privacy-channel-export">
+            <header>
+              <span>04</span>
+              <strong>sanitized export</strong>
+              <em>source removed</em>
+            </header>
+            <code className="privacy-channel-value" data-sanitized-output>
+              {sanitized}
+            </code>
+            <label>
+              <span>replacement</span>
+              <input
+                aria-label="Sanitized export replacement"
+                onChange={event => setReplacement(event.target.value)}
+                spellCheck="false"
+                value={replacement}
+              />
+            </label>
+            <p>This demo creates a new string whose selected terms have been replaced.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/demo/src/main.tsx
+++ b/apps/demo/src/main.tsx
@@ -5,6 +5,7 @@ import { App } from './App';
 import './styles.css';
 import './poetry.css';
 import './spoilers.css';
+import './privacy.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/apps/demo/src/privacy.css
+++ b/apps/demo/src/privacy.css
@@ -1,0 +1,201 @@
+.privacy-section {
+  padding: 86px 0;
+  border-bottom: 1px solid #171512;
+}
+
+.privacy-lab {
+  display: grid;
+  grid-template-columns: minmax(230px, 0.34fr) minmax(0, 1fr);
+  border: 1px solid #171512;
+  background: rgba(251, 248, 240, 0.62);
+}
+
+.privacy-source-card {
+  padding: 22px;
+  border-right: 1px solid #171512;
+  background: #cfc5b3;
+}
+
+.privacy-kicker,
+.privacy-term-list,
+.privacy-channel header,
+.privacy-channel p,
+.privacy-channel label span {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.privacy-kicker {
+  margin: 0 0 24px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.62;
+}
+
+.privacy-source-card > p:nth-child(2) {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(28px, 3vw, 46px);
+  line-height: 1.06;
+  letter-spacing: -0.045em;
+}
+
+.privacy-term-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 32px;
+}
+
+.privacy-term-list span {
+  border: 1px solid #171512;
+  padding: 6px 8px;
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.privacy-channel-grid {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.privacy-channel {
+  min-width: 0;
+  min-height: 255px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 18px;
+  border-right: 1px solid #171512;
+  border-bottom: 1px solid #171512;
+}
+
+.privacy-channel:nth-child(even) {
+  border-right: 0;
+}
+
+.privacy-channel:nth-last-child(-n + 2) {
+  border-bottom: 0;
+}
+
+.privacy-channel-screen {
+  background: rgba(23, 21, 18, 0.035);
+}
+
+.privacy-channel-export {
+  background: #171512;
+  color: #f2eee5;
+}
+
+.privacy-channel header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: baseline;
+  gap: 9px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid currentColor;
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.privacy-channel header span {
+  opacity: 0.52;
+}
+
+.privacy-channel header em {
+  font-style: normal;
+  opacity: 0.58;
+}
+
+.privacy-channel-value {
+  min-width: 0;
+  margin: auto 0;
+  overflow-wrap: anywhere;
+  white-space: normal;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(20px, 2vw, 31px);
+  line-height: 1.2;
+  letter-spacing: -0.025em;
+}
+
+code.privacy-channel-value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: clamp(13px, 1.35vw, 18px);
+  line-height: 1.5;
+}
+
+.privacy-channel p {
+  margin: 0;
+  padding-top: 10px;
+  border-top: 1px solid color-mix(in srgb, currentColor 32%, transparent);
+  font-size: 8px;
+  line-height: 1.45;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.privacy-channel label {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.privacy-channel label span {
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.62;
+}
+
+.privacy-channel input {
+  width: 100%;
+  border: 1px solid currentColor;
+  border-radius: 0;
+  background: transparent;
+  color: inherit;
+  padding: 8px 9px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+}
+
+@media (max-width: 900px) {
+  .privacy-lab {
+    grid-template-columns: 1fr;
+  }
+
+  .privacy-source-card {
+    border-right: 0;
+    border-bottom: 1px solid #171512;
+  }
+}
+
+@media (max-width: 620px) {
+  .privacy-channel-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .privacy-channel,
+  .privacy-channel:nth-child(even),
+  .privacy-channel:nth-last-child(-n + 2) {
+    min-height: 220px;
+    border-right: 0;
+    border-bottom: 1px solid #171512;
+  }
+
+  .privacy-channel:last-child {
+    border-bottom: 0;
+  }
+
+  .privacy-channel header {
+    grid-template-columns: auto 1fr;
+  }
+
+  .privacy-channel header em {
+    grid-column: 2;
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Start with the repository README for installation and the shortest path for your
 
 - [`compatibility.md`](./compatibility.md) — JavaScript/browser capabilities, Node baseline, React majors, grapheme fallback, DOM/CSS/TypeScript expectations
 - [`versioning.md`](./versioning.md) — synchronized release train, 0.x semver policy, public data/CSS contracts, and deprecation rules
+- [`privacy-and-output.md`](./privacy-and-output.md) — visual covers, presentation/screenshot guarantees, accessibility policy, and sanitized export semantics
 - [`language-packs.md`](./language-packs.md) — author and compose language/rule packs, semantic targets, boundaries, coverage helpers, and corpora
 - [`dom.md`](./dom.md) — arbitrary-page DOM application, observation, exclusions, and exact restoration
 - [`releasing.md`](./releasing.md) — first-release gates, package verification, registry checks, and publication sequence

--- a/docs/privacy-and-output.md
+++ b/docs/privacy-and-output.md
@@ -1,0 +1,78 @@
+# Privacy and output semantics
+
+Scrawlix began as reversible censorship. Privacy-oriented uses need precise language about **where the original source still exists** and **which audience receives it**.
+
+The central rule is simple: a visual cover changes presentation. A sanitized export creates a different artifact.
+
+## Current guarantees
+
+| Mode / use | Visible pixels | DOM / source string | React accessibility output | Intended use |
+| --- | --- | --- | --- | --- |
+| ordinary visual cover | covered according to appearance + coverage | original source preserved | exact original source preserved | profanity, spoilers, editorial play |
+| presentation profile | choose full coverage + non-revealing appearance | original source preserved | source behavior depends on adapter; React preserves it | screen sharing, projectors, demos |
+| screenshot-safe presentation | selected text must remain covered in rendered pixels for the captured state | original source may remain present | source may remain present | screenshots / recordings where pixel output is the boundary |
+| assistive-tech-safe concealment | covered | source policy must be explicit | selected source is intentionally withheld or replaced | a future privacy mode with a different accessibility contract |
+| sanitized export | replacement / omission chosen by exporter | selected source is absent from the exported artifact | exported artifact contains only sanitized output | files, pasted text, reports, HTML/text exports |
+
+## Ordinary Scrawlix rendering
+
+`@scrawlix/react` intentionally keeps exactly one accessible source copy. The rendered visual tree is decorative and `aria-hidden="true"`. A black bar, blur, scrawl, asterisk mask, or grawlix therefore does **not** remove the source from the component's accessible reading.
+
+`@scrawlix/dom` also preserves the exact source strings required for controller-owned restoration. Extension presentation leaves the covered source substring in the page.
+
+These behaviors are features for reversible censorship, spoilers, editorial treatments, and playful typography.
+
+## Presentation-safe
+
+A presentation profile is for a projector, screen share, livestream, or recorded demo where the visible page is the intended audience.
+
+A conservative presentation profile should use:
+
+- `coverage: full`
+- an opaque appearance such as `bar` or another pixel-covering treatment
+- `reveal: never`
+- explicit private-term lenses
+
+The source can still exist in the DOM, browser accessibility tree, page serialization, developer tools, selection/copy behavior, or application state. Presentation mode therefore carries a **visible-output** guarantee, not a source-removal guarantee.
+
+## Screenshot-safe
+
+Screenshot-safe means: **for the tested rendered state, selected source text does not appear in the captured pixels.**
+
+That guarantee requires a pixel-covering appearance, full coverage for the selected terms, reveal disabled, and browser-level regression coverage for the intended capture environment. CSS failure, missing styles, a revealed state, or a different renderer can change the result.
+
+A screenshot-safe label must never imply that the source disappeared from the DOM or application data.
+
+## Assistive-tech-safe
+
+This is a separate policy. Current `CensoredText` deliberately exposes the exact source to assistive technology, so it does not satisfy assistive-tech-safe concealment.
+
+A future assistive-tech-safe renderer would need an explicit alternate accessibility value or omission policy and dedicated keyboard/screen-reader regressions. Applications should choose that behavior intentionally because withholding source from assistive technology changes the reading experience.
+
+## Sanitized export
+
+Sanitized export produces a **new output artifact** in which selected source substrings are replaced or removed.
+
+Example:
+
+```text
+source:    Project Velvet ships Friday to Acme Widgets.
+export:    [REDACTED] ships Friday to [REDACTED].
+```
+
+Once that plain-text export has been produced, the selected source terms are absent from that exported string. The original input can still exist in the application that performed the export; callers remain responsible for storage, logs, backups, clipboard history, and other copies outside Scrawlix.
+
+The public reusable packages do not currently expose a sanitized-export API. The demo includes a local proof of the operation so the contract can be pressure-tested before a package API is chosen.
+
+## Product vocabulary
+
+Use these terms consistently:
+
+- **cover** — reversible presentation over source text
+- **reveal** — expose source that was already retained
+- **presentation profile** — a visible-output configuration for sharing a screen
+- **screenshot-safe** — a tested pixel-output guarantee for a specific rendered state
+- **assistive-tech-safe** — an explicit policy that also withholds/replaces selected source in accessibility output
+- **sanitize / sanitized export** — create a new artifact with selected source removed or replaced
+
+Avoid calling ordinary CSS masking “secure redaction.” Reserve redaction/export language for APIs whose output contract says exactly where the source went.

--- a/tests/browser/privacy.spec.ts
+++ b/tests/browser/privacy.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test';
+
+const sourceText = 'Project Velvet ships Friday to Acme Widgets.';
+
+test('demo controls distinguish reversible covers from sanitized output', async ({ page }) => {
+  await page.goto('http://127.0.0.1:4173');
+
+  const lab = page.locator('[data-privacy-lab]');
+  const pixels = lab.locator('[data-privacy-pixels]');
+  const root = pixels.locator('[data-scrawlix-root]');
+  const covers = pixels.locator('[data-scrawlix-cover]');
+  const sanitized = lab.locator('[data-sanitized-output]');
+
+  await expect(lab).toBeVisible();
+  await expect(root).toHaveAttribute('data-reveal', 'never');
+  await expect(covers).toHaveCount(2);
+  expect(await covers.allTextContents()).toEqual(['Project Velvet', 'Acme Widgets']);
+
+  await expect(root.locator('[data-scrawlix-a11y]')).toHaveText(sourceText);
+  await expect(lab.locator('[data-privacy-a11y]')).toHaveText(sourceText);
+  await expect(lab.locator('[data-privacy-dom]')).toHaveText(sourceText);
+
+  await expect(sanitized).toHaveText('[REDACTED] ships Friday to [REDACTED].');
+  expect(await sanitized.textContent()).not.toContain('Project Velvet');
+  expect(await sanitized.textContent()).not.toContain('Acme Widgets');
+
+  await lab.getByLabel('Sanitized export replacement').fill('████');
+  await expect(sanitized).toHaveText('████ ships Friday to ████.');
+  expect(await sanitized.textContent()).not.toContain('Project Velvet');
+  expect(await sanitized.textContent()).not.toContain('Acme Widgets');
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - window.innerWidth
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
+});


### PR DESCRIPTION
## What

Defines clear product language for where Scrawlix source text survives, then makes the distinction visible in the demo.

- new `docs/privacy-and-output.md` with explicit guarantees for visual covers, presentation profiles, screenshot-safe states, assistive-tech-safe concealment, and sanitized export
- README/docs index links to that contract
- new demo **Output Lab** showing the same private sentence through four audiences:
  - presentation pixels — full bar coverage, `reveal="never"`
  - assistive technology — exact source retained by current React semantics
  - DOM/source — exact source retained for reversible presentation
  - sanitized export — a newly generated string with selected terms replaced
- sanitized export stays demo-local; no reusable package API is introduced yet

## Product boundary

A visual cover changes presentation. A sanitized export creates a different artifact.

The docs reserve `screenshot-safe` for tested pixel-output states and `assistive-tech-safe` for a future explicit accessibility policy. Ordinary CSS masking should never be sold as secure redaction.

## Validation

A Chromium demo smoke verifies:

- presentation mode renders two full, never-revealing covers
- the actual React accessibility copy still contains the exact source
- the explanatory DOM/source channels retain the exact source
- the sanitized output contains neither private term
- changing the replacement token recomputes the sanitized string without reintroducing source terms
- narrow layout stays inside a 390px viewport

Closes #31