### PR TITLE
Document framework-neutral renderer adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added compiled ESM/declaration artifacts for public packages.
 - Added external tarball consumer smoke tests as a CI release gate, with strict declaration checking, React 18/19 production builds, and a Next.js 16 App Router production build using the documented client-wrapper boundary.
 - Added package-local READMEs for every public package, exact install commands, a top-level integration chooser, a docs index, React CSS troubleshooting, Next.js client-boundary guidance, and clearer source/accessibility notes.
+- Added a framework-neutral renderer recipe with plain-DOM, Vue, Svelte, and Solid sketches plus a threshold for when a dedicated adapter package is worth maintaining.
 - Added explicit runtime compatibility and pre-1.0 versioning/public-contract policies.
 - Added explicit privacy/output vocabulary for visual covers, presentation/screenshot guarantees, assistive-tech concealment, and sanitized export.
 - Aligned `README.md`, `AGENTS.md`, `llms.txt`, demo, extension, tests, and smoke consumers on the canonical pre-release public names and conservative defaults.

--- a/apps/demo/public/llms.txt
+++ b/apps/demo/public/llms.txt
@@ -71,6 +71,13 @@ const engine = createScrawlix({
 });
 ```
 
+Framework-neutral renderer rule:
+- For Vue, Svelte, Solid, plain DOM, or another UI layer, start from `engine.segment(text)` before proposing a new Scrawlix package.
+- Render segments in order and preserve each `segment.text` exactly. Covered segments carry `covered: true` plus `ruleIds`; appearance and interaction belong to the application renderer.
+- Use `docs/custom-renderers.md` for plain-DOM, Vue, Svelte, and Solid sketches.
+- A dedicated adapter package is justified when it owns reusable framework-specific interaction, accessibility, lifecycle/restoration, SSR/client-boundary behavior, plugin integration, or a tested DOM/CSS contract. A simple segment loop belongs in application code/docs.
+- Custom renderers preserve source text unless they explicitly implement separate sanitized-output semantics; do not market a CSS cover as destructive redaction.
+
 Custom terms and phrases:
 
 ```ts
@@ -119,6 +126,7 @@ The browser extension keeps browser state outside reusable packages. Global trea
 
 Use only documented public package exports. Maintainer guidance: https://github.com/teamleaderleo/scrawlix/blob/main/AGENTS.md
 Docs index: https://github.com/teamleaderleo/scrawlix/blob/main/docs/README.md
+Custom renderers: https://github.com/teamleaderleo/scrawlix/blob/main/docs/custom-renderers.md
 Compatibility: https://github.com/teamleaderleo/scrawlix/blob/main/docs/compatibility.md
 Versioning: https://github.com/teamleaderleo/scrawlix/blob/main/docs/versioning.md
 Language packs: https://github.com/teamleaderleo/scrawlix/blob/main/docs/language-packs.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Start with the repository README for installation and the shortest path for your
 - [`compatibility.md`](./compatibility.md) — JavaScript/browser capabilities, Node baseline, React majors, grapheme fallback, DOM/CSS/TypeScript expectations
 - [`versioning.md`](./versioning.md) — synchronized release train, 0.x semver policy, public data/CSS contracts, and deprecation rules
 - [`privacy-and-output.md`](./privacy-and-output.md) — visual covers, presentation/screenshot guarantees, accessibility policy, and sanitized export semantics
+- [`custom-renderers.md`](./custom-renderers.md) — render `@scrawlix/core` segments in plain DOM, Vue, Svelte, Solid, or another UI layer without adding another Scrawlix package
 - [`language-packs.md`](./language-packs.md) — author and compose language/rule packs, semantic targets, boundaries, coverage helpers, and corpora
 - [`dom.md`](./dom.md) — arbitrary-page DOM application, observation, exclusions, and exact restoration
 - [`releasing.md`](./releasing.md) — first-release gates, package verification, registry checks, and publication sequence
@@ -17,7 +18,8 @@ Start with the repository README for installation and the shortest path for your
 - React rendering and reveal behavior: `@scrawlix/react`
 - Markdown / unified / HAST: `@scrawlix/rehype`
 - existing browser DOM or extension content scripts: `@scrawlix/dom`
-- matching/segmentation or a custom renderer: `@scrawlix/core`
+- Vue, Svelte, Solid, or a custom renderer: `@scrawlix/core` + [`custom-renderers.md`](./custom-renderers.md)
+- matching/segmentation without rendering: `@scrawlix/core`
 - packaged English rules: `@scrawlix/en`
 
 Each public package has its own README so the npm package page contains a usable quickstart.

--- a/docs/custom-renderers.md
+++ b/docs/custom-renderers.md
@@ -1,0 +1,174 @@
+# Custom and framework-neutral renderers
+
+`@scrawlix/core` is enough when a framework only needs to turn matched ranges into its own markup. A dedicated adapter earns its keep when it owns interaction, accessibility, lifecycle, restoration, SSR/client-boundary behavior, or a stable framework-specific DOM/CSS contract.
+
+## Install
+
+```sh
+npm install @scrawlix/core @scrawlix/en
+```
+
+## The renderer contract
+
+`createScrawlix(...).segment(text)` returns ordered `ScrawlixSegment` values:
+
+```ts
+type ScrawlixSegment = {
+  text: string;
+  covered: boolean;
+  ruleIds: readonly string[];
+};
+```
+
+Renderers should preserve these invariants:
+
+- render segments in the returned order
+- preserve every `segment.text` exactly
+- treat `covered: true` as presentation metadata rather than rewriting the source substring
+- keep `ruleIds` available when styling, diagnostics, analytics, or policy UI needs to know which rules contributed
+- make `segments.map(segment => segment.text).join('')` equivalent to the original source text
+
+Core deliberately leaves appearance, reveal interaction, accessibility presentation, and DOM ownership to the renderer.
+
+## Plain DOM example
+
+This is the smallest useful adapter: semantic covered spans plus application-owned CSS.
+
+```ts
+import { createScrawlix } from '@scrawlix/core';
+import { englishStrongProfanityRules } from '@scrawlix/en';
+
+const engine = createScrawlix({
+  rules: englishStrongProfanityRules,
+  coverage: 'middle',
+});
+
+export function renderScrawlixText(text: string) {
+  const root = document.createElement('span');
+
+  for (const segment of engine.segment(text)) {
+    if (!segment.covered) {
+      root.append(document.createTextNode(segment.text));
+      continue;
+    }
+
+    const cover = document.createElement('span');
+    cover.setAttribute('data-scrawlix-cover', '');
+    cover.setAttribute('data-scrawlix-rules', segment.ruleIds.join(','));
+    cover.textContent = segment.text;
+    root.append(cover);
+  }
+
+  return root;
+}
+```
+
+```css
+[data-scrawlix-cover] {
+  background: currentColor;
+  color: transparent;
+  border-radius: 0.08em;
+}
+```
+
+This preserves the source substring in the DOM. It is reversible visual presentation. See `privacy-and-output.md` before using a custom renderer for secrets, screenshots, assistive-technology concealment, or sanitized export.
+
+## Vue sketch
+
+Keep the engine outside render work when its rules/options are stable, derive segments from the current text, and let Vue escape text content normally.
+
+```vue
+<script setup lang="ts">
+import { computed } from 'vue';
+import { createScrawlix } from '@scrawlix/core';
+import { englishStrongProfanityRules } from '@scrawlix/en';
+
+const props = defineProps<{ text: string }>();
+const engine = createScrawlix({ rules: englishStrongProfanityRules });
+const segments = computed(() => engine.segment(props.text));
+</script>
+
+<template>
+  <template v-for="(segment, index) in segments" :key="index">
+    <span
+      v-if="segment.covered"
+      data-scrawlix-cover
+      :data-scrawlix-rules="segment.ruleIds.join(',')"
+    >{{ segment.text }}</span>
+    <template v-else>{{ segment.text }}</template>
+  </template>
+</template>
+```
+
+## Svelte sketch
+
+```svelte
+<script lang="ts">
+  import { createScrawlix } from '@scrawlix/core';
+  import { englishStrongProfanityRules } from '@scrawlix/en';
+
+  export let text: string;
+  const engine = createScrawlix({ rules: englishStrongProfanityRules });
+  $: segments = engine.segment(text);
+</script>
+
+{#each segments as segment}
+  {#if segment.covered}
+    <span data-scrawlix-cover data-scrawlix-rules={segment.ruleIds.join(',')}>
+      {segment.text}
+    </span>
+  {:else}
+    {segment.text}
+  {/if}
+{/each}
+```
+
+## Solid sketch
+
+```tsx
+import { For } from 'solid-js';
+import { createScrawlix } from '@scrawlix/core';
+import { englishStrongProfanityRules } from '@scrawlix/en';
+
+const engine = createScrawlix({ rules: englishStrongProfanityRules });
+
+export function ScrawlixText(props: { text: string }) {
+  const segments = () => engine.segment(props.text);
+
+  return (
+    <For each={segments()}>
+      {segment =>
+        segment.covered ? (
+          <span
+            data-scrawlix-cover
+            data-scrawlix-rules={segment.ruleIds.join(',')}
+          >
+            {segment.text}
+          </span>
+        ) : (
+          segment.text
+        )
+      }
+    </For>
+  );
+}
+```
+
+These sketches intentionally stop at semantic covered spans. They do not attempt to reproduce `@scrawlix/react` reveal state or accessibility behavior.
+
+## When a dedicated adapter package is justified
+
+A new public framework adapter should solve framework-specific behavior that would otherwise be duplicated across applications. Good reasons include:
+
+- keyboard/pointer reveal interaction with regression tests
+- a deliberate accessibility contract
+- framework lifecycle cleanup or restoration
+- SSR/hydration or server/client-boundary requirements
+- framework-native plugin hooks or content-pipeline integration
+- a stable appearance DOM/CSS contract that needs coordinated package tests
+
+If the implementation is only `engine.segment(text)` plus a loop that renders text and covered spans, keep it as an application component or recipe. That keeps the public package set small while giving every framework a short adoption path.
+
+## Authoring your own adapter
+
+Start with core rather than copying another adapter's internals. Preserve source text, keep rule selection explicit, and add tests for the framework-specific behavior your adapter introduces. If an adapter becomes reusable enough to propose as a Scrawlix package, document the new responsibility in `AGENTS.md`, add packed-package consumer coverage, and give it its own package README.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -27,7 +27,7 @@ const scrawlix = createScrawlix({
 const segments = scrawlix.segment('what the fuck');
 ```
 
-The engine preserves the caller-owned source string. It reports matches and covered segments; rendering belongs to an adapter such as `@scrawlix/react`, `@scrawlix/rehype`, or `@scrawlix/dom`.
+The engine preserves the caller-owned source string. It reports matches and covered segments; rendering belongs to an adapter such as `@scrawlix/react`, `@scrawlix/rehype`, or `@scrawlix/dom`, or to a small application-owned renderer. Vue, Svelte, Solid, plain-DOM, and other consumers can start with [`docs/custom-renderers.md`](../../docs/custom-renderers.md) instead of waiting for another package.
 
 ## Custom terms
 
@@ -158,4 +158,4 @@ Profile names describe the matching path. Packs still own linguistic scope, revi
 
 Scrawlix deliberately has no built-in language or hidden profanity list. Callers select rules explicitly.
 
-See the repository README for framework quickstarts and `docs/language-packs.md` for pack authoring.
+See the repository README for framework quickstarts, [`docs/custom-renderers.md`](../../docs/custom-renderers.md) for framework-neutral rendering, and `docs/language-packs.md` for pack authoring.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -27,7 +27,7 @@ const scrawlix = createScrawlix({
 const segments = scrawlix.segment('what the fuck');
 ```
 
-The engine preserves the caller-owned source string. It reports matches and covered segments; rendering belongs to an adapter such as `@scrawlix/react`, `@scrawlix/rehype`, or `@scrawlix/dom`, or to a small application-owned renderer. Vue, Svelte, Solid, plain-DOM, and other consumers can start with [`docs/custom-renderers.md`](../../docs/custom-renderers.md) instead of waiting for another package.
+The engine preserves the caller-owned source string. It reports matches and covered segments; rendering belongs to an adapter such as `@scrawlix/react`, `@scrawlix/rehype`, or `@scrawlix/dom`, or to a small application-owned renderer. Vue, Svelte, Solid, plain-DOM, and other consumers can start with the [custom-renderer recipe](https://github.com/teamleaderleo/scrawlix/blob/main/docs/custom-renderers.md) instead of waiting for another package.
 
 ## Custom terms
 
@@ -158,4 +158,4 @@ Profile names describe the matching path. Packs still own linguistic scope, revi
 
 Scrawlix deliberately has no built-in language or hidden profanity list. Callers select rules explicitly.
 
-See the repository README for framework quickstarts, [`docs/custom-renderers.md`](../../docs/custom-renderers.md) for framework-neutral rendering, and `docs/language-packs.md` for pack authoring.
+See the repository README for framework quickstarts, the [custom-renderer recipe](https://github.com/teamleaderleo/scrawlix/blob/main/docs/custom-renderers.md) for framework-neutral rendering, and `docs/language-packs.md` for pack authoring.


### PR DESCRIPTION
## Summary

Closes the non-React adoption gap from #49 without adding another public package.

### Renderer contract
- document the `ScrawlixSegment` rendering contract from `engine.segment(text)`
- preserve source text and rule metadata explicitly
- call out that appearance, reveal interaction, accessibility presentation, and DOM ownership belong to the renderer

### Recipes
- add a complete plain-DOM renderer
- add compact Vue, Svelte, and Solid sketches
- link the recipe from the docs index and the `@scrawlix/core` package README
- teach coding agents the same path in `llms.txt`

### Package threshold
- document when a dedicated adapter package earns its existence: reusable interaction/accessibility, lifecycle/restoration, SSR/client boundaries, framework plugin hooks, or a tested framework-specific DOM/CSS contract
- keep a plain `segment()` loop in app code/docs instead of multiplying public packages

No runtime/package API changes and no new framework dependencies.

Closes #49.