### PR TITLE
Preserve semantic targets in obfuscated forms

### DIFF
--- a/fixtures/consumer/runtime.mjs
+++ b/fixtures/consumer/runtime.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { createScrawlix } from '@scrawlix/core';
+import { censorRuleFromTargetedObfuscatedTerms } from '@scrawlix/core/targeted-obfuscated';
 import { createDomScrawlix } from '@scrawlix/dom';
 import {
   englishObfuscatedStrongProfanityRules,
@@ -35,6 +36,23 @@ assert.ok(
     testCase => testCase.id === 'obfuscated-shit-digit'
   )
 );
+
+const targetedEngine = createScrawlix({
+  rules: [
+    censorRuleFromTargetedObfuscatedTerms(
+      'targeted-smoke',
+      [{ term: 'fucking', target: 'fuck' }],
+      {
+        substitutions: { u: ['*'] },
+        maxSubstitutions: 1,
+      }
+    ),
+  ],
+});
+const targetedMatch = targetedEngine.find('f*cking')[0];
+assert.equal(targetedMatch?.text, 'f*cking');
+assert.equal(targetedMatch?.targetText, 'f*ck');
+assert.equal(targetedMatch?.profile, 'obfuscated');
 
 const tree = {
   type: 'root',

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -104,11 +104,43 @@ const engine = createScrawlix({ rules: [canonical, obfuscated] });
 
 The obfuscated helper applies the same NFC/source-range, grapheme, and boundary guarantees as canonical terms. It defaults to `profile: 'obfuscated'` so `find()` and coverage callbacks can identify the aggressive path.
 
+### Semantic targets in obfuscated forms
+
+When a full inflection or compound should match while coverage stays attached to a smaller semantic root, use the explicit subpath helper:
+
+```ts
+import { createScrawlix } from '@scrawlix/core';
+import { censorRuleFromTargetedObfuscatedTerms } from '@scrawlix/core/targeted-obfuscated';
+
+const rule = censorRuleFromTargetedObfuscatedTerms(
+  'example-obfuscated',
+  [
+    { term: 'fucking', target: 'fuck' },
+    { term: 'motherfucker', target: 'fuck' },
+  ],
+  {
+    substitutions: { u: ['*'] },
+    ignored: ['-'],
+    maxSubstitutions: 1,
+    maxIgnored: 1,
+    maxChanges: 1,
+  }
+);
+
+const engine = createScrawlix({ rules: [rule] });
+engine.find('f*cking')[0]?.targetText; // "f*ck"
+engine.find('mother-fucker')[0]?.targetText; // "fuck"
+```
+
+Each object entry declares a full canonical `term` and one unique exact canonical `target` substring. Target edges must align to extended-grapheme boundaries. The helper delegates full matching, transform budgets, boundary policy, and canonical-source matching to `censorRuleFromObfuscatedTerms()`, then maps the declared target through the accepted transformed source slice. Ignored graphemes inside the semantic root remain inside `targetText`; ignored graphemes before or after the root remain outside it.
+
+String entries are also accepted and use the complete term as their semantic target. This helper lives on a focused subpath while the API is exercised by language packs before a wider pre-1.0 barrel decision.
+
 ## Match profiles
 
 Rules can carry an optional `profile` string. `find()` exposes it as `match.profile`, and coverage callbacks receive the same value in their context. This lets packs distinguish conservative and aggressive matching paths in diagnostics and policy code.
 
-`censorRuleFromTerms()` labels its rules `canonical` by default, while `censorRuleFromObfuscatedTerms()` labels its rules `obfuscated` by default.
+`censorRuleFromTerms()` labels its rules `canonical` by default, while `censorRuleFromObfuscatedTerms()` and the targeted obfuscated helper label their rules `obfuscated` by default.
 
 Profile names describe the matching path. Packs still own linguistic scope, reviewed transform tables, budgets, and regression negatives.
 
@@ -121,6 +153,7 @@ Profile names describe the matching path. Packs still own linguistic scope, revi
 - generic coverage presets are `full`, `tail`, `middle`, and `inner`
 - literal/custom-term matching defaults to NFC canonical equivalence and `profile: 'canonical'`
 - bounded aggressive term matching is opt-in through `censorRuleFromObfuscatedTerms()`
+- targeted aggressive matching can preserve a smaller semantic root through `@scrawlix/core/targeted-obfuscated`
 - every exposed match, target, and covered segment respects extended-grapheme boundaries
 
 Scrawlix deliberately has no built-in language or hidden profanity list. Callers select rules explicitly.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./targeted-obfuscated": {
+      "types": "./dist/targeted-obfuscated.d.ts",
+      "import": "./dist/targeted-obfuscated.js",
+      "default": "./dist/targeted-obfuscated.js"
     }
   },
   "repository": {

--- a/packages/core/src/targeted-obfuscated.test.ts
+++ b/packages/core/src/targeted-obfuscated.test.ts
@@ -90,6 +90,7 @@ describe('targeted obfuscated terms', () => {
 
   it('preserves NFC/NFD target source ranges', () => {
     const source = 'cafe\u0301s';
+    const obfuscated = `ca-fe\u0301s`;
     const engine = createScrawlix({
       rules: [
         censorRuleFromTargetedObfuscatedTerms(
@@ -103,16 +104,16 @@ describe('targeted obfuscated terms', () => {
       ],
     });
 
-    expect(engine.find(`ca-fe\u0301s`)).toEqual([
+    expect(engine.find(obfuscated)).toEqual([
       {
         ruleId: 'cafe-obfuscated',
         profile: 'obfuscated',
-        text: `ca-fe\u0301s`,
+        text: obfuscated,
         start: 0,
-        end: 8,
+        end: obfuscated.length,
         targetText: `ca-fe\u0301`,
         targetStart: 0,
-        targetEnd: 7,
+        targetEnd: `ca-fe\u0301`.length,
       },
     ]);
     expect(source.normalize('NFC')).toBe('cafés');

--- a/packages/core/src/targeted-obfuscated.test.ts
+++ b/packages/core/src/targeted-obfuscated.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import { createScrawlix } from './index';
+import { censorRuleFromTargetedObfuscatedTerms } from './targeted-obfuscated';
+
+describe('targeted obfuscated terms', () => {
+  it('preserves a semantic root inside an obfuscated inflection', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromTargetedObfuscatedTerms(
+          'fuck-obfuscated',
+          [{ term: 'fucking', target: 'fuck' }],
+          {
+            substitutions: { u: ['*'] },
+            maxSubstitutions: 1,
+          }
+        ),
+      ],
+    });
+
+    expect(engine.find('f*cking')).toEqual([
+      {
+        ruleId: 'fuck-obfuscated',
+        profile: 'obfuscated',
+        text: 'f*cking',
+        start: 0,
+        end: 7,
+        targetText: 'f*ck',
+        targetStart: 0,
+        targetEnd: 4,
+      },
+    ]);
+  });
+
+  it('maps a compound root after an ignored separator', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromTargetedObfuscatedTerms(
+          'fuck-obfuscated',
+          [{ term: 'motherfucker', target: 'fuck' }],
+          {
+            ignored: ['-'],
+            maxIgnored: 1,
+          }
+        ),
+      ],
+    });
+
+    expect(engine.find('mother-fucker')).toEqual([
+      {
+        ruleId: 'fuck-obfuscated',
+        profile: 'obfuscated',
+        text: 'mother-fucker',
+        start: 0,
+        end: 13,
+        targetText: 'fuck',
+        targetStart: 7,
+        targetEnd: 11,
+      },
+    ]);
+  });
+
+  it('keeps ignored graphemes inside the semantic target source slice', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromTargetedObfuscatedTerms(
+          'fuck-obfuscated',
+          [{ term: 'motherfucker', target: 'fuck' }],
+          {
+            ignored: ['-'],
+            maxIgnored: 1,
+          }
+        ),
+      ],
+      coverage: 'full',
+    });
+
+    const text = 'motherf-ucker';
+    expect(engine.find(text)[0]).toMatchObject({
+      text,
+      targetText: 'f-uck',
+      targetStart: 6,
+      targetEnd: 11,
+    });
+    expect(engine.segment(text)).toEqual([
+      { text: 'mother', covered: false, ruleIds: [] },
+      { text: 'f-uck', covered: true, ruleIds: ['fuck-obfuscated'] },
+      { text: 'er', covered: false, ruleIds: [] },
+    ]);
+  });
+
+  it('preserves NFC/NFD target source ranges', () => {
+    const source = 'cafe\u0301s';
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromTargetedObfuscatedTerms(
+          'cafe-obfuscated',
+          [{ term: 'cafés', target: 'café' }],
+          {
+            ignored: ['-'],
+            maxIgnored: 1,
+          }
+        ),
+      ],
+    });
+
+    expect(engine.find(`ca-fe\u0301s`)).toEqual([
+      {
+        ruleId: 'cafe-obfuscated',
+        profile: 'obfuscated',
+        text: `ca-fe\u0301s`,
+        start: 0,
+        end: 8,
+        targetText: `ca-fe\u0301`,
+        targetStart: 0,
+        targetEnd: 7,
+      },
+    ]);
+    expect(source.normalize('NFC')).toBe('cafés');
+  });
+
+  it('keeps string entries as full semantic targets', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromTargetedObfuscatedTerms('plain', ['shit'], {
+          substitutions: { i: ['1'] },
+          maxSubstitutions: 1,
+        }),
+      ],
+    });
+
+    expect(engine.find('sh1t')[0]).toMatchObject({
+      text: 'sh1t',
+      targetText: 'sh1t',
+      targetStart: 0,
+      targetEnd: 4,
+    });
+  });
+
+  it('rejects missing, repeated, split, and conflicting targets', () => {
+    expect(() =>
+      censorRuleFromTargetedObfuscatedTerms(
+        'bad',
+        [{ term: 'fucking', target: 'root' }],
+        { substitutions: { u: ['*'] }, maxSubstitutions: 1 }
+      )
+    ).toThrow('must be an exact substring');
+
+    expect(() =>
+      censorRuleFromTargetedObfuscatedTerms(
+        'bad',
+        [{ term: 'badbad', target: 'bad' }],
+        { substitutions: { a: ['@'] }, maxSubstitutions: 1 }
+      )
+    ).toThrow('must occur exactly once');
+
+    expect(() =>
+      censorRuleFromTargetedObfuscatedTerms(
+        'bad',
+        [{ term: 'e\u0301x', target: 'e' }],
+        {
+          normalization: 'none',
+          substitutions: { x: ['*'] },
+          maxSubstitutions: 1,
+        }
+      )
+    ).toThrow('must align to extended-grapheme boundaries');
+
+    expect(() =>
+      censorRuleFromTargetedObfuscatedTerms(
+        'bad',
+        [
+          { term: 'fucking', target: 'fuck' },
+          { term: 'fucking', target: 'fucking' },
+        ],
+        { substitutions: { u: ['*'] }, maxSubstitutions: 1 }
+      )
+    ).toThrow('conflicting semantic targets');
+  });
+});

--- a/packages/core/src/targeted-obfuscated.ts
+++ b/packages/core/src/targeted-obfuscated.ts
@@ -1,0 +1,248 @@
+import {
+  censorRuleFromObfuscatedTerms,
+  graphemeRanges,
+  type CensorMatcher,
+  type CensorMatcherMatch,
+  type CensorRule,
+  type ObfuscatedTermOptions,
+  type UnicodeNormalization,
+} from './index.js';
+
+export type TargetedObfuscatedTerm =
+  | string
+  | {
+      /** Full canonical form used for matching. */
+      term: string;
+      /** Unique exact canonical substring used as the semantic target. */
+      target: string;
+    };
+
+type PreparedTargetedObfuscatedTerm = {
+  term: string;
+  targetStart: number;
+  targetEnd: number;
+  matcher: CensorMatcher;
+};
+
+type TargetShadow = {
+  startByOffset: ReadonlyMap<number, number>;
+  endByOffset: ReadonlyMap<number, number>;
+};
+
+function normalize(value: string, normalization: UnicodeNormalization) {
+  return normalization === 'none' ? value : value.normalize(normalization);
+}
+
+function graphemeBoundaries(value: string) {
+  const boundaries = new Set<number>([0, value.length]);
+  for (const range of graphemeRanges(value)) {
+    boundaries.add(range.start);
+    boundaries.add(range.end);
+  }
+  return boundaries;
+}
+
+function prepareTarget(
+  entry: TargetedObfuscatedTerm,
+  normalization: UnicodeNormalization
+) {
+  const rawTerm = typeof entry === 'string' ? entry : entry.term;
+  const term = normalize(rawTerm.trim(), normalization);
+  if (!term) {
+    throw new Error('A targeted obfuscated term needs a non-empty term.');
+  }
+
+  if (typeof entry === 'string') {
+    return { term, targetStart: 0, targetEnd: term.length };
+  }
+
+  const target = normalize(entry.target.trim(), normalization);
+  if (!target) {
+    throw new Error(
+      `Targeted obfuscated term ${JSON.stringify(rawTerm)} needs a non-empty target.`
+    );
+  }
+
+  const targetStart = term.indexOf(target);
+  if (targetStart < 0) {
+    throw new Error(
+      `Target ${JSON.stringify(entry.target)} must be an exact substring of term ${JSON.stringify(rawTerm)} after normalization.`
+    );
+  }
+  if (term.indexOf(target, targetStart + 1) >= 0) {
+    throw new Error(
+      `Target ${JSON.stringify(entry.target)} must occur exactly once in term ${JSON.stringify(rawTerm)}.`
+    );
+  }
+
+  const targetEnd = targetStart + target.length;
+  const boundaries = graphemeBoundaries(term);
+  if (!boundaries.has(targetStart) || !boundaries.has(targetEnd)) {
+    throw new Error(
+      `Target ${JSON.stringify(entry.target)} must align to extended-grapheme boundaries inside term ${JSON.stringify(rawTerm)}.`
+    );
+  }
+
+  return { term, targetStart, targetEnd };
+}
+
+function targetTransformLookup(
+  options: ObfuscatedTermOptions,
+  normalization: UnicodeNormalization
+) {
+  const substitutions = new Map<string, string>();
+  for (const [canonicalValue, sourceValues] of Object.entries(
+    options.substitutions ?? {}
+  )) {
+    const canonical = normalize(canonicalValue, normalization);
+    for (const sourceValue of sourceValues) {
+      substitutions.set(normalize(sourceValue, normalization), canonical);
+    }
+  }
+
+  const ignored = new Set(
+    (options.ignored ?? []).map(value => normalize(value, normalization))
+  );
+
+  return { substitutions, ignored };
+}
+
+function sourceTargetShadow(
+  source: string,
+  sourceOffset: number,
+  normalization: UnicodeNormalization,
+  substitutions: ReadonlyMap<string, string>,
+  ignored: ReadonlySet<string>
+): TargetShadow {
+  let shadowOffset = 0;
+  const startByOffset = new Map<number, number>();
+  const endByOffset = new Map<number, number>();
+
+  for (const range of graphemeRanges(source)) {
+    const sourceGrapheme = normalize(
+      source.slice(range.start, range.end),
+      normalization
+    );
+    if (ignored.has(sourceGrapheme)) continue;
+
+    const mapped = substitutions.get(sourceGrapheme) ?? sourceGrapheme;
+    startByOffset.set(shadowOffset, sourceOffset + range.start);
+    shadowOffset += mapped.length;
+    endByOffset.set(shadowOffset, sourceOffset + range.end);
+  }
+
+  return { startByOffset, endByOffset };
+}
+
+function targetRangeForMatch(
+  text: string,
+  match: CensorMatcherMatch,
+  prepared: PreparedTargetedObfuscatedTerm,
+  normalization: UnicodeNormalization,
+  substitutions: ReadonlyMap<string, string>,
+  ignored: ReadonlySet<string>
+) {
+  if (prepared.targetStart === 0 && prepared.targetEnd === prepared.term.length) {
+    return { targetStart: match.start, targetEnd: match.end };
+  }
+
+  const shadow = sourceTargetShadow(
+    text.slice(match.start, match.end),
+    match.start,
+    normalization,
+    substitutions,
+    ignored
+  );
+  const targetStart = shadow.startByOffset.get(prepared.targetStart);
+  const targetEnd = shadow.endByOffset.get(prepared.targetEnd);
+  if (targetStart === undefined || targetEnd === undefined) {
+    throw new Error(
+      `Targeted obfuscated matcher could not map semantic target [${prepared.targetStart}, ${prepared.targetEnd}) back to source for term ${JSON.stringify(prepared.term)}.`
+    );
+  }
+
+  return { targetStart, targetEnd };
+}
+
+/**
+ * Build a bounded obfuscated term rule whose declared full forms can identify a
+ * smaller semantic target. The transform/budget semantics are exactly those of
+ * censorRuleFromObfuscatedTerms(); this helper only adds target-source mapping.
+ */
+export function censorRuleFromTargetedObfuscatedTerms(
+  id: string,
+  entries: readonly TargetedObfuscatedTerm[],
+  options: ObfuscatedTermOptions = {}
+): CensorRule {
+  const normalization = options.normalization ?? 'NFC';
+  const preparedByTerm = new Map<
+    string,
+    Omit<PreparedTargetedObfuscatedTerm, 'matcher'>
+  >();
+
+  for (const entry of entries) {
+    const prepared = prepareTarget(entry, normalization);
+    const previous = preparedByTerm.get(prepared.term);
+    if (previous) {
+      if (
+        previous.targetStart !== prepared.targetStart ||
+        previous.targetEnd !== prepared.targetEnd
+      ) {
+        throw new Error(
+          `Targeted obfuscated term ${JSON.stringify(prepared.term)} was declared with conflicting semantic targets.`
+        );
+      }
+      continue;
+    }
+    preparedByTerm.set(prepared.term, prepared);
+  }
+
+  if (preparedByTerm.size === 0) {
+    throw new Error('A censor rule needs at least one non-empty term.');
+  }
+
+  const prepared: PreparedTargetedObfuscatedTerm[] = [];
+  for (const target of preparedByTerm.values()) {
+    const baseRule = censorRuleFromObfuscatedTerms(id, [target.term], options);
+    if (!baseRule.matcher) {
+      throw new Error('Targeted obfuscated terms require a matcher-backed rule.');
+    }
+    prepared.push({ ...target, matcher: baseRule.matcher });
+  }
+  prepared.sort((left, right) => right.term.length - left.term.length);
+
+  const transforms = targetTransformLookup(options, normalization);
+
+  return {
+    id,
+    profile: options.profile ?? 'obfuscated',
+    coverage: options.coverage,
+    matcher: {
+      *find(text) {
+        const seen = new Set<string>();
+
+        for (const candidate of prepared) {
+          for (const match of candidate.matcher.find(text)) {
+            const target = targetRangeForMatch(
+              text,
+              match,
+              candidate,
+              normalization,
+              transforms.substitutions,
+              transforms.ignored
+            );
+            const key = `${match.start}:${match.end}:${target.targetStart}:${target.targetEnd}`;
+            if (seen.has(key)) continue;
+            seen.add(key);
+            yield {
+              start: match.start,
+              end: match.end,
+              targetStart: target.targetStart,
+              targetEnd: target.targetEnd,
+            };
+          }
+        }
+      },
+    },
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,9 @@
     "baseUrl": ".",
     "paths": {
       "@scrawlix/core": ["packages/core/src/index.ts"],
+      "@scrawlix/core/targeted-obfuscated": [
+        "packages/core/src/targeted-obfuscated.ts"
+      ],
       "@scrawlix/en": ["packages/en/src/index.ts"],
       "@scrawlix/en/corpus": ["packages/en/src/corpus.ts"],
       "@scrawlix/react": ["packages/react/src/index.tsx"],


### PR DESCRIPTION
## Summary
Add a focused core subpath for obfuscated full forms that need a smaller semantic target.

- add `@scrawlix/core/targeted-obfuscated`
- add `censorRuleFromTargetedObfuscatedTerms()`
- accept string entries for full-target behavior or `{ term, target }` entries for a unique exact semantic root
- delegate full matching, boundaries, normalization, substitutions, ignored graphemes, and budgets to `censorRuleFromObfuscatedTerms()`
- map the declared target back through the accepted transformed source slice
- preserve ignored graphemes that occur inside the semantic root while excluding ignored graphemes before/after it
- reject missing, repeated, grapheme-splitting, and conflicting target declarations
- cover transformed inflections, compounds, NFC/NFD ranges, coverage segmentation, and full-target string entries
- export and exercise the helper through packed-package runtime smoke

## Why a subpath
This keeps the core engine barrel stable while the target-aware aggressive API is exercised by language packs. The helper compiles with the package and has a real export/declaration surface, so it can graduate into the main barrel later without making the first implementation depend on a large engine-file rewrite.

Progress on #38
Next: expand the opt-in English aggressive pack to canonical inflections/compounds using this target mapper, with corpus diff evidence.