### PR TITLE
Rebind extension observation after body replacement

### DIFF
--- a/apps/extension/src/content.ts
+++ b/apps/extension/src/content.ts
@@ -25,6 +25,7 @@ const INTERACTIVE_ANCESTOR =
 
 let observation: DomObservation | null = null;
 let presentationObserver: MutationObserver | null = null;
+let bodyIdentityObserver: MutationObserver | null = null;
 let activeState: ExtensionSessionState | null = null;
 let activeBody: HTMLElement | null = null;
 let restartGeneration = 0;
@@ -150,6 +151,20 @@ async function restart() {
   refreshPresentation(body, profile);
 }
 
+function startBodyIdentityObserver() {
+  const root = document.documentElement;
+  if (!root || bodyIdentityObserver) return;
+
+  let previousBody = document.body;
+  bodyIdentityObserver = new MutationObserver(() => {
+    const body = document.body;
+    if (body === previousBody) return;
+    previousBody = body;
+    void restart();
+  });
+  bodyIdentityObserver.observe(root, { childList: true });
+}
+
 function clickRootFromEvent(event: Event) {
   const target = event.target;
   if (!(target instanceof Element)) return null;
@@ -189,8 +204,18 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
 });
 
 function startWhenReady() {
+  startBodyIdentityObserver();
   if (document.body) void restart();
-  else window.addEventListener('DOMContentLoaded', () => void restart(), { once: true });
+  else {
+    window.addEventListener(
+      'DOMContentLoaded',
+      () => {
+        startBodyIdentityObserver();
+        void restart();
+      },
+      { once: true }
+    );
+  }
 }
 
 startWhenReady();

--- a/tests/browser/body-replacement.spec.ts
+++ b/tests/browser/body-replacement.spec.ts
@@ -1,0 +1,42 @@
+import { chromium, expect, test } from '@playwright/test';
+import { resolve } from 'node:path';
+
+const extensionPath = resolve(process.cwd(), 'apps/extension/dist');
+
+test('built extension rebinds after the page replaces document.body', async ({}, testInfo) => {
+  const context = await chromium.launchPersistentContext(
+    testInfo.outputPath('extension-body-replacement'),
+    {
+      channel: 'chromium',
+      headless: true,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+      ],
+    }
+  );
+
+  try {
+    const page = context.pages()[0] ?? (await context.newPage());
+    await page.goto('http://127.0.0.1:4174/fixture.html');
+    await expect(page.locator('#initial [data-scrawlix-dom-root]')).toHaveCount(1);
+
+    await page.getByRole('button', { name: 'replace body' }).click();
+
+    await expect(
+      page.locator('#replacement [data-scrawlix-dom-root]')
+    ).toHaveCount(1);
+    await expect(
+      page.locator('#replacement [data-scrawlix-cover]')
+    ).toHaveText('uc');
+    await expect(
+      page.locator('#replacement-link [data-scrawlix-dom-root]')
+    ).toHaveCount(1);
+
+    await page.locator('#replacement-link').click();
+    await expect(page).toHaveURL('http://127.0.0.1:4174/clicked.html');
+    await expect(page.locator('#clicked')).toHaveText('native link worked');
+  } finally {
+    await context.close();
+  }
+});

--- a/tests/browser/fixture-server.mjs
+++ b/tests/browser/fixture-server.mjs
@@ -15,6 +15,7 @@ const fixture = `<!doctype html>
       <button id="native-button" type="button">fuck</button>
       <a id="native-link" href="/clicked.html">fuck</a>
       <button id="add-dynamic" type="button">add dynamic</button>
+      <button id="replace-body" type="button">replace body</button>
       <section id="dynamic-root"></section>
     </main>
     <script>
@@ -23,6 +24,12 @@ const fixture = `<!doctype html>
         paragraph.id = 'dynamic-copy';
         paragraph.textContent = 'dynamic fuck arrived';
         document.querySelector('#dynamic-root').append(paragraph);
+      });
+
+      document.querySelector('#replace-body').addEventListener('click', () => {
+        const nextBody = document.createElement('body');
+        nextBody.innerHTML = '<main><p id="replacement">replacement fuck arrived</p><a id="replacement-link" href="/clicked.html">fuck</a></main>';
+        document.body.replaceWith(nextBody);
       });
     </script>
   </body>


### PR DESCRIPTION
## What changed

- watch direct `documentElement` child changes for `document.body` identity replacement
- restart the current extension session when the body element changes
- preserve the existing generation guard so rapid remove/replace sequences converge on the latest body
- add a dedicated real-Chromium regression using the built MV3 extension
- replace the fixture body, verify replacement profanity is censored, and verify a transformed replacement link keeps native navigation

## Why

The semantic and presentation observers attach to a specific body element. Pages that replace `<body>` leave both observers attached to a detached tree unless the content script notices the identity change.

The watcher observes only direct document-element children, so ordinary page mutation traffic never hits it.

Refs #54 and #23.