### PR TITLE
Add reviewable corpus behavior diffs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
           version: 10.34.5
@@ -16,6 +18,9 @@ jobs:
         with:
           node-version: 22
       - run: pnpm install --frozen-lockfile
+      - name: Corpus behavior diff
+        if: github.event_name == 'pull_request'
+        run: pnpm corpus:diff -- "${{ github.event.pull_request.base.sha }}" HEAD
       - run: pnpm typecheck
       - run: pnpm test
       - run: pnpm build

--- a/docs/language-packs.md
+++ b/docs/language-packs.md
@@ -159,7 +159,25 @@ Run corpus validation with:
 pnpm validate:corpora
 ```
 
-The workspace test command runs that validation before package tests. `@scrawlix/en/corpus` remains the public JavaScript export; the English implementation imports the validated JSON so its tests and public corpus consume the same source data.
+The workspace test command runs that validation plus the corpus-tool unit tests before package tests. `@scrawlix/en/corpus` remains the public JavaScript export; the English implementation imports the validated JSON so its tests and public corpus consume the same source data.
+
+### Review corpus deltas
+
+Use `corpus:diff` to compare the expected corpus behavior between a Git ref and the working tree:
+
+```sh
+pnpm corpus:diff -- main
+```
+
+Or compare two committed refs:
+
+```sh
+pnpm corpus:diff -- main HEAD
+```
+
+Add `--json` for machine-readable output. The diff joins cases by package plus stable case id and classifies newly matching, newly clean, changed semantic target, changed full match, added clean regression, removed case, and metadata-only changes. The command is informational and exits successfully when it finds intentional behavioral changes.
+
+Pull-request CI runs the same command against the PR's exact base SHA and prints the report before the test suite. Checkout uses full git history so the comparison is reproducible from the workflow log.
 
 Useful corpora contain positive matches, semantic targets, casing and punctuation variants, compounds and inflections, false-positive traps, Unicode context, and dialect or severity cases when relevant. Every matcher expansion should ideally arrive with the newly caught form plus plausible clean neighbors that could regress.
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "build": "pnpm build:packages && pnpm --filter scrawlix-demo build && pnpm --filter scrawlix-extension build",
     "build:packages": "pnpm --filter @scrawlix/core build && pnpm --filter @scrawlix/en build && pnpm --filter @scrawlix/react build && pnpm --filter @scrawlix/rehype build && pnpm --filter @scrawlix/dom build",
+    "corpus:diff": "node scripts/diff-corpora.mjs",
     "dev": "pnpm --filter scrawlix-demo dev",
     "smoke:packages": "node scripts/smoke-packages.mjs",
-    "test": "pnpm validate:corpora && pnpm build:packages && pnpm -r --if-present test",
+    "test": "pnpm validate:corpora && node --test scripts/*.test.mjs && pnpm build:packages && pnpm -r --if-present test",
     "test:browser": "playwright test -c playwright.config.ts",
     "test:browser:demo": "playwright test -c playwright.config.ts -g \"demo controls\"",
     "test:browser:extension": "playwright test -c playwright.config.ts -g \"built extension\"",

--- a/scripts/corpus-diff-lib.mjs
+++ b/scripts/corpus-diff-lib.mjs
@@ -1,0 +1,191 @@
+const stableJson = value => JSON.stringify(value);
+
+function matchSnapshot(matches) {
+  return matches.map(match => ({
+    ruleId: match.ruleId,
+    ...(match.packId === undefined ? {} : { packId: match.packId }),
+    ...(match.entryId === undefined ? {} : { entryId: match.entryId }),
+    text: match.text,
+    start: match.start,
+    end: match.end,
+    targetText: match.targetText,
+    targetStart: match.targetStart,
+    targetEnd: match.targetEnd,
+  }));
+}
+
+function targetSnapshot(matches) {
+  return matches.map(match => ({
+    ruleId: match.ruleId,
+    ...(match.packId === undefined ? {} : { packId: match.packId }),
+    ...(match.entryId === undefined ? {} : { entryId: match.entryId }),
+    targetText: match.targetText,
+    targetStart: match.targetStart,
+    targetEnd: match.targetEnd,
+  }));
+}
+
+function metadataSnapshot(corpusCase) {
+  return {
+    text: corpusCase.text,
+    profile: corpusCase.profile,
+    tags: corpusCase.tags ?? [],
+    ...(corpusCase.note === undefined ? {} : { note: corpusCase.note }),
+    ...(corpusCase.provenance === undefined
+      ? {}
+      : { provenance: corpusCase.provenance }),
+  };
+}
+
+function summarizedCase(record) {
+  if (!record) return null;
+  return {
+    packageName: record.packageName,
+    file: record.file,
+    id: record.corpusCase.id,
+    profile: record.corpusCase.profile,
+    text: record.corpusCase.text,
+    matches: matchSnapshot(record.corpusCase.matches),
+  };
+}
+
+export function indexCorpusDocuments(documents) {
+  const indexed = new Map();
+
+  for (const document of documents) {
+    for (const corpusCase of document.cases) {
+      const key = `${document.packageName}:${corpusCase.id}`;
+      if (indexed.has(key)) {
+        throw new Error(`Duplicate corpus case key while diffing: ${key}`);
+      }
+      indexed.set(key, {
+        packageName: document.packageName,
+        file: document.file,
+        corpusCase,
+      });
+    }
+  }
+
+  return indexed;
+}
+
+export function diffCorpusDocuments(baseDocuments, headDocuments) {
+  const base = indexCorpusDocuments(baseDocuments);
+  const head = indexCorpusDocuments(headDocuments);
+  const keys = [...new Set([...base.keys(), ...head.keys()])].sort();
+  const diff = {
+    newlyMatching: [],
+    newlyClean: [],
+    changedTarget: [],
+    changedMatch: [],
+    addedClean: [],
+    removed: [],
+    metadataOnly: [],
+  };
+
+  for (const key of keys) {
+    const before = base.get(key);
+    const after = head.get(key);
+
+    if (!before && after) {
+      const item = { key, before: null, after: summarizedCase(after) };
+      if (after.corpusCase.matches.length > 0) diff.newlyMatching.push(item);
+      else diff.addedClean.push(item);
+      continue;
+    }
+
+    if (before && !after) {
+      diff.removed.push({ key, before: summarizedCase(before), after: null });
+      continue;
+    }
+
+    const beforeCase = before.corpusCase;
+    const afterCase = after.corpusCase;
+    const beforeMatches = matchSnapshot(beforeCase.matches);
+    const afterMatches = matchSnapshot(afterCase.matches);
+    const beforeHasMatches = beforeMatches.length > 0;
+    const afterHasMatches = afterMatches.length > 0;
+    const item = {
+      key,
+      before: summarizedCase(before),
+      after: summarizedCase(after),
+    };
+
+    if (!beforeHasMatches && afterHasMatches) {
+      diff.newlyMatching.push(item);
+      continue;
+    }
+    if (beforeHasMatches && !afterHasMatches) {
+      diff.newlyClean.push(item);
+      continue;
+    }
+
+    if (stableJson(beforeMatches) !== stableJson(afterMatches)) {
+      if (
+        stableJson(targetSnapshot(beforeCase.matches)) !==
+        stableJson(targetSnapshot(afterCase.matches))
+      ) {
+        diff.changedTarget.push(item);
+      } else {
+        diff.changedMatch.push(item);
+      }
+      continue;
+    }
+
+    if (
+      stableJson(metadataSnapshot(beforeCase)) !==
+      stableJson(metadataSnapshot(afterCase)) ||
+      before.file !== after.file
+    ) {
+      diff.metadataOnly.push(item);
+    }
+  }
+
+  return diff;
+}
+
+export function corpusDiffCount(diff) {
+  return Object.values(diff).reduce((count, items) => count + items.length, 0);
+}
+
+const sectionDefinitions = [
+  ['newlyMatching', 'Newly matching'],
+  ['newlyClean', 'Newly clean'],
+  ['changedTarget', 'Changed semantic target'],
+  ['changedMatch', 'Changed full match'],
+  ['addedClean', 'Added clean regression'],
+  ['removed', 'Removed corpus case'],
+  ['metadataOnly', 'Metadata-only change'],
+];
+
+function describeSide(side) {
+  if (!side) return '∅';
+  const matches = side.matches.length === 0
+    ? 'clean'
+    : side.matches
+        .map(match =>
+          `${match.ruleId}:${JSON.stringify(match.text)}→${JSON.stringify(match.targetText)}@[${match.start},${match.end})/[${match.targetStart},${match.targetEnd})`
+        )
+        .join(', ');
+  return `${side.profile} ${JSON.stringify(side.text)} (${matches})`;
+}
+
+export function formatCorpusDiff(diff, { baseLabel = 'base', headLabel = 'head' } = {}) {
+  const total = corpusDiffCount(diff);
+  const lines = [`Corpus diff: ${baseLabel} → ${headLabel}`, `${total} changed case${total === 1 ? '' : 's'}.`];
+
+  if (total === 0) return lines.join('\n');
+
+  for (const [key, title] of sectionDefinitions) {
+    const items = diff[key];
+    if (items.length === 0) continue;
+    lines.push('', `${title} (${items.length})`);
+    for (const item of items) {
+      lines.push(`- ${item.key}`);
+      lines.push(`  ${baseLabel}: ${describeSide(item.before)}`);
+      lines.push(`  ${headLabel}: ${describeSide(item.after)}`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/scripts/corpus-diff-lib.test.mjs
+++ b/scripts/corpus-diff-lib.test.mjs
@@ -53,7 +53,11 @@ test('classifies behavioral and metadata corpus deltas', () => {
     corpusCase({ id: 'becomes-match' }),
     corpusCase({ id: 'becomes-clean', matches: [match()] }),
     corpusCase({ id: 'target-change', matches: [match()] }),
-    corpusCase({ id: 'match-change', matches: [match()] }),
+    corpusCase({
+      id: 'match-change',
+      text: 'bad!',
+      matches: [match({ targetText: 'bad', targetStart: 0, targetEnd: 3 })],
+    }),
     corpusCase({ id: 'metadata', matches: [match()] }),
     corpusCase({ id: 'removed', matches: [match()] }),
   ]);
@@ -66,8 +70,17 @@ test('classifies behavioral and metadata corpus deltas', () => {
     }),
     corpusCase({
       id: 'match-change',
-      text: 'x bad',
-      matches: [match({ start: 2, end: 5, targetStart: 2, targetEnd: 5 })],
+      text: 'bad!',
+      matches: [
+        match({
+          text: 'bad!',
+          start: 0,
+          end: 4,
+          targetText: 'bad',
+          targetStart: 0,
+          targetEnd: 3,
+        }),
+      ],
     }),
     corpusCase({ id: 'metadata', tags: ['unicode'], matches: [match()] }),
     corpusCase({ id: 'added-positive', matches: [match()] }),

--- a/scripts/corpus-diff-lib.test.mjs
+++ b/scripts/corpus-diff-lib.test.mjs
@@ -105,7 +105,7 @@ test('classifies behavioral and metadata corpus deltas', () => {
   assert.deepEqual(diff.addedClean.map(item => item.key), ['example:added-clean']);
   assert.deepEqual(diff.removed.map(item => item.key), ['example:removed']);
   assert.deepEqual(diff.metadataOnly.map(item => item.key), ['example:metadata']);
-  assert.equal(corpusDiffCount(diff), 7);
+  assert.equal(corpusDiffCount(diff), 8);
 
   const output = formatCorpusDiff(diff, { baseLabel: 'main', headLabel: 'HEAD' });
   assert.match(output, /Corpus diff: main → HEAD/);

--- a/scripts/corpus-diff-lib.test.mjs
+++ b/scripts/corpus-diff-lib.test.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  corpusDiffCount,
+  diffCorpusDocuments,
+  formatCorpusDiff,
+} from './corpus-diff-lib.mjs';
+
+const match = ({
+  ruleId = 'rule',
+  text = 'bad',
+  start = 0,
+  end = 3,
+  targetText = text,
+  targetStart = start,
+  targetEnd = end,
+} = {}) => ({
+  ruleId,
+  text,
+  start,
+  end,
+  targetText,
+  targetStart,
+  targetEnd,
+});
+
+const corpusCase = ({
+  id,
+  text = 'bad',
+  profile = 'canonical',
+  tags = [],
+  matches = [],
+  note,
+}) => ({
+  id,
+  text,
+  profile,
+  tags,
+  matches,
+  ...(note === undefined ? {} : { note }),
+});
+
+const docs = cases => [
+  {
+    packageName: 'example',
+    file: 'packages/example/src/corpus-data/cases.json',
+    cases,
+  },
+];
+
+test('classifies behavioral and metadata corpus deltas', () => {
+  const base = docs([
+    corpusCase({ id: 'becomes-match' }),
+    corpusCase({ id: 'becomes-clean', matches: [match()] }),
+    corpusCase({ id: 'target-change', matches: [match()] }),
+    corpusCase({ id: 'match-change', matches: [match()] }),
+    corpusCase({ id: 'metadata', matches: [match()] }),
+    corpusCase({ id: 'removed', matches: [match()] }),
+  ]);
+  const head = docs([
+    corpusCase({ id: 'becomes-match', matches: [match()] }),
+    corpusCase({ id: 'becomes-clean' }),
+    corpusCase({
+      id: 'target-change',
+      matches: [match({ targetText: 'ad', targetStart: 1, targetEnd: 3 })],
+    }),
+    corpusCase({
+      id: 'match-change',
+      text: 'x bad',
+      matches: [match({ start: 2, end: 5, targetStart: 2, targetEnd: 5 })],
+    }),
+    corpusCase({ id: 'metadata', tags: ['unicode'], matches: [match()] }),
+    corpusCase({ id: 'added-positive', matches: [match()] }),
+    corpusCase({ id: 'added-clean' }),
+  ]);
+
+  const diff = diffCorpusDocuments(base, head);
+
+  assert.deepEqual(diff.newlyMatching.map(item => item.key), [
+    'example:added-positive',
+    'example:becomes-match',
+  ]);
+  assert.deepEqual(diff.newlyClean.map(item => item.key), [
+    'example:becomes-clean',
+  ]);
+  assert.deepEqual(diff.changedTarget.map(item => item.key), [
+    'example:target-change',
+  ]);
+  assert.deepEqual(diff.changedMatch.map(item => item.key), [
+    'example:match-change',
+  ]);
+  assert.deepEqual(diff.addedClean.map(item => item.key), ['example:added-clean']);
+  assert.deepEqual(diff.removed.map(item => item.key), ['example:removed']);
+  assert.deepEqual(diff.metadataOnly.map(item => item.key), ['example:metadata']);
+  assert.equal(corpusDiffCount(diff), 7);
+
+  const output = formatCorpusDiff(diff, { baseLabel: 'main', headLabel: 'HEAD' });
+  assert.match(output, /Corpus diff: main → HEAD/);
+  assert.match(output, /Newly matching \(2\)/);
+  assert.match(output, /Changed semantic target \(1\)/);
+  assert.match(output, /Added clean regression \(1\)/);
+});
+
+test('reports an empty diff cleanly', () => {
+  const current = docs([corpusCase({ id: 'same', matches: [match()] })]);
+  const diff = diffCorpusDocuments(current, current);
+
+  assert.equal(corpusDiffCount(diff), 0);
+  assert.equal(
+    formatCorpusDiff(diff, { baseLabel: 'main', headLabel: 'HEAD' }),
+    'Corpus diff: main → HEAD\n0 changed cases.'
+  );
+});
+
+test('rejects duplicate package/case identities', () => {
+  assert.throws(
+    () =>
+      diffCorpusDocuments(
+        docs([corpusCase({ id: 'dup' }), corpusCase({ id: 'dup' })]),
+        []
+      ),
+    /Duplicate corpus case key while diffing: example:dup/
+  );
+});

--- a/scripts/diff-corpora.mjs
+++ b/scripts/diff-corpora.mjs
@@ -1,0 +1,128 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import {
+  corpusDiffCount,
+  diffCorpusDocuments,
+  formatCorpusDiff,
+} from './corpus-diff-lib.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const packagesRoot = path.join(root, 'packages');
+const corpusPathPattern = /^packages\/([^/]+)\/src\/corpus-data\/([^/]+\.json)$/;
+
+function runGit(args) {
+  const result = spawnSync('git', args, {
+    cwd: root,
+    encoding: 'utf8',
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim();
+    throw new Error(`git ${args.join(' ')} failed${detail ? `: ${detail}` : ''}`);
+  }
+  return result.stdout;
+}
+
+async function exists(file) {
+  try {
+    await fs.access(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readWorktreeDocuments() {
+  const documents = [];
+
+  for (const packageEntry of await fs.readdir(packagesRoot, { withFileTypes: true })) {
+    if (!packageEntry.isDirectory()) continue;
+
+    const corpusDir = path.join(packagesRoot, packageEntry.name, 'src', 'corpus-data');
+    if (!(await exists(corpusDir))) continue;
+
+    const files = (await fs.readdir(corpusDir))
+      .filter(file => file.endsWith('.json'))
+      .sort();
+
+    for (const file of files) {
+      const absolute = path.join(corpusDir, file);
+      documents.push({
+        packageName: packageEntry.name,
+        file: path.relative(root, absolute).replaceAll('\\', '/'),
+        cases: JSON.parse(await fs.readFile(absolute, 'utf8')),
+      });
+    }
+  }
+
+  return documents;
+}
+
+function readRefDocuments(ref) {
+  runGit(['rev-parse', '--verify', `${ref}^{commit}`]);
+  const paths = runGit(['ls-tree', '-r', '--name-only', ref, '--', 'packages'])
+    .split('\n')
+    .filter(Boolean)
+    .filter(file => corpusPathPattern.test(file))
+    .sort();
+
+  return paths.map(file => {
+    const match = corpusPathPattern.exec(file);
+    return {
+      packageName: match[1],
+      file,
+      cases: JSON.parse(runGit(['show', `${ref}:${file}`])),
+    };
+  });
+}
+
+function parseArguments(argv) {
+  const positional = [];
+  let json = false;
+
+  for (const argument of argv) {
+    if (argument === '--json') json = true;
+    else positional.push(argument);
+  }
+
+  if (positional.length > 2) {
+    throw new Error('Usage: pnpm corpus:diff -- [--json] [base-ref] [head-ref|WORKTREE]');
+  }
+
+  return {
+    json,
+    baseRef: positional[0] ?? 'main',
+    headRef: positional[1] ?? 'WORKTREE',
+  };
+}
+
+const { json, baseRef, headRef } = parseArguments(process.argv.slice(2));
+const baseDocuments = readRefDocuments(baseRef);
+const headDocuments =
+  headRef === 'WORKTREE' ? await readWorktreeDocuments() : readRefDocuments(headRef);
+const diff = diffCorpusDocuments(baseDocuments, headDocuments);
+
+if (json) {
+  console.log(
+    JSON.stringify(
+      {
+        base: baseRef,
+        head: headRef,
+        changedCases: corpusDiffCount(diff),
+        diff,
+      },
+      null,
+      2
+    )
+  );
+} else {
+  console.log(
+    formatCorpusDiff(diff, {
+      baseLabel: baseRef,
+      headLabel: headRef,
+    })
+  );
+}

--- a/scripts/diff-corpora.mjs
+++ b/scripts/diff-corpora.mjs
@@ -84,6 +84,7 @@ function parseArguments(argv) {
   let json = false;
 
   for (const argument of argv) {
+    if (argument === '--') continue;
     if (argument === '--json') json = true;
     else positional.push(argument);
   }


### PR DESCRIPTION
## Summary
Add the corpus-diff prerequisite from #52 before obfuscated profiles start expanding the matching surface.

- add `pnpm corpus:diff -- <base-ref> [head-ref|WORKTREE]`
- join corpus cases by package + stable case id
- classify newly matching, newly clean, changed semantic target, changed full match, added clean regression, removed case, and metadata-only changes
- add `--json` for machine-readable output
- keep the command informational so intentional behavior edits remain reviewable rather than automatically failing
- test the classifier with Node's built-in test runner and include those tests in `pnpm test`
- make PR CI fetch full git history and print a corpus diff against the pull request's exact base SHA
- document local/ref-to-ref review workflows for pack authors

## Why
Aggressive matching changes need an explicit behavioral delta. Stable corpus ids already give us the join key; this command turns that data into a compact review report before transform-heavy profiles grow.

Progress on #52
Related: #38