### PR TITLE
Add explicit locale-aware term boundaries

### DIFF
--- a/docs/language-packs.md
+++ b/docs/language-packs.md
@@ -54,21 +54,28 @@ Raw regex rules and custom matchers keep their own matching policy. Core validat
 
 ## Boundaries
 
-`censorRuleFromTerms()` defaults to `boundary: 'word'`, using Unicode-aware lookarounds. Letters, numbers, combining marks, connector punctuation, ZWNJ, and ZWJ keep a candidate attached to surrounding text. This prevents a boundary from appearing inside many decomposed or connected Unicode sequences while still blocking ordinary substring false positives.
+`censorRuleFromTerms()` supports explicit boundary strategies:
 
-Some scripts and phrase lists need direct substring matching:
+- `word` — compatibility spelling for the existing Unicode-aware word-context rule
+- `unicode-word` — the same behavior under its descriptive name; letters, numbers, combining marks, connector punctuation, ZWNJ, and ZWJ keep adjacent text connected
+- `substring` — direct adjacency is accepted
+- `{ mode: 'locale-word', locale: ... }` — candidate edges must coincide with `Intl.Segmenter` word-like segment edges for the locale selected by the pack or caller
+
+For locale-sensitive matching, select the locale explicitly:
 
 ```ts
-import { censorRuleFromTerms } from '@scrawlix/core';
-
-const rule = censorRuleFromTerms('ja-example', ['くそ'], {
-  boundary: 'substring',
+const japaneseRule = censorRuleFromTerms('ja-example', ['くそ'], {
+  boundary: { mode: 'locale-word', locale: 'ja' },
 });
 ```
 
-`substring` means exactly that: a listed phrase may match while adjacent to other letters. A language pack should choose it deliberately and carry regression cases that demonstrate expected behavior.
+With current `Intl.Segmenter` behavior, `くそ` is a lexical segment in `これはくそだ`, while the same characters do not form the same complete segment inside `これはくそったれだ`. A `substring` rule intentionally matches both.
 
-Future packs may need richer tokenization than either mode. Add that capability when a real corpus demonstrates the need; keep the simple path small.
+Locale segmentation also gives punctuation conventions a concrete owner. In English, an apostrophe keeps `don't` together, a hyphen separates the words in `foo-bar`, an underscore keeps `foo_bar` together, and join controls remain attached to their surrounding word. Packs should carry regression cases for the conventions they depend on instead of assuming one universal token model.
+
+Thai and Lao examples are covered in core regressions using explicit `th` and `lo` segmenters. Those cases prove the API path and the runtime's segmentation behavior; a production language pack still needs its own corpus, scope notes, and review before claiming linguistic coverage.
+
+Locale selection is pack/application policy. Scrawlix does not infer a language from the input. A custom matcher remains the escape hatch when a pack needs boundaries beyond these strategies.
 
 ## Semantic targets
 

--- a/packages/core/src/boundary.test.ts
+++ b/packages/core/src/boundary.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import { censorRuleFromTerms, createScrawlix } from './index';
+
+function texts(engine: ReturnType<typeof createScrawlix>, text: string) {
+  return engine.find(text).map(match => match.text);
+}
+
+describe('term boundary strategies', () => {
+  it('keeps word as a compatibility spelling for unicode-word', () => {
+    const legacy = createScrawlix({
+      rules: [censorRuleFromTerms('legacy', ['bad'], { boundary: 'word' })],
+    });
+    const explicit = createScrawlix({
+      rules: [
+        censorRuleFromTerms('explicit', ['bad'], {
+          boundary: 'unicode-word',
+        }),
+      ],
+    });
+
+    for (const text of ['bad', 'badly', 'bad‿word', 'bad-word', '(bad)']) {
+      expect(texts(legacy, text).map(() => 'bad')).toEqual(
+        texts(explicit, text).map(() => 'bad')
+      );
+    }
+  });
+
+  it('uses Japanese lexical boundaries when locale-word is selected', () => {
+    const localeWord = createScrawlix({
+      rules: [
+        censorRuleFromTerms('ja', ['くそ'], {
+          boundary: { mode: 'locale-word', locale: 'ja' },
+        }),
+      ],
+    });
+    const substring = createScrawlix({
+      rules: [
+        censorRuleFromTerms('ja', ['くそ'], {
+          boundary: 'substring',
+        }),
+      ],
+    });
+
+    expect(texts(localeWord, 'これはくそだ')).toEqual(['くそ']);
+    expect(texts(localeWord, 'これはくそったれだ')).toEqual([]);
+    expect(texts(substring, 'これはくそったれだ')).toEqual(['くそ']);
+  });
+
+  it('treats apostrophes and join controls as part of locale words', () => {
+    const localeDon = createScrawlix({
+      rules: [
+        censorRuleFromTerms('don', ['don'], {
+          boundary: { mode: 'locale-word', locale: 'en' },
+        }),
+      ],
+    });
+    const unicodeDon = createScrawlix({
+      rules: [
+        censorRuleFromTerms('don', ['don'], {
+          boundary: 'unicode-word',
+        }),
+      ],
+    });
+    const localeA = createScrawlix({
+      rules: [
+        censorRuleFromTerms('a', ['a'], {
+          boundary: { mode: 'locale-word', locale: 'en' },
+        }),
+      ],
+    });
+
+    expect(texts(localeDon, "don't")).toEqual([]);
+    expect(texts(unicodeDon, "don't")).toEqual(['don']);
+    expect(texts(localeA, 'a\u200Cb')).toEqual([]);
+  });
+
+  it('treats hyphens as lexical breaks and underscores as connected word text', () => {
+    const localeBar = createScrawlix({
+      rules: [
+        censorRuleFromTerms('bar', ['bar'], {
+          boundary: { mode: 'locale-word', locale: 'en' },
+        }),
+      ],
+    });
+    const localeFoo = createScrawlix({
+      rules: [
+        censorRuleFromTerms('foo', ['foo'], {
+          boundary: { mode: 'locale-word', locale: 'en' },
+        }),
+      ],
+    });
+
+    expect(texts(localeBar, 'foo-bar')).toEqual(['bar']);
+    expect(texts(localeFoo, 'foo_bar')).toEqual([]);
+    expect(texts(localeFoo, '(foo)')).toEqual(['foo']);
+  });
+
+  it('supports locale-selected Thai and Lao word segmentation', () => {
+    const thai = createScrawlix({
+      rules: [
+        censorRuleFromTerms('th', ['ไทย'], {
+          boundary: { mode: 'locale-word', locale: 'th' },
+        }),
+      ],
+    });
+    const lao = createScrawlix({
+      rules: [
+        censorRuleFromTerms('lo', ['ລາວ'], {
+          boundary: { mode: 'locale-word', locale: 'lo' },
+        }),
+      ],
+    });
+
+    expect(texts(thai, 'ภาษาไทยดี')).toEqual(['ไทย']);
+    expect(texts(lao, 'ພາສາລາວດີ')).toEqual(['ລາວ']);
+  });
+
+  it('preserves original NFC/NFD source ranges with locale-word matching', () => {
+    const source = 'cafe\u0301';
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromTerms('cafe', ['café'], {
+          boundary: { mode: 'locale-word', locale: 'en' },
+        }),
+      ],
+    });
+
+    expect(engine.find(source)).toEqual([
+      {
+        ruleId: 'cafe',
+        text: source,
+        start: 0,
+        end: source.length,
+        targetText: source,
+        targetStart: 0,
+        targetEnd: source.length,
+      },
+    ]);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,7 +67,12 @@ export type CensorRulePack = {
   rules: readonly CensorRule[];
 };
 
-export type WordBoundaryMode = 'word' | 'substring';
+export type WordBoundaryMode = 'word' | 'unicode-word' | 'substring';
+export type LocaleWordBoundary = {
+  mode: 'locale-word';
+  locale: string | readonly string[];
+};
+export type TermBoundaryStrategy = WordBoundaryMode | LocaleWordBoundary;
 export type UnicodeNormalization = 'none' | 'NFC';
 
 export type ScrawlixMatch = {
@@ -609,9 +614,9 @@ function segmentFromRanges(text: string, ranges: readonly CoveredRange[]) {
   return segments;
 }
 
-function normalizedShadow(
+function sourceShadow(
   value: string,
-  normalization: Exclude<UnicodeNormalization, 'none'>
+  normalization: UnicodeNormalization
 ): NormalizedShadow {
   let shadow = '';
   const sourceOffsets = new Map<number, number>([[0, 0]]);
@@ -619,32 +624,64 @@ function normalizedShadow(
   for (const range of graphemeRanges(value)) {
     const shadowStart = shadow.length;
     sourceOffsets.set(shadowStart, range.start);
-    shadow += value.slice(range.start, range.end).normalize(normalization);
+    const sourceGrapheme = value.slice(range.start, range.end);
+    shadow +=
+      normalization === 'none'
+        ? sourceGrapheme
+        : sourceGrapheme.normalize(normalization);
     sourceOffsets.set(shadow.length, range.end);
   }
 
   return { value: shadow, sourceOffsets };
 }
 
+function isUnicodeWordBoundary(
+  boundary: TermBoundaryStrategy
+): boundary is 'word' | 'unicode-word' {
+  return boundary === 'word' || boundary === 'unicode-word';
+}
+
 function termPatternSource(
   alternatives: readonly string[],
-  boundary: WordBoundaryMode
+  boundary: TermBoundaryStrategy
 ) {
   const source = `(?:${alternatives.map(escapeRegExp).join('|')})`;
-  return boundary === 'word'
+  return isUnicodeWordBoundary(boundary)
     ? `(?<![${wordContextClass}])${source}(?![${wordContextClass}])`
     : source;
 }
 
-function normalizedTermMatcher(
+function localeWordBoundaries(value: string, boundary: LocaleWordBoundary) {
+  const locales =
+    typeof boundary.locale === 'string'
+      ? boundary.locale
+      : [...boundary.locale];
+  const segmenter = new Intl.Segmenter(locales, { granularity: 'word' });
+  const boundaries = new Set<number>();
+
+  for (const part of segmenter.segment(value)) {
+    if (!part.isWordLike) continue;
+    boundaries.add(part.index);
+    boundaries.add(part.index + part.segment.length);
+  }
+
+  return boundaries;
+}
+
+function termMatcher(
   patternSource: string,
   caseSensitive: boolean,
-  normalization: Exclude<UnicodeNormalization, 'none'>
+  normalization: UnicodeNormalization,
+  boundary: TermBoundaryStrategy
 ): CensorMatcher {
   return {
     *find(text) {
-      const shadow = normalizedShadow(text, normalization);
+      const shadow = sourceShadow(text, normalization);
       const pattern = new RegExp(patternSource, caseSensitive ? 'gu' : 'giu');
+      const lexicalBoundaries =
+        typeof boundary === 'object'
+          ? localeWordBoundaries(shadow.value, boundary)
+          : null;
       let match: RegExpExecArray | null;
 
       while ((match = pattern.exec(shadow.value)) !== null) {
@@ -657,8 +694,16 @@ function normalizedTermMatcher(
           continue;
         }
 
+        const shadowEnd = match.index + match[0].length;
+        if (
+          lexicalBoundaries &&
+          (!lexicalBoundaries.has(match.index) || !lexicalBoundaries.has(shadowEnd))
+        ) {
+          continue;
+        }
+
         const start = shadow.sourceOffsets.get(match.index);
-        const end = shadow.sourceOffsets.get(match.index + match[0].length);
+        const end = shadow.sourceOffsets.get(shadowEnd);
         if (start === undefined || end === undefined) continue;
         yield { start, end };
       }
@@ -677,7 +722,7 @@ export function censorRuleFromTerms(
   }: {
     caseSensitive?: boolean;
     coverage?: CoverageSelector;
-    boundary?: WordBoundaryMode;
+    boundary?: TermBoundaryStrategy;
     normalization?: UnicodeNormalization;
   } = {}
 ): CensorRule {
@@ -695,7 +740,7 @@ export function censorRuleFromTerms(
   }
 
   const patternSource = termPatternSource(alternatives, boundary);
-  if (normalization === 'none') {
+  if (normalization === 'none' && typeof boundary === 'string') {
     return {
       id,
       coverage,
@@ -706,7 +751,7 @@ export function censorRuleFromTerms(
   return {
     id,
     coverage,
-    matcher: normalizedTermMatcher(patternSource, caseSensitive, normalization),
+    matcher: termMatcher(patternSource, caseSensitive, normalization, boundary),
   };
 }
 


### PR DESCRIPTION
## Summary
Implement the first concrete boundary-strategy slice from #36.

- keep `boundary: 'word'` as a compatibility spelling
- add the descriptive `boundary: 'unicode-word'` spelling for the existing Unicode word-context behavior
- add `{ mode: 'locale-word', locale }` using caller/pack-selected `Intl.Segmenter` word segmentation
- keep `substring` as the explicit adjacency-allowed mode
- run locale segmentation against the canonical shadow text so NFC/NFD matching still maps to exact original-source ranges
- add Japanese cases where locale segmentation and substring behavior materially differ
- pin English apostrophe, hyphen, underscore, punctuation, and join-control behavior
- add explicit Thai and Lao segmentation fixtures without claiming complete language-pack coverage
- document locale selection as pack/application policy rather than automatic language detection

## Locale-word contract
A candidate is accepted when both candidate edges coincide with the edges of `Intl.Segmenter(..., { granularity: 'word' })` word-like segments for the selected locale. Multi-word/compound terms can span intervening punctuation or separators when their outer edges remain lexical boundaries.

Custom `CensorMatcher` rules remain the escape hatch for pack-owned tokenization beyond these built-in strategies.

Progress on #36
Related: #35, #33