### PR TITLE
Extend English obfuscated matching to inflections and compounds

### DIFF
--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -21,6 +21,12 @@ export default defineConfig({
         replacement: workspaceFile('../../packages/en/src/index.ts'),
       },
       {
+        find: '@scrawlix/core/targeted-obfuscated',
+        replacement: workspaceFile(
+          '../../packages/core/src/targeted-obfuscated.ts'
+        ),
+      },
+      {
         find: '@scrawlix/core',
         replacement: workspaceFile('../../packages/core/src/index.ts'),
       },

--- a/fixtures/consumer/runtime.mjs
+++ b/fixtures/consumer/runtime.mjs
@@ -37,6 +37,23 @@ assert.ok(
   )
 );
 
+const obfuscatedInflection = obfuscatedEngine.find('f*cking')[0];
+assert.equal(obfuscatedInflection?.text, 'f*cking');
+assert.equal(obfuscatedInflection?.targetText, 'f*ck');
+assert.equal(obfuscatedInflection?.targetStart, 0);
+assert.equal(obfuscatedInflection?.targetEnd, 4);
+assert.ok(
+  englishObfuscatedProfanityCorpus.some(
+    testCase => testCase.id === 'obfuscated-fuck-ing-star'
+  )
+);
+
+const obfuscatedCompound = obfuscatedEngine.find('mother-fucker')[0];
+assert.equal(obfuscatedCompound?.text, 'mother-fucker');
+assert.equal(obfuscatedCompound?.targetText, 'fuck');
+assert.equal(obfuscatedCompound?.targetStart, 7);
+assert.equal(obfuscatedCompound?.targetEnd, 11);
+
 const targetedEngine = createScrawlix({
   rules: [
     censorRuleFromTargetedObfuscatedTerms(

--- a/packages/en/README.md
+++ b/packages/en/README.md
@@ -36,14 +36,14 @@ const scrawlix = createScrawlix({
 
 Canonical English rules expose `profile: 'canonical'` in match metadata.
 
-## Opt-in obfuscated base-form pilot
+## Opt-in obfuscated strong-profanity pack
 
-The package also exports a separate aggressive pilot:
+The package also exports a separate aggressive pack:
 
 - `englishObfuscatedStrongProfanityRules`
 - `englishObfuscatedStrongProfanityPack`
 
-It catches a small reviewed set of one-change evasions for the exact base forms `fuck`, `shit`, `bitch`, `asshole`, and `cunt`. The pilot allows one reviewed symbol/digit substitution **or** one internal `.`, `-`, or zero-width-space insertion per candidate.
+It catches a small reviewed set of one-change evasions across the same inflection and compound families declared by the canonical pack for `fuck`, `shit`, `bitch`, `asshole`, and `cunt`. The pack allows one reviewed symbol/digit substitution **or** one internal `.`, `-`, or zero-width-space insertion per candidate.
 
 ```ts
 import { createScrawlix, rulesFromPacks } from '@scrawlix/core';
@@ -60,9 +60,11 @@ const scrawlix = createScrawlix({
 });
 ```
 
-Examples covered by the pilot include `f*ck`, `sh1t`, `sh-it`, `b!tch`, `assh0le`, and `c*nt`. Matches from this pack expose `profile: 'obfuscated'` and `packId: 'en-strong-profanity-obfuscated'` when composed through `rulesFromPacks()`.
+Examples include base forms such as `f*ck` and `sh1t`, inflections such as `f*cking`, `b!tches`, `assh0les`, and `c*nts`, and compounds such as `motherf*cker`, `mother-fucker`, and `bullsh1t`. Matches from this pack expose `profile: 'obfuscated'` and `packId: 'en-strong-profanity-obfuscated'` when composed through `rulesFromPacks()`.
 
-The pilot deliberately caps each candidate at one transform. It covers exact base forms only; inflected and compound evasions need a later semantic-target-aware expansion. The reviewed table lives in ordinary package code, and its positives plus false-positive/over-budget cases live in JSON corpora.
+Full obfuscated forms preserve the canonical semantic root. For example, `f*cking` reports full match text `f*cking` with target text `f*ck`; `mother-fucker` reports the full compound with target text `fuck`; and an inserted separator inside the root, as in `motherf-ucker`, stays inside target text `f-uck`. Coverage therefore follows the same semantic profanity root as the canonical regex pack.
+
+The pack deliberately caps each candidate at one transform. The reviewed table lives in ordinary package code, and its positives plus false-positive/over-budget cases live in JSON corpora. New morphology is added only alongside explicit corpus examples and ordinary-word/boundary negatives.
 
 ## Regression data
 

--- a/packages/en/src/corpus-data/obfuscated-clean.json
+++ b/packages/en/src/corpus-data/obfuscated-clean.json
@@ -15,6 +15,20 @@
     "matches": []
   },
   {
+    "id": "obfuscated-clean-canonical-fucking",
+    "text": "fucking",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "canonical-form", "inflection"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-canonical-motherfucker",
+    "text": "motherfucker",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "canonical-form", "compound"],
+    "matches": []
+  },
+  {
     "id": "obfuscated-clean-two-substitutions",
     "text": "sh17",
     "profile": "obfuscated",
@@ -26,6 +40,13 @@
     "text": "sh1-t",
     "profile": "obfuscated",
     "tags": ["false-positive", "obfuscation", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-inflection-mixed-budget",
+    "text": "f*-cking",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "budget", "inflection"],
     "matches": []
   },
   {
@@ -68,6 +89,41 @@
     "text": "a$$orted",
     "profile": "obfuscated",
     "tags": ["false-positive", "ordinary-word"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-motherfuckerly",
+    "text": "motherf*ckerly",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "word-boundary", "compound"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-bullshitake",
+    "text": "bullsh1take",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "word-boundary", "compound"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-bitchcraft",
+    "text": "b!tchcraft",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "word-boundary", "ordinary-word"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-assholeish",
+    "text": "assh0leish",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "word-boundary"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-shittingly",
+    "text": "shit-tingly",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "word-boundary", "inflection"],
     "matches": []
   }
 ]

--- a/packages/en/src/corpus-data/obfuscated.json
+++ b/packages/en/src/corpus-data/obfuscated.json
@@ -35,6 +35,74 @@
     ]
   },
   {
+    "id": "obfuscated-fuck-ing-star",
+    "text": "f*cking",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "substitution", "inflection", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "fuck-obfuscated",
+        "text": "f*cking",
+        "start": 0,
+        "end": 7,
+        "targetText": "f*ck",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-fuck-mother-star",
+    "text": "motherf*cker",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "substitution", "compound", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "fuck-obfuscated",
+        "text": "motherf*cker",
+        "start": 0,
+        "end": 12,
+        "targetText": "f*ck",
+        "targetStart": 6,
+        "targetEnd": 10
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-fuck-mother-hyphen",
+    "text": "mother-fucker",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "punctuation-insertion", "compound", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "fuck-obfuscated",
+        "text": "mother-fucker",
+        "start": 0,
+        "end": 13,
+        "targetText": "fuck",
+        "targetStart": 7,
+        "targetEnd": 11
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-fuck-mother-root-hyphen",
+    "text": "motherf-ucker",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "punctuation-insertion", "compound", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "fuck-obfuscated",
+        "text": "motherf-ucker",
+        "start": 0,
+        "end": 13,
+        "targetText": "f-uck",
+        "targetStart": 6,
+        "targetEnd": 11
+      }
+    ]
+  },
+  {
     "id": "obfuscated-shit-digit",
     "text": "sh1t",
     "profile": "obfuscated",
@@ -103,6 +171,40 @@
     ]
   },
   {
+    "id": "obfuscated-shit-bull-digit",
+    "text": "bullsh1t",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "substitution", "compound", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "shit-obfuscated",
+        "text": "bullsh1t",
+        "start": 0,
+        "end": 8,
+        "targetText": "sh1t",
+        "targetStart": 4,
+        "targetEnd": 8
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-shit-suffix-hyphen",
+    "text": "shit-ting",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "punctuation-insertion", "inflection", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "shit-obfuscated",
+        "text": "shit-ting",
+        "start": 0,
+        "end": 9,
+        "targetText": "shit",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
     "id": "obfuscated-bitch-bang",
     "text": "b!tch",
     "profile": "obfuscated",
@@ -113,6 +215,23 @@
         "text": "b!tch",
         "start": 0,
         "end": 5,
+        "targetText": "b!tch",
+        "targetStart": 0,
+        "targetEnd": 5
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-bitch-plural-bang",
+    "text": "b!tches",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "substitution", "plural", "inflection", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "bitch-obfuscated",
+        "text": "b!tches",
+        "start": 0,
+        "end": 7,
         "targetText": "b!tch",
         "targetStart": 0,
         "targetEnd": 5
@@ -154,6 +273,23 @@
     ]
   },
   {
+    "id": "obfuscated-asshole-plural-zero",
+    "text": "assh0les",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "substitution", "plural", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "asshole-obfuscated",
+        "text": "assh0les",
+        "start": 0,
+        "end": 8,
+        "targetText": "assh0le",
+        "targetStart": 0,
+        "targetEnd": 7
+      }
+    ]
+  },
+  {
     "id": "obfuscated-cunt-star",
     "text": "c*nt",
     "profile": "obfuscated",
@@ -164,6 +300,23 @@
         "text": "c*nt",
         "start": 0,
         "end": 4,
+        "targetText": "c*nt",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-cunt-plural-star",
+    "text": "c*nts",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "substitution", "plural", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "cunt-obfuscated",
+        "text": "c*nts",
+        "start": 0,
+        "end": 5,
         "targetText": "c*nt",
         "targetStart": 0,
         "targetEnd": 4

--- a/packages/en/src/index.test.ts
+++ b/packages/en/src/index.test.ts
@@ -72,6 +72,15 @@ describe('@scrawlix/en', () => {
     expect(obfuscatedEngine.find(corpusCase.text)).toEqual([]);
   });
 
+  it('covers only the semantic root inside obfuscated inflections and compounds', () => {
+    expect(marked(obfuscatedEngine.segment('f*cking mother-fucker'))).toBe(
+      '[f*ck]ing mother-[fuck]er'
+    );
+    expect(marked(obfuscatedEngine.segment('motherf-ucker'))).toBe(
+      'mother[f-uck]er'
+    );
+  });
+
   it('exports composable canonical and opt-in obfuscated packs', () => {
     expect(englishStrongProfanityPack.id).toBe('en-strong-profanity');
     expect(englishStrongProfanityPack.locale).toBe('en');

--- a/packages/en/src/index.ts
+++ b/packages/en/src/index.ts
@@ -1,10 +1,13 @@
 import {
-  censorRuleFromObfuscatedTerms,
   graphemeRanges,
   type CensorRule,
   type CensorRulePack,
   type CoverageSelector,
 } from '@scrawlix/core';
+import {
+  censorRuleFromTargetedObfuscatedTerms,
+  type TargetedObfuscatedTerm,
+} from '@scrawlix/core/targeted-obfuscated';
 
 /**
  * Covers orthographic English vowels (a/e/i/o/u) inside the semantic target.
@@ -66,15 +69,65 @@ export const englishStrongProfanityPack: CensorRulePack = {
 
 const englishObfuscatedIgnored = ['.', '-', '\u200B'] as const;
 
+function targetedForms(
+  target: string,
+  forms: readonly string[]
+): TargetedObfuscatedTerm[] {
+  return forms.map(term => ({ term, target }));
+}
+
+const englishFuckForms = targetedForms('fuck', [
+  'fuck',
+  'fucking',
+  'fucked',
+  'fucker',
+  'fuckers',
+  'fucks',
+  'motherfuck',
+  'motherfucking',
+  'motherfucked',
+  'motherfucker',
+  'motherfuckers',
+  'motherfucks',
+]);
+
+const englishShitForms = targetedForms('shit', [
+  'shit',
+  'shitting',
+  'shitted',
+  'shitter',
+  'shitters',
+  'shits',
+  'shitty',
+  'bullshit',
+  'bullshitting',
+  'bullshitted',
+  'bullshitter',
+  'bullshitters',
+  'bullshits',
+  'bullshitty',
+]);
+
+const englishBitchForms = targetedForms('bitch', [
+  'bitch',
+  'bitches',
+  'bitching',
+  'bitched',
+  'bitchy',
+]);
+
+const englishAssholeForms = targetedForms('asshole', ['asshole', 'assholes']);
+const englishCuntForms = targetedForms('cunt', ['cunt', 'cunts']);
+
 /**
- * Conservative opt-in evasions for exact base forms only.
+ * Conservative opt-in evasions mirroring the canonical pack's declared forms.
  *
  * Each candidate may use one reviewed substitution OR one reviewed internal
- * separator/zero-width insertion. Inflected and compound evasions remain outside
- * this pilot until they can preserve the canonical pack's semantic target ranges.
+ * separator/zero-width insertion. Full inflections/compounds are matched, while
+ * coverage and target metadata stay attached to the canonical profanity root.
  */
 export const englishObfuscatedStrongProfanityRules: readonly CensorRule[] = [
-  censorRuleFromObfuscatedTerms('fuck-obfuscated', ['fuck'], {
+  censorRuleFromTargetedObfuscatedTerms('fuck-obfuscated', englishFuckForms, {
     substitutions: {
       u: ['*'],
       c: ['('],
@@ -84,7 +137,7 @@ export const englishObfuscatedStrongProfanityRules: readonly CensorRule[] = [
     maxIgnored: 1,
     maxChanges: 1,
   }),
-  censorRuleFromObfuscatedTerms('shit-obfuscated', ['shit'], {
+  censorRuleFromTargetedObfuscatedTerms('shit-obfuscated', englishShitForms, {
     substitutions: {
       s: ['$', '5'],
       i: ['1', '!', '*'],
@@ -95,7 +148,7 @@ export const englishObfuscatedStrongProfanityRules: readonly CensorRule[] = [
     maxIgnored: 1,
     maxChanges: 1,
   }),
-  censorRuleFromObfuscatedTerms('bitch-obfuscated', ['bitch'], {
+  censorRuleFromTargetedObfuscatedTerms('bitch-obfuscated', englishBitchForms, {
     substitutions: {
       i: ['1', '!', '*'],
       t: ['7'],
@@ -105,7 +158,7 @@ export const englishObfuscatedStrongProfanityRules: readonly CensorRule[] = [
     maxIgnored: 1,
     maxChanges: 1,
   }),
-  censorRuleFromObfuscatedTerms('asshole-obfuscated', ['asshole'], {
+  censorRuleFromTargetedObfuscatedTerms('asshole-obfuscated', englishAssholeForms, {
     substitutions: {
       a: ['@'],
       s: ['$', '5'],
@@ -116,7 +169,7 @@ export const englishObfuscatedStrongProfanityRules: readonly CensorRule[] = [
     maxIgnored: 1,
     maxChanges: 1,
   }),
-  censorRuleFromObfuscatedTerms('cunt-obfuscated', ['cunt'], {
+  censorRuleFromTargetedObfuscatedTerms('cunt-obfuscated', englishCuntForms, {
     substitutions: {
       u: ['*'],
     },


### PR DESCRIPTION
## Summary
Expand the opt-in English aggressive pack from exact base forms to the same declared morphology families as the canonical pack, while preserving canonical semantic roots.

- switch English aggressive rules to `censorRuleFromTargetedObfuscatedTerms()`
- mirror the canonical pack's declared `fuck`, `shit`, `bitch`, `asshole`, and `cunt` inflections/compounds
- keep the existing one-transform budget and reviewed substitution/separator table unchanged
- preserve root targets such as `f*cking` → `f*ck`, `motherf*cker` → `f*ck`, `mother-fucker` → `fuck`, and `bullsh1t` → `sh1t`
- keep ignored separators inside the semantic target only when they occur inside the root (`motherf-ucker` → `f-uck`)
- add 9 positive morphology/compound corpus cases
- add 8 clean regressions covering canonical zero-change forms, over-budget morphology, and word-boundary neighbors
- add English-level coverage assertions proving only the semantic root is covered inside inflections/compounds
- update package docs and packed runtime smoke for inflection/compound target metadata
- wire the demo workspace alias for the new `@scrawlix/core/targeted-obfuscated` source subpath while packed consumers continue to exercise the package export

## Review expectation
`corpus:diff` reports exactly 17 new cases: 9 newly matching + 8 added clean regressions. Existing aggressive base-form cases stay behaviorally unchanged.

## Dependency
Builds on merged #95, which added the target-aware core subpath and source mapping.

Progress on #38