### PR TITLE
Add bounded source-mapped obfuscated term matching

### DIFF
--- a/docs/language-packs.md
+++ b/docs/language-packs.md
@@ -2,7 +2,7 @@
 
 Scrawlix keeps linguistic knowledge outside `@scrawlix/core`.
 
-The core knows how to execute rules, preserve semantic target ranges, apply coverage, merge overlaps, and return source-preserving segments. A language pack decides which terms exist, how they inflect or combine, and which language-specific coverage helpers make sense.
+The core knows how to execute rules, preserve semantic target ranges, apply coverage, merge overlaps, and return source-preserving segments. A language pack decides which terms exist, how they inflect or combine, which evasion transforms are reviewed, and which language-specific coverage helpers make sense.
 
 ## Minimal pack
 
@@ -77,6 +77,43 @@ Thai and Lao examples are covered in core regressions using explicit `th` and `l
 
 Locale selection is pack/application policy. Scrawlix does not infer a language from the input. A custom matcher remains the escape hatch when a pack needs boundaries beyond these strategies.
 
+## Bounded obfuscated profiles
+
+`censorRuleFromObfuscatedTerms()` provides a source-mapped execution path for reviewed evasions without supplying a universal evasion table. A pack chooses every substitution and ignored grapheme itself.
+
+```ts
+const obfuscatedRule = censorRuleFromObfuscatedTerms('example-obfuscated', ['shit'], {
+  substitutions: {
+    i: ['1'],
+    t: ['7'],
+  },
+  maxSubstitutions: 1,
+});
+```
+
+Substitution maps use canonical grapheme → accepted source graphemes. Keys and values are each exactly one extended grapheme. Core rejects ambiguous mappings, self-mappings, and graphemes configured simultaneously as substitutions and ignored values.
+
+Packs can review punctuation or zero-width insertion separately:
+
+```ts
+const punctuationRule = censorRuleFromObfuscatedTerms(
+  'example-punctuation',
+  ['shit'],
+  {
+    ignored: ['.'],
+    maxIgnored: 3,
+  }
+);
+```
+
+Internal ignored graphemes remain inside the exact original-source range returned by `find()`. A source such as `s.h.i.t` therefore yields that complete original slice even though matching happens against a transformed shadow.
+
+Every enabled transform class requires an explicit non-negative integer budget. When substitutions and ignored graphemes are enabled together, the pack must also set `maxChanges`, which caps the combined cost. The obfuscated helper filters zero-change candidates, so canonical and aggressive paths can be composed without duplicating ordinary canonical matches.
+
+This first helper intentionally covers only reviewed single-grapheme substitutions and reviewed ignored graphemes. Repeated-letter collapsing, width folding, confusables, transliteration, and other transforms should arrive as separate reviewed capabilities with their own corpus positives and ordinary-text negatives. A pack-specific confusable table belongs in that pack; blanket Unicode skeleton equivalence would create a much larger false-positive surface.
+
+The helper defaults to `profile: 'obfuscated'`. `find()` and coverage callbacks therefore expose which path produced a match, alongside `packId` when rules were composed from a pack.
+
 ## Semantic targets
 
 A regex rule can match a larger inflection or compound while identifying the semantic core with a named capture group:
@@ -93,7 +130,7 @@ Coverage runs against `core`, while `find()` still reports the full match and bo
 
 ## Custom matcher escape hatch
 
-Regex remains the compact path for ordinary rules. A pack that needs locale-specific segmentation, a trie, obfuscation handling, or another matching algorithm can provide a custom matcher instead:
+Regex remains the compact path for ordinary rules. A pack that needs locale-specific segmentation, a trie, a transform beyond the bounded helper, or another matching algorithm can provide a custom matcher instead:
 
 ```ts
 import type { CensorRule } from '@scrawlix/core';
@@ -202,7 +239,8 @@ A publishable third-party pack should contain:
 2. one or more named rule collections plus a `CensorRulePack` export
 3. locale and scope/severity notes
 4. positive and clean/false-positive regression data
-5. tests for semantic targets, casing, punctuation, compounds/inflections, Unicode context, and known ambiguity
-6. an ordinary package README with an install command and copy/paste consumer example
+5. tests for semantic targets, casing, punctuation, compounds/inflections, Unicode context, known ambiguity, and every enabled obfuscation class
+6. explicit transform tables and budgets for any aggressive profile
+7. an ordinary package README with an install command and copy/paste consumer example
 
 Keep pack-specific presentation and application state outside the pack. Matching policy should remain inspectable as ordinary code/data.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -49,23 +49,68 @@ Use `{ boundary: 'substring' }` deliberately for packs/scripts where adjacent le
 
 Core requires `Intl.Segmenter` and exports `graphemeRanges()` so language-specific coverage helpers can share the same extended-grapheme boundaries as matching and segmentation.
 
+## Bounded obfuscated terms
+
+`censorRuleFromObfuscatedTerms()` builds an opt-in aggressive rule from caller-reviewed transforms. Core ships the execution mechanism; packs decide which substitutions or ignored graphemes are acceptable for their language and policy.
+
+```ts
+import {
+  censorRuleFromObfuscatedTerms,
+  createScrawlix,
+} from '@scrawlix/core';
+
+const obfuscated = censorRuleFromObfuscatedTerms('example', ['shit'], {
+  substitutions: {
+    i: ['1'],
+    t: ['7'],
+  },
+  maxSubstitutions: 1,
+});
+
+const engine = createScrawlix({ rules: [obfuscated] });
+engine.find('sh1t');
+```
+
+Every substitution key and value is exactly one extended grapheme. The map reads as canonical grapheme → reviewed source graphemes. Core rejects ambiguous mappings and self-mappings.
+
+Ignored graphemes are also explicit and budgeted:
+
+```ts
+const punctuationEvasion = censorRuleFromObfuscatedTerms(
+  'example-punctuation',
+  ['shit'],
+  {
+    ignored: ['.'],
+    maxIgnored: 3,
+  }
+);
+```
+
+A match against `s.h.i.t` reports the exact original source slice `s.h.i.t`. Ignored internal graphemes stay inside the returned source range and count against the candidate budget.
+
+Each enabled transform class requires its own integer budget. When substitutions and ignored graphemes are combined, `maxChanges` is required as an additional total budget. This keeps transform composition finite and reviewable.
+
+Canonical zero-change candidates are filtered from the obfuscated helper. Compose a canonical rule and an obfuscated rule explicitly when an application wants both profiles:
+
+```ts
+const canonical = censorRuleFromTerms('example-canonical', ['shit']);
+const obfuscated = censorRuleFromObfuscatedTerms('example-obfuscated', ['shit'], {
+  substitutions: { i: ['1'] },
+  maxSubstitutions: 1,
+});
+
+const engine = createScrawlix({ rules: [canonical, obfuscated] });
+```
+
+The obfuscated helper applies the same NFC/source-range, grapheme, and boundary guarantees as canonical terms. It defaults to `profile: 'obfuscated'` so `find()` and coverage callbacks can identify the aggressive path.
+
 ## Match profiles
 
 Rules can carry an optional `profile` string. `find()` exposes it as `match.profile`, and coverage callbacks receive the same value in their context. This lets packs distinguish conservative and aggressive matching paths in diagnostics and policy code.
 
-`censorRuleFromTerms()` labels its rules `canonical` by default:
+`censorRuleFromTerms()` labels its rules `canonical` by default, while `censorRuleFromObfuscatedTerms()` labels its rules `obfuscated` by default.
 
-```ts
-const canonical = censorRuleFromTerms('private', ['Project Velvet']);
-
-const obfuscatedRule = {
-  id: 'private-obfuscated',
-  profile: 'obfuscated',
-  matcher: mySourceMappedMatcher,
-};
-```
-
-Profile names describe the matching path; they do not alter matching on their own. A pack that implements an obfuscated profile still owns its transforms, budgets, source mapping, and regression negatives.
+Profile names describe the matching path. Packs still own linguistic scope, reviewed transform tables, budgets, and regression negatives.
 
 ## Public concepts
 
@@ -75,6 +120,7 @@ Profile names describe the matching path; they do not alter matching on their ow
 - `segment(text)` returns source-preserving covered/uncovered segments
 - generic coverage presets are `full`, `tail`, `middle`, and `inner`
 - literal/custom-term matching defaults to NFC canonical equivalence and `profile: 'canonical'`
+- bounded aggressive term matching is opt-in through `censorRuleFromObfuscatedTerms()`
 - every exposed match, target, and covered segment respects extended-grapheme boundaries
 
 Scrawlix deliberately has no built-in language or hidden profanity list. Callers select rules explicitly.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,6 +77,26 @@ export type LocaleWordBoundary = {
 };
 export type TermBoundaryStrategy = WordBoundaryMode | LocaleWordBoundary;
 export type UnicodeNormalization = 'none' | 'NFC';
+export type ObfuscatedTermSubstitutions = Readonly<
+  Record<string, readonly string[]>
+>;
+export type ObfuscatedTermOptions = {
+  caseSensitive?: boolean;
+  coverage?: CoverageSelector;
+  boundary?: TermBoundaryStrategy;
+  normalization?: UnicodeNormalization;
+  profile?: string;
+  /** Canonical grapheme -> reviewed source graphemes that may stand in for it. */
+  substitutions?: ObfuscatedTermSubstitutions;
+  /** Reviewed source graphemes that may be ignored between matched graphemes. */
+  ignored?: readonly string[];
+  /** Required when substitutions are configured. */
+  maxSubstitutions?: number;
+  /** Required when ignored graphemes are configured. */
+  maxIgnored?: number;
+  /** Required when both transform classes are enabled. */
+  maxChanges?: number;
+};
 
 export type ScrawlixMatch = {
   ruleId: string;
@@ -126,6 +146,30 @@ type CoveredRange = {
 type NormalizedShadow = {
   value: string;
   sourceOffsets: ReadonlyMap<number, number>;
+};
+
+type ObfuscatedShadowUnit = {
+  shadowStart: number;
+  shadowEnd: number;
+  sourceStart: number;
+  sourceEnd: number;
+  substitutionCost: number;
+  ignoredBefore: number;
+};
+
+type ObfuscatedShadow = {
+  value: string;
+  units: readonly ObfuscatedShadowUnit[];
+  startUnitByOffset: ReadonlyMap<number, number>;
+  endUnitByOffset: ReadonlyMap<number, number>;
+};
+
+type CompiledObfuscation = {
+  substitutionLookup: ReadonlyMap<string, string>;
+  ignored: ReadonlySet<string>;
+  maxSubstitutions: number;
+  maxIgnored: number;
+  maxChanges: number;
 };
 
 const graphemeSegmenter =
@@ -620,6 +664,10 @@ function segmentFromRanges(text: string, ranges: readonly CoveredRange[]) {
   return segments;
 }
 
+function normalizeGrapheme(value: string, normalization: UnicodeNormalization) {
+  return normalization === 'none' ? value : value.normalize(normalization);
+}
+
 function sourceShadow(
   value: string,
   normalization: UnicodeNormalization
@@ -630,11 +678,7 @@ function sourceShadow(
   for (const range of graphemeRanges(value)) {
     const shadowStart = shadow.length;
     sourceOffsets.set(shadowStart, range.start);
-    const sourceGrapheme = value.slice(range.start, range.end);
-    shadow +=
-      normalization === 'none'
-        ? sourceGrapheme
-        : sourceGrapheme.normalize(normalization);
+    shadow += normalizeGrapheme(value.slice(range.start, range.end), normalization);
     sourceOffsets.set(shadow.length, range.end);
   }
 
@@ -717,6 +761,255 @@ function termMatcher(
   };
 }
 
+function requireSingleGrapheme(
+  value: string,
+  label: string,
+  normalization: UnicodeNormalization
+) {
+  const normalized = normalizeGrapheme(value, normalization);
+  const ranges = graphemeRanges(normalized);
+  if (
+    normalized.length === 0 ||
+    ranges.length !== 1 ||
+    ranges[0]!.start !== 0 ||
+    ranges[0]!.end !== normalized.length
+  ) {
+    throw new Error(`${label} must be exactly one extended grapheme.`);
+  }
+  return normalized;
+}
+
+function requireBudget(name: string, value: number | undefined, enabled: boolean) {
+  if (enabled && value === undefined) {
+    throw new Error(
+      `censorRuleFromObfuscatedTerms() requires an explicit ${name} when that transform class is configured.`
+    );
+  }
+  const resolved = value ?? 0;
+  if (!Number.isInteger(resolved) || resolved < 0) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  return resolved;
+}
+
+function compileObfuscation(
+  substitutions: ObfuscatedTermSubstitutions,
+  ignoredValues: readonly string[],
+  normalization: UnicodeNormalization,
+  maxSubstitutions: number | undefined,
+  maxIgnored: number | undefined,
+  maxChanges: number | undefined
+): CompiledObfuscation {
+  const substitutionLookup = new Map<string, string>();
+
+  for (const [canonicalValue, sourceValues] of Object.entries(substitutions)) {
+    const canonical = requireSingleGrapheme(
+      canonicalValue,
+      `Substitution key ${JSON.stringify(canonicalValue)}`,
+      normalization
+    );
+
+    for (const sourceValue of sourceValues) {
+      const source = requireSingleGrapheme(
+        sourceValue,
+        `Substitution value ${JSON.stringify(sourceValue)}`,
+        normalization
+      );
+      if (source === canonical) {
+        throw new Error(
+          `Substitution value ${JSON.stringify(sourceValue)} maps to itself; remove it from the obfuscated transform.`
+        );
+      }
+      const previous = substitutionLookup.get(source);
+      if (previous && previous !== canonical) {
+        throw new Error(
+          `Substitution value ${JSON.stringify(sourceValue)} maps to both ${JSON.stringify(previous)} and ${JSON.stringify(canonical)}.`
+        );
+      }
+      substitutionLookup.set(source, canonical);
+    }
+  }
+
+  const ignored = new Set<string>();
+  for (const ignoredValue of ignoredValues) {
+    const normalized = requireSingleGrapheme(
+      ignoredValue,
+      `Ignored value ${JSON.stringify(ignoredValue)}`,
+      normalization
+    );
+    if (substitutionLookup.has(normalized)) {
+      throw new Error(
+        `Grapheme ${JSON.stringify(ignoredValue)} cannot be both ignored and substituted.`
+      );
+    }
+    ignored.add(normalized);
+  }
+
+  const substitutionsEnabled = substitutionLookup.size > 0;
+  const ignoredEnabled = ignored.size > 0;
+  if (!substitutionsEnabled && !ignoredEnabled) {
+    throw new Error(
+      'censorRuleFromObfuscatedTerms() needs at least one substitution or ignored grapheme.'
+    );
+  }
+
+  const resolvedMaxSubstitutions = requireBudget(
+    'maxSubstitutions',
+    maxSubstitutions,
+    substitutionsEnabled
+  );
+  const resolvedMaxIgnored = requireBudget(
+    'maxIgnored',
+    maxIgnored,
+    ignoredEnabled
+  );
+
+  if (substitutionsEnabled && ignoredEnabled && maxChanges === undefined) {
+    throw new Error(
+      'censorRuleFromObfuscatedTerms() requires an explicit maxChanges when substitutions and ignored graphemes are both configured.'
+    );
+  }
+  const resolvedMaxChanges = requireBudget(
+    'maxChanges',
+    maxChanges ?? Math.max(resolvedMaxSubstitutions, resolvedMaxIgnored),
+    true
+  );
+
+  return {
+    substitutionLookup,
+    ignored,
+    maxSubstitutions: resolvedMaxSubstitutions,
+    maxIgnored: resolvedMaxIgnored,
+    maxChanges: resolvedMaxChanges,
+  };
+}
+
+function obfuscatedShadow(
+  value: string,
+  normalization: UnicodeNormalization,
+  config: CompiledObfuscation
+): ObfuscatedShadow {
+  let shadow = '';
+  let ignoredSincePreviousUnit = 0;
+  const units: ObfuscatedShadowUnit[] = [];
+  const startUnitByOffset = new Map<number, number>();
+  const endUnitByOffset = new Map<number, number>();
+
+  for (const range of graphemeRanges(value)) {
+    const sourceGrapheme = normalizeGrapheme(
+      value.slice(range.start, range.end),
+      normalization
+    );
+    if (config.ignored.has(sourceGrapheme)) {
+      ignoredSincePreviousUnit += 1;
+      continue;
+    }
+
+    const replacement = config.substitutionLookup.get(sourceGrapheme);
+    const shadowStart = shadow.length;
+    shadow += replacement ?? sourceGrapheme;
+    const unitIndex = units.length;
+    units.push({
+      shadowStart,
+      shadowEnd: shadow.length,
+      sourceStart: range.start,
+      sourceEnd: range.end,
+      substitutionCost: replacement === undefined ? 0 : 1,
+      ignoredBefore: ignoredSincePreviousUnit,
+    });
+    startUnitByOffset.set(shadowStart, unitIndex);
+    endUnitByOffset.set(shadow.length, unitIndex);
+    ignoredSincePreviousUnit = 0;
+  }
+
+  return { value: shadow, units, startUnitByOffset, endUnitByOffset };
+}
+
+function candidateTransformCost(
+  shadow: ObfuscatedShadow,
+  firstUnit: number,
+  lastUnit: number
+) {
+  let substitutions = 0;
+  let ignored = 0;
+
+  for (let unitIndex = firstUnit; unitIndex <= lastUnit; unitIndex += 1) {
+    const unit = shadow.units[unitIndex]!;
+    substitutions += unit.substitutionCost;
+    if (unitIndex > firstUnit) ignored += unit.ignoredBefore;
+  }
+
+  return { substitutions, ignored, changes: substitutions + ignored };
+}
+
+function obfuscatedTermMatcher(
+  patternSource: string,
+  caseSensitive: boolean,
+  normalization: UnicodeNormalization,
+  boundary: TermBoundaryStrategy,
+  config: CompiledObfuscation
+): CensorMatcher {
+  return {
+    *find(text) {
+      const shadow = obfuscatedShadow(text, normalization, config);
+      const pattern = new RegExp(patternSource, caseSensitive ? 'gu' : 'giu');
+      const lexicalBoundaries =
+        typeof boundary === 'object'
+          ? localeWordBoundaries(shadow.value, boundary)
+          : null;
+      let match: RegExpExecArray | null;
+
+      while ((match = pattern.exec(shadow.value)) !== null) {
+        if (!match[0]) {
+          pattern.lastIndex = advanceStringIndex(
+            shadow.value,
+            match.index,
+            pattern.unicode
+          );
+          continue;
+        }
+
+        const shadowEnd = match.index + match[0].length;
+        if (
+          lexicalBoundaries &&
+          (!lexicalBoundaries.has(match.index) || !lexicalBoundaries.has(shadowEnd))
+        ) {
+          continue;
+        }
+
+        const firstUnit = shadow.startUnitByOffset.get(match.index);
+        const lastUnit = shadow.endUnitByOffset.get(shadowEnd);
+        if (firstUnit === undefined || lastUnit === undefined) continue;
+
+        const cost = candidateTransformCost(shadow, firstUnit, lastUnit);
+        if (cost.changes === 0) continue;
+        if (cost.substitutions > config.maxSubstitutions) continue;
+        if (cost.ignored > config.maxIgnored) continue;
+        if (cost.changes > config.maxChanges) continue;
+
+        yield {
+          start: shadow.units[firstUnit]!.sourceStart,
+          end: shadow.units[lastUnit]!.sourceEnd,
+        };
+      }
+    },
+  };
+}
+
+function preparedTermAlternatives(
+  terms: readonly string[],
+  normalization: UnicodeNormalization
+) {
+  return [
+    ...new Set(
+      terms
+        .map(term => term.trim())
+        .filter(Boolean)
+        .map(term => normalizeGrapheme(term, normalization))
+    ),
+  ].sort((left, right) => right.length - left.length);
+}
+
 export function censorRuleFromTerms(
   id: string,
   terms: readonly string[],
@@ -734,14 +1027,7 @@ export function censorRuleFromTerms(
     profile?: string;
   } = {}
 ): CensorRule {
-  const preparedTerms = terms.map(term => term.trim()).filter(Boolean);
-  const alternatives = [
-    ...new Set(
-      preparedTerms.map(term =>
-        normalization === 'none' ? term : term.normalize(normalization)
-      )
-    ),
-  ].sort((left, right) => right.length - left.length);
+  const alternatives = preparedTermAlternatives(terms, normalization);
 
   if (alternatives.length === 0) {
     throw new Error('A censor rule needs at least one non-empty term.');
@@ -762,6 +1048,51 @@ export function censorRuleFromTerms(
     profile,
     coverage,
     matcher: termMatcher(patternSource, caseSensitive, normalization, boundary),
+  };
+}
+
+export function censorRuleFromObfuscatedTerms(
+  id: string,
+  terms: readonly string[],
+  {
+    caseSensitive = false,
+    coverage,
+    boundary = 'word',
+    normalization = 'NFC',
+    profile = 'obfuscated',
+    substitutions = {},
+    ignored = [],
+    maxSubstitutions,
+    maxIgnored,
+    maxChanges,
+  }: ObfuscatedTermOptions = {}
+): CensorRule {
+  const alternatives = preparedTermAlternatives(terms, normalization);
+  if (alternatives.length === 0) {
+    throw new Error('A censor rule needs at least one non-empty term.');
+  }
+
+  const config = compileObfuscation(
+    substitutions,
+    ignored,
+    normalization,
+    maxSubstitutions,
+    maxIgnored,
+    maxChanges
+  );
+  const patternSource = termPatternSource(alternatives, boundary);
+
+  return {
+    id,
+    profile,
+    coverage,
+    matcher: obfuscatedTermMatcher(
+      patternSource,
+      caseSensitive,
+      normalization,
+      boundary,
+      config
+    ),
   };
 }
 

--- a/packages/core/src/obfuscated.test.ts
+++ b/packages/core/src/obfuscated.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import {
+  censorRuleFromObfuscatedTerms,
+  createScrawlix,
+  type ScrawlixSegment,
+} from './index';
+
+function marked(segments: readonly ScrawlixSegment[]) {
+  return segments
+    .map(segment => (segment.covered ? `[${segment.text}]` : segment.text))
+    .join('');
+}
+
+describe('bounded obfuscated term matching', () => {
+  it('matches caller-reviewed substitutions and exposes the obfuscated profile', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromObfuscatedTerms('shit', ['shit'], {
+          substitutions: { i: ['1'] },
+          maxSubstitutions: 1,
+        }),
+      ],
+    });
+
+    expect(engine.find('sh1t')).toEqual([
+      {
+        ruleId: 'shit',
+        profile: 'obfuscated',
+        text: 'sh1t',
+        start: 0,
+        end: 4,
+        targetText: 'sh1t',
+        targetStart: 0,
+        targetEnd: 4,
+      },
+    ]);
+    expect(engine.find('shit')).toEqual([]);
+  });
+
+  it('enforces substitution budgets per matched candidate', () => {
+    const oneChange = createScrawlix({
+      rules: [
+        censorRuleFromObfuscatedTerms('shit', ['shit'], {
+          substitutions: { i: ['1'], t: ['7'] },
+          maxSubstitutions: 1,
+        }),
+      ],
+    });
+    const twoChanges = createScrawlix({
+      rules: [
+        censorRuleFromObfuscatedTerms('shit', ['shit'], {
+          substitutions: { i: ['1'], t: ['7'] },
+          maxSubstitutions: 2,
+        }),
+      ],
+    });
+
+    expect(oneChange.find('sh17')).toEqual([]);
+    expect(twoChanges.find('sh17')[0]?.text).toBe('sh17');
+  });
+
+  it('matches bounded ignored punctuation and preserves its exact source span', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromObfuscatedTerms('shit', ['shit'], {
+          ignored: ['.'],
+          maxIgnored: 3,
+        }),
+      ],
+    });
+
+    expect(engine.find('say s.h.i.t now')[0]).toMatchObject({
+      profile: 'obfuscated',
+      text: 's.h.i.t',
+      start: 4,
+      end: 11,
+      targetText: 's.h.i.t',
+      targetStart: 4,
+      targetEnd: 11,
+    });
+    expect(marked(engine.segment('say s.h.i.t now'))).toBe('say [s.h.i.t] now');
+    expect(engine.find('s....h.i.t')).toEqual([]);
+  });
+
+  it('can ignore an explicitly reviewed zero-width grapheme', () => {
+    const source = 'sh\u200Bit';
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromObfuscatedTerms('shit', ['shit'], {
+          ignored: ['\u200B'],
+          maxIgnored: 1,
+        }),
+      ],
+    });
+
+    expect(engine.find(source)[0]).toMatchObject({
+      text: source,
+      start: 0,
+      end: source.length,
+    });
+  });
+
+  it('requires an explicit combined budget when transform classes are mixed', () => {
+    expect(() =>
+      censorRuleFromObfuscatedTerms('shit', ['shit'], {
+        substitutions: { i: ['1'] },
+        ignored: ['.'],
+        maxSubstitutions: 1,
+        maxIgnored: 1,
+      })
+    ).toThrow('requires an explicit maxChanges');
+
+    const oneTotalChange = createScrawlix({
+      rules: [
+        censorRuleFromObfuscatedTerms('shit', ['shit'], {
+          substitutions: { i: ['1'] },
+          ignored: ['.'],
+          maxSubstitutions: 1,
+          maxIgnored: 1,
+          maxChanges: 1,
+        }),
+      ],
+    });
+    const twoTotalChanges = createScrawlix({
+      rules: [
+        censorRuleFromObfuscatedTerms('shit', ['shit'], {
+          substitutions: { i: ['1'] },
+          ignored: ['.'],
+          maxSubstitutions: 1,
+          maxIgnored: 1,
+          maxChanges: 2,
+        }),
+      ],
+    });
+
+    expect(oneTotalChange.find('sh1.t')).toEqual([]);
+    expect(twoTotalChanges.find('sh1.t')[0]?.text).toBe('sh1.t');
+  });
+
+  it('keeps canonical normalization and source mapping through ignored graphemes', () => {
+    const source = 'ca.fe\u0301';
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromObfuscatedTerms('cafe', ['café'], {
+          ignored: ['.'],
+          maxIgnored: 1,
+        }),
+      ],
+    });
+
+    expect(engine.find(source)).toEqual([
+      {
+        ruleId: 'cafe',
+        profile: 'obfuscated',
+        text: source,
+        start: 0,
+        end: source.length,
+        targetText: source,
+        targetStart: 0,
+        targetEnd: source.length,
+      },
+    ]);
+  });
+
+  it('applies word boundaries after transforms to block ordinary-word substrings', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromObfuscatedTerms('shit', ['shit'], {
+          substitutions: { i: ['1'] },
+          maxSubstitutions: 1,
+        }),
+      ],
+    });
+
+    expect(engine.find('xsh1t')).toEqual([]);
+    expect(engine.find('sh1tword')).toEqual([]);
+    expect(engine.find('(sh1t)')).toHaveLength(1);
+  });
+
+  it('requires explicit budgets for every enabled transform class', () => {
+    expect(() =>
+      censorRuleFromObfuscatedTerms('shit', ['shit'], {
+        substitutions: { i: ['1'] },
+      })
+    ).toThrow('requires an explicit maxSubstitutions');
+
+    expect(() =>
+      censorRuleFromObfuscatedTerms('shit', ['shit'], {
+        ignored: ['.'],
+      })
+    ).toThrow('requires an explicit maxIgnored');
+  });
+
+  it('requires reviewed transforms to be unambiguous single graphemes', () => {
+    expect(() =>
+      censorRuleFromObfuscatedTerms('shit', ['shit'], {
+        substitutions: { i: ['ab'] },
+        maxSubstitutions: 1,
+      })
+    ).toThrow('must be exactly one extended grapheme');
+
+    expect(() =>
+      censorRuleFromObfuscatedTerms('shit', ['shit'], {
+        substitutions: { i: ['1'], t: ['1'] },
+        maxSubstitutions: 1,
+      })
+    ).toThrow('maps to both');
+
+    expect(() =>
+      censorRuleFromObfuscatedTerms('shit', ['shit'], {
+        substitutions: { i: ['1'] },
+        ignored: ['1'],
+        maxSubstitutions: 1,
+        maxIgnored: 1,
+        maxChanges: 1,
+      })
+    ).toThrow('cannot be both ignored and substituted');
+  });
+});


### PR DESCRIPTION
## Summary
Add the first real `obfuscated` execution path in core, deliberately limited to two reviewable transform classes.

- add `censorRuleFromObfuscatedTerms()`
- support caller-reviewed single-grapheme substitutions (canonical grapheme -> accepted source graphemes)
- support caller-reviewed ignored graphemes for internal punctuation/zero-width insertion
- require explicit `maxSubstitutions` / `maxIgnored` budgets whenever those classes are enabled
- require explicit `maxChanges` when transform classes are combined
- build a per-grapheme transformed shadow with exact original-source ranges and per-candidate transform costs
- filter zero-change canonical candidates from the obfuscated path
- preserve NFC/NFD equivalence, boundary strategies, grapheme invariants, coverage behavior, and `profile: 'obfuscated'`
- reject ambiguous, self-mapped, multi-grapheme, and conflicting transform definitions
- add regressions for substitutions, punctuation insertion, zero-width insertion, combined budgets, source preservation, canonical normalization, and ordinary-word boundary traps

## Deliberate scope
This helper does not ship universal leetspeak or confusable tables. Packs own every reviewed mapping. Repeated-letter collapsing, width variants, confusables, transliteration, and other transform classes remain separate future slices with their own positive/negative corpora.

## Source invariant
A match is reported from the first matched source grapheme through the last matched source grapheme. Internal ignored graphemes stay inside that exact original-source slice and count against the candidate budget.

Progress on #38