### PR TITLE
Prune redundant DOM observer work

### DIFF
--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -90,6 +90,13 @@ function ownerDocument(node: Node): Document | null {
   return node.ownerDocument;
 }
 
+function isGeneratedRoot(node: Node) {
+  return (
+    node.nodeType === ELEMENT_NODE &&
+    (node as Element).hasAttribute('data-scrawlix-dom-root')
+  );
+}
+
 function hasGeneratedAncestor(node: Text) {
   let element = node.parentElement;
   while (element) {
@@ -179,8 +186,11 @@ export function createDomScrawlix(
   const ownedRoots = new WeakSet<Element>();
   const originalText = new WeakMap<Element, string>();
 
-  function transformTextNode(node: Text): DomApplyResult {
-    if (!isEligibleText(node, prepared)) return emptyResult();
+  function transformTextNode(
+    node: Text,
+    knownEligible = false
+  ): DomApplyResult {
+    if (!knownEligible && !isEligibleText(node, prepared)) return emptyResult();
 
     const segments = engine.segment(node.data);
     const coveredSegments = segments.filter(segment => segment.covered).length;
@@ -210,10 +220,7 @@ export function createDomScrawlix(
       return transformTextNode(root as Text);
     }
 
-    if (
-      root.nodeType === ELEMENT_NODE &&
-      (root as Element).hasAttribute('data-scrawlix-dom-root')
-    ) {
+    if (isGeneratedRoot(root)) {
       return emptyResult();
     }
 
@@ -232,7 +239,7 @@ export function createDomScrawlix(
     }
 
     return candidates.reduce(
-      (result, node) => addResults(result, transformTextNode(node)),
+      (result, node) => addResults(result, transformTextNode(node, true)),
       emptyResult()
     );
   }
@@ -240,10 +247,7 @@ export function createDomScrawlix(
   function generatedRootsWithin(root: Node): Element[] {
     const roots: Element[] = [];
 
-    if (
-      root.nodeType === ELEMENT_NODE &&
-      (root as Element).hasAttribute('data-scrawlix-dom-root')
-    ) {
+    if (isGeneratedRoot(root)) {
       roots.push(root as Element);
     }
 
@@ -284,9 +288,22 @@ export function createDomScrawlix(
     const pending = new Set<Node>();
     let scheduled = false;
 
+    const queue = (node: Node) => {
+      if (isGeneratedRoot(node)) return;
+
+      for (const existing of pending) {
+        if (existing === node || existing.contains(node)) return;
+        if (node.contains(existing)) pending.delete(existing);
+      }
+
+      pending.add(node);
+    };
+
     const flush = () => {
       scheduled = false;
-      const queued = [...pending];
+      const queued = [...pending].filter(
+        node => node === root || root.contains(node)
+      );
       pending.clear();
 
       return queued.reduce(
@@ -312,12 +329,12 @@ export function createDomScrawlix(
     const observer = new MutationObserverConstructor(records => {
       for (const record of records) {
         if (record.type === 'characterData') {
-          pending.add(record.target);
+          queue(record.target);
           continue;
         }
 
         for (const added of Array.from(record.addedNodes)) {
-          pending.add(added);
+          queue(added);
         }
       }
       if (pending.size > 0) schedule();

--- a/packages/dom/src/observation.test.ts
+++ b/packages/dom/src/observation.test.ts
@@ -29,4 +29,76 @@ describe('DOM observation lifecycle', () => {
 
     expect(document.querySelector('[data-scrawlix-dom-root]')).toBeNull();
   });
+
+  it('drops added roots that detach before queued work flushes', async () => {
+    let eligibilityChecks = 0;
+    const controller = createDomScrawlix({
+      rules,
+      coverage: 'full',
+      shouldSkipText() {
+        eligibilityChecks += 1;
+        return false;
+      },
+    });
+    const observation = controller.observe(document.body, { initial: false });
+
+    const paragraph = document.createElement('p');
+    paragraph.textContent = 'safe';
+    document.body.append(paragraph);
+    paragraph.remove();
+
+    await tick();
+
+    expect(eligibilityChecks).toBe(0);
+    observation.disconnect();
+  });
+
+  it('collapses ancestor and descendant roots from one mutation burst', async () => {
+    let eligibilityChecks = 0;
+    const controller = createDomScrawlix({
+      rules,
+      coverage: 'full',
+      shouldSkipText() {
+        eligibilityChecks += 1;
+        return false;
+      },
+    });
+    const observation = controller.observe(document.body, { initial: false });
+
+    const section = document.createElement('section');
+    document.body.append(section);
+
+    const paragraph = document.createElement('p');
+    paragraph.textContent = 'safe';
+    section.append(paragraph);
+
+    await tick();
+
+    expect(eligibilityChecks).toBe(1);
+    observation.disconnect();
+  });
+
+  it('checks dynamic text once and skips its generated wrapper mutation', async () => {
+    let eligibilityChecks = 0;
+    const controller = createDomScrawlix({
+      rules,
+      coverage: 'full',
+      shouldSkipText() {
+        eligibilityChecks += 1;
+        return false;
+      },
+    });
+    const observation = controller.observe(document.body, { initial: false });
+
+    const paragraph = document.createElement('p');
+    paragraph.textContent = 'fuck';
+    document.body.append(paragraph);
+
+    await tick();
+    await tick();
+
+    expect(eligibilityChecks).toBe(1);
+    expect(paragraph.querySelector('[data-scrawlix-dom-root]')).not.toBeNull();
+    observation.disconnect();
+  });
 });


### PR DESCRIPTION
## What changed

- avoid the second full eligibility/ancestor check when a TreeWalker candidate was already validated
- collapse pending mutation roots so an already-queued ancestor subsumes descendant roots
- discard queued nodes that detach from the observed root before flush
- ignore Scrawlix-generated wrapper roots when their own replacement mutation comes back through `MutationObserver`
- add operation-count regressions instead of wall-clock thresholds

## Invariants

- append then remove before flush performs zero eligibility scans
- ancestor + descendant mutation bursts inspect a safe text node once
- dynamic censorship checks eligible text once and its generated wrapper causes no follow-up scan

Replayed directly onto the current main tree after upstream activity; the DOM files had not otherwise changed.

Refs #54 and #57.