### PR TITLE
Expose named match profiles in core metadata

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -45,18 +45,36 @@ const scrawlix = createScrawlix({ rules: [privateTerms] });
 
 `censorRuleFromTerms()` uses Unicode-aware word boundaries and NFC canonical equivalence by default. A term such as `café` therefore matches both NFC `café` and NFD `cafe\u0301`, while `find()` still returns the exact spelling and UTF-16 range from the original source.
 
-Use `{ boundary: 'substring' }` deliberately for packs/scripts where adjacent letters are valid. Use `{ normalization: 'none' }` when a rule intentionally distinguishes canonically equivalent source forms.
+Use `{ boundary: 'substring' }` deliberately for packs/scripts where adjacent letters are valid. Use `boundary: 'unicode-word'` when you want to name the default Unicode word-context behavior explicitly, or `{ boundary: { mode: 'locale-word', locale: 'ja' } }` when the pack owns a locale-specific lexical segmentation choice. Use `{ normalization: 'none' }` when a rule intentionally distinguishes canonically equivalent source forms.
 
 Core requires `Intl.Segmenter` and exports `graphemeRanges()` so language-specific coverage helpers can share the same extended-grapheme boundaries as matching and segmentation.
+
+## Match profiles
+
+Rules can carry an optional `profile` string. `find()` exposes it as `match.profile`, and coverage callbacks receive the same value in their context. This lets packs distinguish conservative and aggressive matching paths in diagnostics and policy code.
+
+`censorRuleFromTerms()` labels its rules `canonical` by default:
+
+```ts
+const canonical = censorRuleFromTerms('private', ['Project Velvet']);
+
+const obfuscatedRule = {
+  id: 'private-obfuscated',
+  profile: 'obfuscated',
+  matcher: mySourceMappedMatcher,
+};
+```
+
+Profile names describe the matching path; they do not alter matching on their own. A pack that implements an obfuscated profile still owns its transforms, budgets, source mapping, and regression negatives.
 
 ## Public concepts
 
 - **matching** finds a term or phrase
 - **coverage** chooses which part of the semantic target is covered
-- `find(text)` returns semantic match metadata
+- `find(text)` returns semantic match metadata, including optional pack/profile provenance
 - `segment(text)` returns source-preserving covered/uncovered segments
 - generic coverage presets are `full`, `tail`, `middle`, and `inner`
-- literal/custom-term matching defaults to NFC canonical equivalence
+- literal/custom-term matching defaults to NFC canonical equivalence and `profile: 'canonical'`
 - every exposed match, target, and covered segment respects extended-grapheme boundaries
 
 Scrawlix deliberately has no built-in language or hidden profanity list. Callers select rules explicitly.

--- a/packages/core/src/boundary.test.ts
+++ b/packages/core/src/boundary.test.ts
@@ -128,6 +128,7 @@ describe('term boundary strategies', () => {
     expect(engine.find(source)).toEqual([
       {
         ruleId: 'cafe',
+        profile: 'canonical',
         text: source,
         start: 0,
         end: source.length,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export type RelativeRange = {
 export type CoverageContext = {
   ruleId: string;
   packId?: string;
+  profile?: string;
   matchText: string;
   targetText: string;
   matchStart: number;
@@ -42,6 +43,8 @@ export type CensorMatcher = {
 
 type CensorRuleBase = {
   id: string;
+  /** Named matching profile for debug/provenance, e.g. canonical or obfuscated. */
+  profile?: string;
   coverage?: CoverageSelector;
   /** Pack provenance attached by rulesFromPacks(). */
   packId?: string;
@@ -78,6 +81,7 @@ export type UnicodeNormalization = 'none' | 'NFC';
 export type ScrawlixMatch = {
   ruleId: string;
   packId?: string;
+  profile?: string;
   text: string;
   start: number;
   end: number;
@@ -322,6 +326,7 @@ function scannedMatchFromRange(
     match: {
       ruleId: rule.id,
       ...(rule.packId ? { packId: rule.packId } : {}),
+      ...(rule.profile ? { profile: rule.profile } : {}),
       text: text.slice(start, end),
       start,
       end,
@@ -529,6 +534,7 @@ function collectCoveredRanges(
     const context: CoverageContext = {
       ruleId: match.ruleId,
       ...(match.packId ? { packId: match.packId } : {}),
+      ...(match.profile ? { profile: match.profile } : {}),
       matchText: match.text,
       targetText: match.targetText,
       matchStart: match.start,
@@ -719,11 +725,13 @@ export function censorRuleFromTerms(
     coverage,
     boundary = 'word',
     normalization = 'NFC',
+    profile = 'canonical',
   }: {
     caseSensitive?: boolean;
     coverage?: CoverageSelector;
     boundary?: TermBoundaryStrategy;
     normalization?: UnicodeNormalization;
+    profile?: string;
   } = {}
 ): CensorRule {
   const preparedTerms = terms.map(term => term.trim()).filter(Boolean);
@@ -743,6 +751,7 @@ export function censorRuleFromTerms(
   if (normalization === 'none' && typeof boundary === 'string') {
     return {
       id,
+      profile,
       coverage,
       pattern: new RegExp(patternSource, caseSensitive ? 'gu' : 'giu'),
     };
@@ -750,6 +759,7 @@ export function censorRuleFromTerms(
 
   return {
     id,
+    profile,
     coverage,
     matcher: termMatcher(patternSource, caseSensitive, normalization, boundary),
   };

--- a/packages/core/src/profile.test.ts
+++ b/packages/core/src/profile.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  censorRuleFromTerms,
+  createScrawlix,
+  rulesFromPacks,
+  type CoverageContext,
+} from './index';
+
+describe('match profile metadata', () => {
+  it('labels term-helper matches as canonical by default', () => {
+    const engine = createScrawlix({
+      rules: [censorRuleFromTerms('term', ['café'])],
+    });
+
+    expect(engine.find('cafe\u0301')[0]).toMatchObject({
+      ruleId: 'term',
+      profile: 'canonical',
+      text: 'cafe\u0301',
+    });
+  });
+
+  it('allows a term rule to expose a caller-selected profile name', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromTerms('term', ['secret'], {
+          profile: 'private-canonical',
+        }),
+      ],
+    });
+
+    expect(engine.find('secret')[0]?.profile).toBe('private-canonical');
+  });
+
+  it('propagates an obfuscated custom-matcher profile through matches and coverage', () => {
+    let coverageContext: CoverageContext | undefined;
+    const pack = {
+      id: 'example-pack',
+      rules: [
+        {
+          id: 'leet-example',
+          profile: 'obfuscated',
+          matcher: {
+            find(text: string) {
+              const start = text.indexOf('b4d');
+              return start < 0 ? [] : [{ start, end: start + 3 }];
+            },
+          },
+          coverage(context: CoverageContext) {
+            coverageContext = context;
+            return [{ start: 0, end: context.targetText.length }];
+          },
+        },
+      ],
+    } as const;
+    const engine = createScrawlix({ rules: rulesFromPacks(pack) });
+
+    expect(engine.find('very b4d')[0]).toMatchObject({
+      packId: 'example-pack',
+      ruleId: 'leet-example',
+      profile: 'obfuscated',
+      text: 'b4d',
+    });
+
+    engine.segment('very b4d');
+    expect(coverageContext).toMatchObject({
+      packId: 'example-pack',
+      ruleId: 'leet-example',
+      profile: 'obfuscated',
+      matchText: 'b4d',
+      targetText: 'b4d',
+    });
+  });
+
+  it('keeps profile optional for caller-authored rules', () => {
+    const engine = createScrawlix({
+      rules: [{ id: 'plain', pattern: /plain/u }],
+    });
+
+    expect(engine.find('plain')[0]).toEqual({
+      ruleId: 'plain',
+      text: 'plain',
+      start: 0,
+      end: 5,
+      targetText: 'plain',
+      targetStart: 0,
+      targetEnd: 5,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Add the observability layer required for explicit canonical/obfuscated matching profiles.

- add optional `profile` metadata to every `CensorRule`
- expose `profile` on `ScrawlixMatch`
- expose the same profile in `CoverageContext`
- make `censorRuleFromTerms()` use `profile: 'canonical'` by default, with an override for narrower caller-defined profile names
- preserve profile metadata alongside `packId` through composed packs
- regression-test a custom matcher tagged `obfuscated` through both `find()` and coverage
- keep profile optional for ordinary caller-authored regex rules
- document profiles as descriptive provenance rather than behavior-changing switches

This deliberately does not add aggressive transforms yet. A future obfuscated matcher can now be audited through match/debug metadata while keeping transform policy pack-owned.

Progress on #38