### PR TITLE
Add an opt-in English obfuscated profanity pilot

### DIFF
--- a/fixtures/consumer/runtime.mjs
+++ b/fixtures/consumer/runtime.mjs
@@ -1,8 +1,14 @@
 import assert from 'node:assert/strict';
 import { createScrawlix } from '@scrawlix/core';
 import { createDomScrawlix } from '@scrawlix/dom';
-import { englishStrongProfanityRules } from '@scrawlix/en';
-import { englishProfanityCorpus } from '@scrawlix/en/corpus';
+import {
+  englishObfuscatedStrongProfanityRules,
+  englishStrongProfanityRules,
+} from '@scrawlix/en';
+import {
+  englishObfuscatedProfanityCorpus,
+  englishProfanityCorpus,
+} from '@scrawlix/en/corpus';
 import { transformHast } from '@scrawlix/rehype';
 import { CensoredText } from '@scrawlix/react';
 
@@ -14,7 +20,21 @@ const engine = createScrawlix({
 const matches = engine.find('well, fuck');
 assert.equal(matches.length, 1);
 assert.equal(matches[0]?.targetText.toLowerCase(), 'fuck');
+assert.equal(matches[0]?.profile, 'canonical');
 assert.ok(englishProfanityCorpus.some(testCase => testCase.id === 'fuck-base'));
+
+const obfuscatedEngine = createScrawlix({
+  rules: englishObfuscatedStrongProfanityRules,
+});
+const obfuscatedMatches = obfuscatedEngine.find('sh1t');
+assert.equal(obfuscatedMatches.length, 1);
+assert.equal(obfuscatedMatches[0]?.text, 'sh1t');
+assert.equal(obfuscatedMatches[0]?.profile, 'obfuscated');
+assert.ok(
+  englishObfuscatedProfanityCorpus.some(
+    testCase => testCase.id === 'obfuscated-shit-digit'
+  )
+);
 
 const tree = {
   type: 'root',

--- a/packages/en/README.md
+++ b/packages/en/README.md
@@ -8,7 +8,7 @@ English rule and coverage helpers for Scrawlix.
 npm install @scrawlix/core @scrawlix/en
 ```
 
-## Quick start
+## Canonical strong-profanity pack
 
 ```ts
 import { createScrawlix } from '@scrawlix/core';
@@ -19,7 +19,7 @@ const scrawlix = createScrawlix({
 });
 ```
 
-The package also exports `englishStrongProfanityPack` for pack composition and `englishVowelCoverage` for an English-specific coverage policy.
+The canonical package export also includes `englishStrongProfanityPack` for pack composition and `englishVowelCoverage` for an English-specific coverage policy.
 
 ```ts
 import { createScrawlix, rulesFromPacks } from '@scrawlix/core';
@@ -34,12 +34,49 @@ const scrawlix = createScrawlix({
 });
 ```
 
+Canonical English rules expose `profile: 'canonical'` in match metadata.
+
+## Opt-in obfuscated base-form pilot
+
+The package also exports a separate aggressive pilot:
+
+- `englishObfuscatedStrongProfanityRules`
+- `englishObfuscatedStrongProfanityPack`
+
+It catches a small reviewed set of one-change evasions for the exact base forms `fuck`, `shit`, `bitch`, `asshole`, and `cunt`. The pilot allows one reviewed symbol/digit substitution **or** one internal `.`, `-`, or zero-width-space insertion per candidate.
+
+```ts
+import { createScrawlix, rulesFromPacks } from '@scrawlix/core';
+import {
+  englishObfuscatedStrongProfanityPack,
+  englishStrongProfanityPack,
+} from '@scrawlix/en';
+
+const scrawlix = createScrawlix({
+  rules: rulesFromPacks(
+    englishStrongProfanityPack,
+    englishObfuscatedStrongProfanityPack
+  ),
+});
+```
+
+Examples covered by the pilot include `f*ck`, `sh1t`, `sh-it`, `b!tch`, `assh0le`, and `c*nt`. Matches from this pack expose `profile: 'obfuscated'` and `packId: 'en-strong-profanity-obfuscated'` when composed through `rulesFromPacks()`.
+
+The pilot deliberately caps each candidate at one transform. It covers exact base forms only; inflected and compound evasions need a later semantic-target-aware expansion. The reviewed table lives in ordinary package code, and its positives plus false-positive/over-budget cases live in JSON corpora.
+
+## Regression data
+
 Regression data is available from the explicit subpath:
 
 ```ts
-import { englishProfanityCorpus } from '@scrawlix/en/corpus';
+import {
+  englishCleanCorpus,
+  englishObfuscatedCleanCorpus,
+  englishObfuscatedProfanityCorpus,
+  englishProfanityCorpus,
+} from '@scrawlix/en/corpus';
 ```
 
-The current pack is intentionally narrow strong-profanity coverage. It is a reviewable rule pack, not a claim of complete English moderation.
+The current package is intentionally narrow strong-profanity coverage. It is a reviewable set of English rules and aggressive examples, with explicit corpus evidence for the scope it claims.
 
-See `docs/language-packs.md` in the repository for authoring and composition guidance.
+See `docs/language-packs.md` in the repository for authoring, composition, boundary, Unicode, and obfuscation guidance.

--- a/packages/en/src/corpus-data/obfuscated-clean.json
+++ b/packages/en/src/corpus-data/obfuscated-clean.json
@@ -1,0 +1,73 @@
+[
+  {
+    "id": "obfuscated-clean-canonical-fuck",
+    "text": "fuck",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "canonical-form"],
+    "note": "Canonical forms belong to the canonical pack and are filtered from the obfuscated helper.",
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-canonical-shit",
+    "text": "shit",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "canonical-form"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-two-substitutions",
+    "text": "sh17",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-mixed-budget",
+    "text": "sh1-t",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-two-dollar-substitutions",
+    "text": "a$$hole",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-two-separators",
+    "text": "f--uck",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-shirt",
+    "text": "sh1rt",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "ordinary-word"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-shift",
+    "text": "sh1ft",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "ordinary-word"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-c-unit",
+    "text": "c-unit",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "ordinary-word", "punctuation"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-assorted",
+    "text": "a$$orted",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "ordinary-word"],
+    "matches": []
+  }
+]

--- a/packages/en/src/corpus-data/obfuscated.json
+++ b/packages/en/src/corpus-data/obfuscated.json
@@ -1,0 +1,173 @@
+[
+  {
+    "id": "obfuscated-fuck-star",
+    "text": "f*ck",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "substitution"],
+    "note": "Reviewed one-character vowel masking for the exact base form.",
+    "matches": [
+      {
+        "ruleId": "fuck-obfuscated",
+        "text": "f*ck",
+        "start": 0,
+        "end": 4,
+        "targetText": "f*ck",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-fuck-paren",
+    "text": "fu(k",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "substitution"],
+    "matches": [
+      {
+        "ruleId": "fuck-obfuscated",
+        "text": "fu(k",
+        "start": 0,
+        "end": 4,
+        "targetText": "fu(k",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-shit-digit",
+    "text": "sh1t",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "substitution"],
+    "matches": [
+      {
+        "ruleId": "shit-obfuscated",
+        "text": "sh1t",
+        "start": 0,
+        "end": 4,
+        "targetText": "sh1t",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-shit-dollar",
+    "text": "$hit",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "substitution"],
+    "matches": [
+      {
+        "ruleId": "shit-obfuscated",
+        "text": "$hit",
+        "start": 0,
+        "end": 4,
+        "targetText": "$hit",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-shit-hyphen",
+    "text": "sh-it",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "punctuation-insertion"],
+    "matches": [
+      {
+        "ruleId": "shit-obfuscated",
+        "text": "sh-it",
+        "start": 0,
+        "end": 5,
+        "targetText": "sh-it",
+        "targetStart": 0,
+        "targetEnd": 5
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-shit-zero-width",
+    "text": "sh\u200bit",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "unicode", "zero-width-insertion"],
+    "matches": [
+      {
+        "ruleId": "shit-obfuscated",
+        "text": "sh\u200bit",
+        "start": 0,
+        "end": 5,
+        "targetText": "sh\u200bit",
+        "targetStart": 0,
+        "targetEnd": 5
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-bitch-bang",
+    "text": "b!tch",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "substitution"],
+    "matches": [
+      {
+        "ruleId": "bitch-obfuscated",
+        "text": "b!tch",
+        "start": 0,
+        "end": 5,
+        "targetText": "b!tch",
+        "targetStart": 0,
+        "targetEnd": 5
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-asshole-zero",
+    "text": "assh0le",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "substitution"],
+    "matches": [
+      {
+        "ruleId": "asshole-obfuscated",
+        "text": "assh0le",
+        "start": 0,
+        "end": 7,
+        "targetText": "assh0le",
+        "targetStart": 0,
+        "targetEnd": 7
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-asshole-hyphen",
+    "text": "ass-hole",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "punctuation-insertion"],
+    "matches": [
+      {
+        "ruleId": "asshole-obfuscated",
+        "text": "ass-hole",
+        "start": 0,
+        "end": 8,
+        "targetText": "ass-hole",
+        "targetStart": 0,
+        "targetEnd": 8
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-cunt-star",
+    "text": "c*nt",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "substitution"],
+    "matches": [
+      {
+        "ruleId": "cunt-obfuscated",
+        "text": "c*nt",
+        "start": 0,
+        "end": 4,
+        "targetText": "c*nt",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  }
+]

--- a/packages/en/src/corpus.ts
+++ b/packages/en/src/corpus.ts
@@ -1,4 +1,6 @@
 import cleanCorpus from './corpus-data/clean.json' with { type: 'json' };
+import obfuscatedCleanCorpus from './corpus-data/obfuscated-clean.json' with { type: 'json' };
+import obfuscatedCorpus from './corpus-data/obfuscated.json' with { type: 'json' };
 import profanityCorpus from './corpus-data/profanity.json' with { type: 'json' };
 
 export type EnglishCorpusMatch = {
@@ -30,3 +32,11 @@ export const englishProfanityCorpus: readonly EnglishCorpusCase[] =
 
 /** Cases that contain suspicious substrings or boundaries but should stay clean. */
 export const englishCleanCorpus: readonly EnglishCorpusCase[] = cleanCorpus;
+
+/** Positive cases for the opt-in bounded English obfuscated base-form pack. */
+export const englishObfuscatedProfanityCorpus: readonly EnglishCorpusCase[] =
+  obfuscatedCorpus;
+
+/** False-positive and over-budget cases for the opt-in obfuscated pack. */
+export const englishObfuscatedCleanCorpus: readonly EnglishCorpusCase[] =
+  obfuscatedCleanCorpus;

--- a/packages/en/src/index.test.ts
+++ b/packages/en/src/index.test.ts
@@ -1,7 +1,18 @@
-import { createScrawlix, type ScrawlixSegment } from '@scrawlix/core';
-import { describe, expect, it } from 'vitest';
-import { englishCleanCorpus, englishProfanityCorpus } from './corpus';
 import {
+  createScrawlix,
+  rulesFromPacks,
+  type ScrawlixSegment,
+} from '@scrawlix/core';
+import { describe, expect, it } from 'vitest';
+import {
+  englishCleanCorpus,
+  englishObfuscatedCleanCorpus,
+  englishObfuscatedProfanityCorpus,
+  englishProfanityCorpus,
+} from './corpus';
+import {
+  englishObfuscatedStrongProfanityPack,
+  englishObfuscatedStrongProfanityRules,
   englishStrongProfanityPack,
   englishStrongProfanityRules,
   englishVowelCoverage,
@@ -13,34 +24,97 @@ function marked(segments: readonly ScrawlixSegment[]) {
     .join('');
 }
 
+function expectedMatches(
+  engine: ReturnType<typeof createScrawlix>,
+  text: string,
+  profile: string
+) {
+  const found = engine.find(text);
+  expect(found.every(match => match.profile === profile)).toBe(true);
+  return found.map(match => ({
+    ruleId: match.ruleId,
+    text: match.text,
+    start: match.start,
+    end: match.end,
+    targetText: match.targetText,
+    targetStart: match.targetStart,
+    targetEnd: match.targetEnd,
+  }));
+}
+
 describe('@scrawlix/en', () => {
   const engine = createScrawlix({
     rules: englishStrongProfanityRules,
     coverage: 'full',
   });
+  const obfuscatedEngine = createScrawlix({
+    rules: englishObfuscatedStrongProfanityRules,
+    coverage: 'full',
+  });
 
   it.each(englishProfanityCorpus)('$id', corpusCase => {
-    const matches = engine.find(corpusCase.text).map(match => ({
-      ruleId: match.ruleId,
-      text: match.text,
-      start: match.start,
-      end: match.end,
-      targetText: match.targetText,
-      targetStart: match.targetStart,
-      targetEnd: match.targetEnd,
-    }));
-
-    expect(matches).toEqual(corpusCase.matches);
+    expect(
+      expectedMatches(engine, corpusCase.text, corpusCase.profile)
+    ).toEqual(corpusCase.matches);
   });
 
   it.each(englishCleanCorpus)('$id stays clean', corpusCase => {
     expect(engine.find(corpusCase.text)).toEqual([]);
   });
 
-  it('exports a composable language pack with locale metadata', () => {
+  it.each(englishObfuscatedProfanityCorpus)('$id', corpusCase => {
+    expect(
+      expectedMatches(obfuscatedEngine, corpusCase.text, corpusCase.profile)
+    ).toEqual(corpusCase.matches);
+  });
+
+  it.each(englishObfuscatedCleanCorpus)('$id stays clean', corpusCase => {
+    expect(obfuscatedEngine.find(corpusCase.text)).toEqual([]);
+  });
+
+  it('exports composable canonical and opt-in obfuscated packs', () => {
     expect(englishStrongProfanityPack.id).toBe('en-strong-profanity');
     expect(englishStrongProfanityPack.locale).toBe('en');
     expect(englishStrongProfanityPack.rules).toBe(englishStrongProfanityRules);
+
+    expect(englishObfuscatedStrongProfanityPack.id).toBe(
+      'en-strong-profanity-obfuscated'
+    );
+    expect(englishObfuscatedStrongProfanityPack.locale).toBe('en');
+    expect(englishObfuscatedStrongProfanityPack.rules).toBe(
+      englishObfuscatedStrongProfanityRules
+    );
+  });
+
+  it('keeps canonical and obfuscated provenance distinct when packs are composed', () => {
+    const composed = createScrawlix({
+      rules: rulesFromPacks(
+        englishStrongProfanityPack,
+        englishObfuscatedStrongProfanityPack
+      ),
+    });
+
+    expect(
+      composed.find('fuck f*ck').map(match => ({
+        packId: match.packId,
+        profile: match.profile,
+        ruleId: match.ruleId,
+        text: match.text,
+      }))
+    ).toEqual([
+      {
+        packId: 'en-strong-profanity',
+        profile: 'canonical',
+        ruleId: 'fuck',
+        text: 'fuck',
+      },
+      {
+        packId: 'en-strong-profanity-obfuscated',
+        profile: 'obfuscated',
+        ruleId: 'fuck-obfuscated',
+        text: 'f*ck',
+      },
+    ]);
   });
 
   it('keeps English-specific vowel coverage in the English package', () => {

--- a/packages/en/src/index.ts
+++ b/packages/en/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  censorRuleFromObfuscatedTerms,
   graphemeRanges,
   type CensorRule,
   type CensorRulePack,
@@ -56,4 +57,73 @@ export const englishStrongProfanityPack: CensorRulePack = {
   id: 'en-strong-profanity',
   locale: 'en',
   rules: englishStrongProfanityRules,
+};
+
+const englishObfuscatedIgnored = ['.', '-', '\u200B'] as const;
+
+/**
+ * Conservative opt-in evasions for exact base forms only.
+ *
+ * Each candidate may use one reviewed substitution OR one reviewed internal
+ * separator/zero-width insertion. Inflected and compound evasions remain outside
+ * this pilot until they can preserve the canonical pack's semantic target ranges.
+ */
+export const englishObfuscatedStrongProfanityRules: readonly CensorRule[] = [
+  censorRuleFromObfuscatedTerms('fuck-obfuscated', ['fuck'], {
+    substitutions: {
+      u: ['*'],
+      c: ['('],
+    },
+    ignored: englishObfuscatedIgnored,
+    maxSubstitutions: 1,
+    maxIgnored: 1,
+    maxChanges: 1,
+  }),
+  censorRuleFromObfuscatedTerms('shit-obfuscated', ['shit'], {
+    substitutions: {
+      s: ['$', '5'],
+      i: ['1', '!', '*'],
+      t: ['7'],
+    },
+    ignored: englishObfuscatedIgnored,
+    maxSubstitutions: 1,
+    maxIgnored: 1,
+    maxChanges: 1,
+  }),
+  censorRuleFromObfuscatedTerms('bitch-obfuscated', ['bitch'], {
+    substitutions: {
+      i: ['1', '!', '*'],
+      t: ['7'],
+    },
+    ignored: englishObfuscatedIgnored,
+    maxSubstitutions: 1,
+    maxIgnored: 1,
+    maxChanges: 1,
+  }),
+  censorRuleFromObfuscatedTerms('asshole-obfuscated', ['asshole'], {
+    substitutions: {
+      a: ['@'],
+      s: ['$', '5'],
+      o: ['0'],
+    },
+    ignored: englishObfuscatedIgnored,
+    maxSubstitutions: 1,
+    maxIgnored: 1,
+    maxChanges: 1,
+  }),
+  censorRuleFromObfuscatedTerms('cunt-obfuscated', ['cunt'], {
+    substitutions: {
+      u: ['*'],
+    },
+    ignored: englishObfuscatedIgnored,
+    maxSubstitutions: 1,
+    maxIgnored: 1,
+    maxChanges: 1,
+  }),
+] as const;
+
+export const englishObfuscatedStrongProfanityPack: CensorRulePack = {
+  id: 'en-strong-profanity-obfuscated',
+  locale: 'en',
+  rules: englishObfuscatedStrongProfanityRules,
 };

--- a/packages/en/src/index.ts
+++ b/packages/en/src/index.ts
@@ -23,30 +23,35 @@ export const englishVowelCoverage: CoverageSelector = context =>
 export const englishStrongProfanityRules: readonly CensorRule[] = [
   {
     id: 'fuck',
+    profile: 'canonical',
     pattern:
       /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?:mother)?(?<core>fuck)(?:ing|ed|er|ers|s)?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
     target: { group: 'core' },
   },
   {
     id: 'shit',
+    profile: 'canonical',
     pattern:
       /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?:bull)?(?<core>shit)(?:ting|ted|ter|ters|s|ty)?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
     target: { group: 'core' },
   },
   {
     id: 'bitch',
+    profile: 'canonical',
     pattern:
       /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?<core>bitch)(?:es|ing|ed|y)?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
     target: { group: 'core' },
   },
   {
     id: 'asshole',
+    profile: 'canonical',
     pattern:
       /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?<core>asshole)s?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
     target: { group: 'core' },
   },
   {
     id: 'cunt',
+    profile: 'canonical',
     pattern:
       /(?<![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])(?<core>cunt)s?(?![\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D])/giu,
     target: { group: 'core' },


### PR DESCRIPTION
## Summary
Dogfood the bounded core obfuscation helper in `@scrawlix/en` as a separate opt-in pack with explicit corpus evidence.

- add `englishObfuscatedStrongProfanityRules`
- add `englishObfuscatedStrongProfanityPack` with id `en-strong-profanity-obfuscated`
- keep the pilot limited to exact base forms: `fuck`, `shit`, `bitch`, `asshole`, `cunt`
- allow one reviewed digit/symbol substitution OR one internal `.`, `-`, or zero-width-space insertion per candidate
- use distinct `*-obfuscated` rule ids
- label the existing canonical English regex rules with `profile: 'canonical'`
- add ten positive obfuscated corpus cases and ten clean/over-budget/ordinary-neighbor cases
- export those corpora from `@scrawlix/en/corpus`
- test canonical and obfuscated corpora independently and test composed pack provenance
- exercise the new rules and corpus export through the packed-package direct Node runtime smoke
- document the pilot’s narrow base-form and one-change scope

## Deliberate scope
Inflected and compound evasions stay outside this pilot because the generic literal helper currently targets the full transformed term. A later English expansion should preserve the canonical pack’s semantic root targets before adding those forms.

## Review expectation
The PR corpus-diff step should report the new obfuscated positives and clean regressions explicitly, giving reviewers the exact aggressive behavior added by this pack.

Progress on #38