### PR TITLE
Move durable extension settings into a full-tab Options page

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -52,6 +52,20 @@ The popup exposes a tri-state site mode:
 
 The master pause remains a true kill switch and wins over every hostname override.
 
+## Popup and Options
+
+The popup is the current-page control surface. It owns the master pause, current hostname policy, temporary reveal, current browser access, treatment controls, and a compact count of custom terms/site exceptions.
+
+Long-lived collections live in a full-tab `options.html` page opened through `chrome.runtime.openOptionsPage()`:
+
+- General preferences with a live specimen rendered by the real Scrawlix core/coverage/mask logic
+- explicit Add/Remove custom-term management with filtering and the same 200-code-point limit used by context-menu additions
+- searchable site exceptions with `always on`, `always off`, and **use default** actions
+- a read-only summary of persistent browser host grants
+- concise privacy/source/version information
+
+Moving custom terms out of the popup removes the popup-lifecycle debounce hazard: term changes now persist through explicit Add/Remove actions in a durable browser tab.
+
 ## Browser access
 
 The store-facing manifest requests no HTTP/HTTPS host permission at install time. It declares broad HTTP/HTTPS patterns under `optional_host_permissions` and exposes two explicit runtime choices:
@@ -64,6 +78,8 @@ A small Manifest V3 service worker keeps one dynamic content-script registration
 Browser access and Scrawlix policy are separate. A site can be configured `on` while Chrome access is still missing; the popup reports that state directly instead of claiming censorship is already active.
 
 Opening the popup on a persistently granted site also ensures the current page runtime is present. This covers pages that were already open when access changed and keeps the displayed current-site state aligned with the actual page.
+
+The Options page currently summarizes granted sites without removing them. Multi-site access removal belongs there only after revocation can restore every affected open tab before Chrome drops the grant.
 
 ## Quick interactions
 
@@ -131,7 +147,8 @@ See [`docs/extension-privacy.md`](../../docs/extension-privacy.md) for the curre
 - `content.js` exists
 - `content.css` exists
 - `popup.html` exists
+- `options.html` exists and is registered as a full-tab Options page
 - broad HTTP/HTTPS patterns remain optional instead of required host permissions
-- every directly referenced popup/background asset exists in `dist`
+- every directly referenced popup/background/options asset exists in `dist`
 
-Unit tests cover preference normalization/reconciliation, browser-access helpers, local-vs-sync storage, and selection normalization. The Chromium smoke build promotes optional host patterns only inside a temporary test copy of the manifest so CI can exercise the same service-worker registration, real content script, and temporary page reveal without weakening the shipping manifest.
+Unit tests cover preference normalization/reconciliation, browser-access helpers, local-vs-sync storage, and selection normalization. The Chromium smoke build promotes optional host patterns only inside a temporary test copy of the manifest so CI can exercise the same service-worker registration, real content script, temporary page reveal, and Options custom-term round trip without weakening the shipping manifest.

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -12,6 +12,10 @@
     "default_popup": "popup.html",
     "default_title": "Scrawlix"
   },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
   "commands": {
     "temporary-reveal": {
       "suggested_key": {

--- a/apps/extension/options.html
+++ b/apps/extension/options.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Scrawlix settings</title>
+  </head>
+  <body>
+    <main class="options-shell">
+      <header class="options-header">
+        <div>
+          <p class="wordmark">scrawlix<span aria-hidden="true">*</span></p>
+          <p class="tagline">browser settings</p>
+        </div>
+        <div class="header-meta">
+          <span id="version"></span>
+          <a href="https://github.com/teamleaderleo/scrawlix" target="_blank" rel="noreferrer">source ↗</a>
+        </div>
+      </header>
+
+      <section class="panel" aria-labelledby="general-heading">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">general</p>
+            <h1 id="general-heading">How Scrawlix behaves</h1>
+          </div>
+          <span id="settings-status" class="save-status" aria-live="polite"></span>
+        </div>
+
+        <div class="general-grid">
+          <label class="toggle-card">
+            <span>
+              <strong>Active</strong>
+              <small>Master pause across every site</small>
+            </span>
+            <input id="active" type="checkbox" />
+          </label>
+
+          <label>
+            <span>Default sites</span>
+            <select id="default-enabled">
+              <option value="on">on</option>
+              <option value="off">off</option>
+            </select>
+          </label>
+
+          <label>
+            <span>Censor style</span>
+            <select id="appearance">
+              <option value="scrawl">scrawl</option>
+              <option value="bar">bar</option>
+              <option value="blur">blur</option>
+              <option value="asterisk">asterisk</option>
+              <option value="grawlix">grawlix</option>
+            </select>
+          </label>
+
+          <label>
+            <span>How much to hide</span>
+            <select id="coverage">
+              <option value="middle">middle</option>
+              <option value="vowel">vowels</option>
+              <option value="inner">inner letters</option>
+              <option value="tail">after first letter</option>
+              <option value="full">whole word</option>
+            </select>
+          </label>
+
+          <label>
+            <span>Reveal</span>
+            <select id="reveal">
+              <option value="hover">hover</option>
+              <option value="focus">focus</option>
+              <option value="click">click</option>
+              <option value="never">hidden</option>
+            </select>
+          </label>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="custom-heading">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">your list</p>
+            <h2 id="custom-heading">Custom terms</h2>
+          </div>
+          <span id="custom-count" class="count-label"></span>
+        </div>
+
+        <form id="add-terms-form" class="add-terms">
+          <label for="new-terms">Add words or phrases</label>
+          <textarea
+            id="new-terms"
+            rows="3"
+            placeholder="Project Velvet&#10;Mothbit&#10;spoiler phrase"
+            spellcheck="false"
+          ></textarea>
+          <div class="form-actions">
+            <p class="hint">One per line · up to 200 Unicode code points each</p>
+            <button type="submit">add terms</button>
+          </div>
+          <p id="custom-status" class="save-status" aria-live="polite"></p>
+        </form>
+
+        <label class="filter-row">
+          <span>Filter custom terms</span>
+          <input id="term-filter" type="search" placeholder="Search your list" />
+        </label>
+        <ul id="term-list" class="managed-list"></ul>
+        <p id="term-empty" class="empty-state">Your custom list is empty.</p>
+      </section>
+
+      <section class="panel" aria-labelledby="sites-heading">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">site policy</p>
+            <h2 id="sites-heading">Site exceptions</h2>
+          </div>
+          <span id="site-count" class="count-label"></span>
+        </div>
+        <p class="section-copy">Only explicit always-on / always-off exceptions appear here. Removing one returns that hostname to your default site behavior.</p>
+        <label class="filter-row">
+          <span>Filter site exceptions</span>
+          <input id="site-filter" type="search" placeholder="Search hostnames" />
+        </label>
+        <ul id="site-list" class="managed-list"></ul>
+        <p id="site-empty" class="empty-state">No site exceptions yet.</p>
+      </section>
+
+      <section class="panel" aria-labelledby="access-heading">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">browser access</p>
+            <h2 id="access-heading">Granted websites</h2>
+          </div>
+          <span id="access-count" class="count-label"></span>
+        </div>
+        <p class="section-copy">Grant or remove access for the page you are browsing from the Scrawlix popup. Chrome also exposes site-access controls in the extension menu.</p>
+        <ul id="access-list" class="access-list"></ul>
+        <p id="access-empty" class="empty-state">Scrawlix has no persistent website access yet.</p>
+      </section>
+
+      <section class="panel privacy-panel" aria-labelledby="privacy-heading">
+        <p class="eyebrow">privacy</p>
+        <h2 id="privacy-heading">Local page processing</h2>
+        <p>Page text is matched in the browser and is never sent to a Scrawlix server. Custom terms and hostname exceptions stay in this browser profile. Compact general preferences may sync through Chrome Sync.</p>
+        <a href="https://github.com/teamleaderleo/scrawlix/blob/main/docs/extension-privacy.md" target="_blank" rel="noreferrer">Read the privacy statement ↗</a>
+      </section>
+    </main>
+
+    <script type="module" src="/src/options.ts"></script>
+  </body>
+</html>

--- a/apps/extension/options.html
+++ b/apps/extension/options.html
@@ -76,6 +76,15 @@
             </select>
           </label>
         </div>
+
+        <div class="preview-card" aria-labelledby="preview-heading">
+          <div>
+            <p class="eyebrow">live specimen</p>
+            <h2 id="preview-heading">Mothbit</h2>
+            <p id="preview-caption" class="section-copy"></p>
+          </div>
+          <p id="preview-stage" class="preview-stage" aria-label="Live Scrawlix treatment preview"></p>
+        </div>
       </section>
 
       <section class="panel" aria-labelledby="custom-heading">

--- a/apps/extension/popup.html
+++ b/apps/extension/popup.html
@@ -96,21 +96,15 @@
         </label>
       </section>
 
-      <section class="custom-words" aria-labelledby="custom-heading">
-        <div class="section-label">
-          <div>
-            <p class="eyebrow">your list</p>
-            <h2 id="custom-heading">Custom words & phrases</h2>
-          </div>
-          <span id="save-status" class="save-status" aria-live="polite"></span>
+      <section class="manage-card" aria-label="Manage Scrawlix settings">
+        <div>
+          <p class="eyebrow">your rules</p>
+          <p class="manage-summary">
+            <span><strong id="custom-count">0</strong> custom terms</span>
+            <span><strong id="site-exception-count">0</strong> site exceptions</span>
+          </p>
         </div>
-        <textarea
-          id="custom-words"
-          rows="5"
-          placeholder="Project Velvet&#10;Mothbit&#10;spoiler phrase"
-          spellcheck="false"
-        ></textarea>
-        <p class="hint">One per line. Saved locally in this browser.</p>
+        <button id="open-options" type="button">manage…</button>
       </section>
 
       <footer>

--- a/apps/extension/scripts/validate-build.mjs
+++ b/apps/extension/scripts/validate-build.mjs
@@ -4,7 +4,14 @@ import { resolve } from 'node:path';
 const dist = resolve(process.cwd(), 'dist');
 const manifestPath = resolve(dist, 'manifest.json');
 
-for (const file of ['manifest.json', 'background.js', 'content.js', 'content.css', 'popup.html']) {
+for (const file of [
+  'manifest.json',
+  'background.js',
+  'content.js',
+  'content.css',
+  'popup.html',
+  'options.html',
+]) {
   if (!existsSync(resolve(dist, file))) {
     throw new Error(`Extension build is missing ${file}.`);
   }
@@ -26,9 +33,14 @@ for (const pattern of ['http://*/*', 'https://*/*']) {
   }
 }
 
+if (manifest.options_ui?.page !== 'options.html' || manifest.options_ui?.open_in_tab !== true) {
+  throw new Error('Extension manifest must register options.html as a full-tab options page.');
+}
+
 const referenced = [
   manifest.action?.default_popup,
   manifest.background?.service_worker,
+  manifest.options_ui?.page,
   ...(manifest.content_scripts ?? []).flatMap(entry => [
     ...(entry.js ?? []),
     ...(entry.css ?? []),

--- a/apps/extension/src/actions.ts
+++ b/apps/extension/src/actions.ts
@@ -1,14 +1,13 @@
 export const ADD_SELECTION_MENU_ID = 'scrawlix-add-selection';
 export const TEMPORARY_REVEAL_COMMAND = 'temporary-reveal';
 export const TEMPORARY_REVEAL_MS = 10_000;
-
-const MAX_CONTEXT_TERM_CODE_POINTS = 200;
+export const MAX_CUSTOM_TERM_CODE_POINTS = 200;
 
 export function customTermFromSelection(value: unknown): string | null {
   if (typeof value !== 'string') return null;
 
   const term = value.trim().replace(/\s+/gu, ' ');
   if (!term) return null;
-  if (Array.from(term).length > MAX_CONTEXT_TERM_CODE_POINTS) return null;
+  if (Array.from(term).length > MAX_CUSTOM_TERM_CODE_POINTS) return null;
   return term;
 }

--- a/apps/extension/src/options.css
+++ b/apps/extension/src/options.css
@@ -1,0 +1,433 @@
+:root {
+  color: #171510;
+  background: #f2eddf;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background:
+    linear-gradient(rgba(23, 21, 16, 0.028) 1px, transparent 1px) 0 0 / 100% 28px,
+    #f2eddf;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button,
+select,
+input,
+textarea {
+  color: inherit;
+}
+
+.options-shell {
+  width: min(880px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 28px 0 64px;
+}
+
+.options-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 18px 0 22px;
+  border-top: 4px solid #171510;
+  border-bottom: 1px solid #171510;
+}
+
+.wordmark {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(36px, 7vw, 64px);
+  font-weight: 700;
+  line-height: 0.86;
+  letter-spacing: -0.055em;
+}
+
+.wordmark span {
+  display: inline-block;
+  margin-left: 2px;
+  transform: rotate(-10deg);
+}
+
+.tagline,
+.eyebrow,
+.header-meta,
+.save-status,
+.count-label,
+.general-grid label > span,
+.general-grid small,
+.filter-row > span,
+.hint,
+.section-copy,
+.empty-state,
+.quiet-button,
+.form-actions button,
+.access-list {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.tagline {
+  margin: 9px 0 0;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.13em;
+  opacity: 0.58;
+}
+
+.header-meta {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.header-meta a,
+.privacy-panel a {
+  color: inherit;
+}
+
+.panel {
+  padding: 24px 0 28px;
+  border-bottom: 1px solid #171510;
+}
+
+.section-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+}
+
+.eyebrow {
+  margin: 0 0 5px;
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  opacity: 0.5;
+}
+
+h1,
+h2 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-weight: 600;
+  letter-spacing: -0.035em;
+}
+
+h1 {
+  font-size: clamp(25px, 4vw, 36px);
+}
+
+h2 {
+  font-size: clamp(22px, 3vw, 30px);
+}
+
+.save-status,
+.count-label {
+  min-height: 1em;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.58;
+}
+
+.general-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.general-grid label {
+  display: block;
+}
+
+.general-grid label > span {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.general-grid .toggle-card {
+  display: flex;
+  grid-column: 1 / -1;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  min-height: 64px;
+  padding: 12px 14px;
+  border: 1px solid rgba(23, 21, 16, 0.42);
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.general-grid .toggle-card span {
+  margin: 0;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.toggle-card strong,
+.toggle-card small {
+  display: block;
+}
+
+.toggle-card strong {
+  font-size: 13px;
+}
+
+.toggle-card small {
+  margin-top: 3px;
+  font-size: 9px;
+  font-weight: 400;
+  opacity: 0.62;
+}
+
+.toggle-card input {
+  width: 20px;
+  height: 20px;
+  accent-color: #171510;
+}
+
+select,
+input[type='search'],
+textarea {
+  width: 100%;
+  border: 1px solid rgba(23, 21, 16, 0.42);
+  border-radius: 0;
+  background: rgba(255, 255, 255, 0.28);
+  outline: none;
+}
+
+select {
+  min-height: 40px;
+  padding: 7px 9px;
+}
+
+input[type='search'] {
+  min-height: 40px;
+  padding: 8px 10px;
+}
+
+textarea {
+  min-height: 88px;
+  padding: 10px;
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  line-height: 1.45;
+}
+
+select:focus,
+input:focus,
+textarea:focus,
+button:focus-visible {
+  outline: 2px solid #171510;
+  outline-offset: 2px;
+}
+
+.add-terms {
+  padding: 14px;
+  border: 1px solid #171510;
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.add-terms > label {
+  display: block;
+  margin-bottom: 7px;
+  font-weight: 650;
+}
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 9px;
+}
+
+.form-actions button,
+.quiet-button {
+  border-radius: 0;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.055em;
+}
+
+.form-actions button {
+  min-height: 36px;
+  padding: 7px 12px;
+  color: #f2eddf;
+  background: #171510;
+  border: 1px solid #171510;
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.hint {
+  margin: 0;
+  font-size: 9px;
+  opacity: 0.58;
+}
+
+#custom-status {
+  display: block;
+  margin: 8px 0 0;
+}
+
+.filter-row {
+  display: grid;
+  grid-template-columns: 160px minmax(0, 1fr);
+  align-items: center;
+  gap: 16px;
+  margin-top: 18px;
+}
+
+.filter-row > span {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.065em;
+}
+
+.managed-list,
+.access-list {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+  border-top: 1px solid rgba(23, 21, 16, 0.35);
+}
+
+.managed-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  min-height: 46px;
+  padding: 8px 0;
+  border-bottom: 1px solid rgba(23, 21, 16, 0.2);
+}
+
+.site-row {
+  grid-template-columns: minmax(0, 1fr) 132px auto;
+}
+
+.site-row select {
+  min-height: 34px;
+  font-size: 11px;
+}
+
+.managed-value {
+  overflow-wrap: anywhere;
+  font-size: 13px;
+}
+
+.hostname {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.quiet-button {
+  min-height: 32px;
+  padding: 5px 8px;
+  border: 1px solid rgba(23, 21, 16, 0.42);
+  background: transparent;
+  font-size: 8px;
+}
+
+.quiet-button:hover {
+  border-color: #171510;
+  background: rgba(23, 21, 16, 0.05);
+}
+
+.section-copy,
+.empty-state {
+  max-width: 70ch;
+  font-size: 10px;
+  line-height: 1.55;
+}
+
+.section-copy {
+  margin: -5px 0 0;
+  opacity: 0.7;
+}
+
+.empty-state {
+  margin: 14px 0 0;
+  opacity: 0.58;
+}
+
+.access-list li {
+  padding: 9px 0;
+  border-bottom: 1px solid rgba(23, 21, 16, 0.2);
+  font-size: 10px;
+  overflow-wrap: anywhere;
+}
+
+.privacy-panel p:not(.eyebrow) {
+  max-width: 72ch;
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.privacy-panel a {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.065em;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 640px) {
+  .options-shell {
+    width: min(100% - 24px, 880px);
+    padding-top: 16px;
+  }
+
+  .options-header,
+  .section-heading,
+  .form-actions {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .general-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .general-grid .toggle-card {
+    grid-column: auto;
+  }
+
+  .filter-row {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+
+  .site-row {
+    grid-template-columns: 1fr;
+  }
+
+  .managed-row {
+    align-items: stretch;
+  }
+}

--- a/apps/extension/src/options.css
+++ b/apps/extension/src/options.css
@@ -207,6 +207,42 @@ h2 {
   accent-color: #171510;
 }
 
+.preview-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.8fr);
+  align-items: center;
+  gap: 28px;
+  margin-top: 18px;
+  padding: 16px;
+  border: 1px solid #171510;
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.preview-card .section-copy {
+  margin-top: 7px;
+}
+
+.preview-stage {
+  display: flex;
+  min-height: 104px;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 18px;
+  border-left: 1px solid rgba(23, 21, 16, 0.35);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(30px, 5vw, 48px);
+  line-height: 1;
+}
+
+.preview-stage [data-scrawlix-dom-root] {
+  cursor: default;
+}
+
+.preview-stage [data-scrawlix-dom-root][data-scrawlix-reveal='click'] {
+  cursor: pointer;
+}
+
 select,
 input[type='search'],
 textarea {
@@ -410,12 +446,19 @@ button:focus-visible {
     flex-direction: column;
   }
 
-  .general-grid {
+  .general-grid,
+  .preview-card {
     grid-template-columns: 1fr;
   }
 
   .general-grid .toggle-card {
     grid-column: auto;
+  }
+
+  .preview-stage {
+    min-height: 86px;
+    border-top: 1px solid rgba(23, 21, 16, 0.35);
+    border-left: 0;
   }
 
   .filter-row {

--- a/apps/extension/src/options.ts
+++ b/apps/extension/src/options.ts
@@ -1,9 +1,13 @@
+import { censorRuleFromWords, createScrawlix } from '@scrawlix/core';
+import './content.css';
 import './options.css';
 import { MAX_CUSTOM_TERM_CODE_POINTS } from './actions';
 import {
   CUSTOM_WORDS_KEY,
   SITE_OVERRIDES_KEY,
   SYNC_SETTINGS_KEY,
+  coverageSelector,
+  maskFor,
   normalizeCustomWords,
   setSiteMode,
   type ExtensionAppearance,
@@ -19,6 +23,9 @@ import {
   saveSettings,
 } from './storage';
 
+const PREVIEW_TERM = 'Mothbit';
+const previewRule = censorRuleFromWords('options-preview', [PREVIEW_TERM]);
+
 function required<T extends HTMLElement>(id: string): T {
   const element = document.getElementById(id);
   if (!element) throw new Error(`Missing options element #${id}`);
@@ -32,6 +39,8 @@ const coverageSelect = required<HTMLSelectElement>('coverage');
 const revealSelect = required<HTMLSelectElement>('reveal');
 const settingsStatus = required<HTMLSpanElement>('settings-status');
 const versionLabel = required<HTMLSpanElement>('version');
+const previewStage = required<HTMLParagraphElement>('preview-stage');
+const previewCaption = required<HTMLParagraphElement>('preview-caption');
 
 const addTermsForm = required<HTMLFormElement>('add-terms-form');
 const newTermsInput = required<HTMLTextAreaElement>('new-terms');
@@ -59,12 +68,73 @@ function filterMatch(value: string, query: string) {
   return value.toLocaleLowerCase().includes(query.trim().toLocaleLowerCase());
 }
 
+function previewInstruction(reveal: ExtensionReveal) {
+  switch (reveal) {
+    case 'hover':
+      return 'Hover the specimen to reveal it.';
+    case 'focus':
+      return 'Tab to the specimen to reveal it.';
+    case 'click':
+      return 'Click or press Enter on the specimen to toggle reveal.';
+    case 'never':
+      return 'The specimen stays covered.';
+  }
+}
+
+function togglePreview(root: HTMLElement) {
+  if (settings.reveal !== 'click') return;
+  root.dataset.scrawlixRevealed =
+    root.dataset.scrawlixRevealed === 'true' ? 'false' : 'true';
+}
+
+function renderPreview() {
+  const engine = createScrawlix({
+    rules: [previewRule],
+    coverage: coverageSelector(settings.coverage),
+  });
+  const root = document.createElement('span');
+  root.dataset.scrawlixDomRoot = '';
+  root.dataset.scrawlixAppearance = settings.appearance;
+  root.dataset.scrawlixReveal = settings.reveal;
+  root.dataset.scrawlixRevealed = 'false';
+  root.setAttribute('aria-hidden', 'true');
+
+  if (settings.reveal === 'focus' || settings.reveal === 'click') {
+    root.tabIndex = 0;
+  }
+
+  for (const segment of engine.segment(PREVIEW_TERM)) {
+    if (!segment.covered) {
+      root.append(document.createTextNode(segment.text));
+      continue;
+    }
+
+    const cover = document.createElement('span');
+    cover.dataset.scrawlixCover = '';
+    const mask = maskFor(segment.text, settings.appearance);
+    if (mask) cover.dataset.scrawlixMask = mask;
+    cover.textContent = segment.text;
+    root.append(cover);
+  }
+
+  root.addEventListener('click', () => togglePreview(root));
+  root.addEventListener('keydown', event => {
+    if (settings.reveal !== 'click' || (event.key !== 'Enter' && event.key !== ' ')) return;
+    event.preventDefault();
+    togglePreview(root);
+  });
+
+  previewStage.replaceChildren(root);
+  previewCaption.textContent = `${settings.appearance} style · ${settings.coverage} coverage. ${previewInstruction(settings.reveal)}`;
+}
+
 function renderGeneral() {
   activeInput.checked = !settings.paused;
   defaultEnabledSelect.value = settings.enabled ? 'on' : 'off';
   appearanceSelect.value = settings.appearance;
   coverageSelect.value = settings.coverage;
   revealSelect.value = settings.reveal;
+  renderPreview();
 }
 
 function renderTerms() {
@@ -160,20 +230,36 @@ function humanAccessPattern(pattern: string) {
   return pattern.replace(/\/\*$/, '');
 }
 
+function accessDisplayEntries(origins: readonly string[]) {
+  const set = new Set(origins.filter(origin => /^https?:\/\//.test(origin)));
+  const entries: string[] = [];
+  const allHttp = set.delete('http://*/*');
+  const allHttps = set.delete('https://*/*');
+
+  if (allHttp && allHttps) entries.push('All HTTP and HTTPS websites');
+  else {
+    if (allHttp) entries.push('All HTTP websites');
+    if (allHttps) entries.push('All HTTPS websites');
+  }
+
+  entries.push(...[...set].sort().map(humanAccessPattern));
+  return entries;
+}
+
 async function renderAccess() {
   const permissions = await chrome.permissions.getAll();
-  const origins = [...new Set((permissions.origins ?? []).filter(origin => /^https?:\/\//.test(origin)))].sort();
+  const entries = accessDisplayEntries(permissions.origins ?? []);
 
-  accessCount.textContent = `${origins.length} ${origins.length === 1 ? 'grant' : 'grants'}`;
+  accessCount.textContent = `${entries.length} ${entries.length === 1 ? 'grant' : 'grants'}`;
   accessList.replaceChildren();
 
-  for (const origin of origins) {
+  for (const entry of entries) {
     const item = document.createElement('li');
-    item.textContent = humanAccessPattern(origin);
+    item.textContent = entry;
     accessList.append(item);
   }
 
-  accessEmpty.hidden = origins.length > 0;
+  accessEmpty.hidden = entries.length > 0;
 }
 
 async function persistSettings(next: SyncSettings) {

--- a/apps/extension/src/options.ts
+++ b/apps/extension/src/options.ts
@@ -1,0 +1,318 @@
+import './options.css';
+import { MAX_CUSTOM_TERM_CODE_POINTS } from './actions';
+import {
+  CUSTOM_WORDS_KEY,
+  SITE_OVERRIDES_KEY,
+  SYNC_SETTINGS_KEY,
+  normalizeCustomWords,
+  setSiteMode,
+  type ExtensionAppearance,
+  type ExtensionCoverage,
+  type ExtensionReveal,
+  type SyncSettings,
+} from './config';
+import {
+  loadCustomWords,
+  loadExtensionState,
+  loadSettings,
+  saveCustomWords,
+  saveSettings,
+} from './storage';
+
+function required<T extends HTMLElement>(id: string): T {
+  const element = document.getElementById(id);
+  if (!element) throw new Error(`Missing options element #${id}`);
+  return element as T;
+}
+
+const activeInput = required<HTMLInputElement>('active');
+const defaultEnabledSelect = required<HTMLSelectElement>('default-enabled');
+const appearanceSelect = required<HTMLSelectElement>('appearance');
+const coverageSelect = required<HTMLSelectElement>('coverage');
+const revealSelect = required<HTMLSelectElement>('reveal');
+const settingsStatus = required<HTMLSpanElement>('settings-status');
+const versionLabel = required<HTMLSpanElement>('version');
+
+const addTermsForm = required<HTMLFormElement>('add-terms-form');
+const newTermsInput = required<HTMLTextAreaElement>('new-terms');
+const customStatus = required<HTMLParagraphElement>('custom-status');
+const customCount = required<HTMLSpanElement>('custom-count');
+const termFilter = required<HTMLInputElement>('term-filter');
+const termList = required<HTMLUListElement>('term-list');
+const termEmpty = required<HTMLParagraphElement>('term-empty');
+
+const siteCount = required<HTMLSpanElement>('site-count');
+const siteFilter = required<HTMLInputElement>('site-filter');
+const siteList = required<HTMLUListElement>('site-list');
+const siteEmpty = required<HTMLParagraphElement>('site-empty');
+
+const accessCount = required<HTMLSpanElement>('access-count');
+const accessList = required<HTMLUListElement>('access-list');
+const accessEmpty = required<HTMLParagraphElement>('access-empty');
+
+let settings: SyncSettings;
+let customWords: string[] = [];
+let settingsSaveQueue = Promise.resolve();
+let stateGeneration = 0;
+
+function filterMatch(value: string, query: string) {
+  return value.toLocaleLowerCase().includes(query.trim().toLocaleLowerCase());
+}
+
+function renderGeneral() {
+  activeInput.checked = !settings.paused;
+  defaultEnabledSelect.value = settings.enabled ? 'on' : 'off';
+  appearanceSelect.value = settings.appearance;
+  coverageSelect.value = settings.coverage;
+  revealSelect.value = settings.reveal;
+}
+
+function renderTerms() {
+  const query = termFilter.value;
+  const filtered = customWords.filter(term => filterMatch(term, query));
+
+  customCount.textContent = `${customWords.length} ${customWords.length === 1 ? 'term' : 'terms'}`;
+  termList.replaceChildren();
+
+  for (const term of filtered) {
+    const row = document.createElement('li');
+    row.className = 'managed-row';
+
+    const text = document.createElement('span');
+    text.className = 'managed-value';
+    text.textContent = term;
+
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'quiet-button';
+    remove.textContent = 'remove';
+    remove.setAttribute('aria-label', `Remove ${term}`);
+    remove.addEventListener('click', () => void removeCustomTerm(term));
+
+    row.append(text, remove);
+    termList.append(row);
+  }
+
+  termEmpty.hidden = filtered.length > 0;
+  if (customWords.length > 0 && filtered.length === 0) {
+    termEmpty.textContent = 'No custom terms match this filter.';
+  } else {
+    termEmpty.textContent = 'Your custom list is empty.';
+  }
+}
+
+function renderSites() {
+  const query = siteFilter.value;
+  const entries = Object.entries(settings.siteOverrides)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .filter(([hostname]) => filterMatch(hostname, query));
+
+  const total = Object.keys(settings.siteOverrides).length;
+  siteCount.textContent = `${total} ${total === 1 ? 'exception' : 'exceptions'}`;
+  siteList.replaceChildren();
+
+  for (const [hostname, mode] of entries) {
+    const row = document.createElement('li');
+    row.className = 'managed-row site-row';
+
+    const text = document.createElement('span');
+    text.className = 'managed-value hostname';
+    text.textContent = hostname;
+
+    const select = document.createElement('select');
+    select.setAttribute('aria-label', `Policy for ${hostname}`);
+    for (const value of ['on', 'off'] as const) {
+      const option = document.createElement('option');
+      option.value = value;
+      option.textContent = value === 'on' ? 'always on' : 'always off';
+      select.append(option);
+    }
+    select.value = mode;
+    select.addEventListener('change', () => {
+      void persistSettings(
+        setSiteMode(settings, hostname, select.value === 'on' ? 'on' : 'off')
+      );
+    });
+
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'quiet-button';
+    remove.textContent = 'use default';
+    remove.addEventListener('click', () => {
+      void persistSettings(setSiteMode(settings, hostname, 'inherit'));
+    });
+
+    row.append(text, select, remove);
+    siteList.append(row);
+  }
+
+  siteEmpty.hidden = entries.length > 0;
+  if (total > 0 && entries.length === 0) {
+    siteEmpty.textContent = 'No site exceptions match this filter.';
+  } else {
+    siteEmpty.textContent = 'No site exceptions yet.';
+  }
+}
+
+function humanAccessPattern(pattern: string) {
+  if (pattern === 'http://*/*') return 'All HTTP websites';
+  if (pattern === 'https://*/*') return 'All HTTPS websites';
+  return pattern.replace(/\/\*$/, '');
+}
+
+async function renderAccess() {
+  const permissions = await chrome.permissions.getAll();
+  const origins = [...new Set((permissions.origins ?? []).filter(origin => /^https?:\/\//.test(origin)))].sort();
+
+  accessCount.textContent = `${origins.length} ${origins.length === 1 ? 'grant' : 'grants'}`;
+  accessList.replaceChildren();
+
+  for (const origin of origins) {
+    const item = document.createElement('li');
+    item.textContent = humanAccessPattern(origin);
+    accessList.append(item);
+  }
+
+  accessEmpty.hidden = origins.length > 0;
+}
+
+async function persistSettings(next: SyncSettings) {
+  settings = next;
+  renderGeneral();
+  renderSites();
+  settingsStatus.textContent = 'saving…';
+
+  const queued = settingsSaveQueue
+    .catch(() => undefined)
+    .then(async () => {
+      try {
+        await saveSettings(next);
+        if (settings === next) settingsStatus.textContent = 'saved';
+      } catch {
+        if (settings === next) {
+          settings = await loadSettings();
+          renderGeneral();
+          renderSites();
+          settingsStatus.textContent = 'save failed';
+        }
+        throw new Error('Failed to save Scrawlix settings.');
+      }
+    });
+
+  settingsSaveQueue = queued.catch(() => undefined);
+  await queued.catch(() => undefined);
+}
+
+async function persistCustomWords(next: string[], successMessage: string) {
+  customStatus.textContent = 'saving…';
+  try {
+    await saveCustomWords(next);
+    customWords = next;
+    renderTerms();
+    customStatus.textContent = successMessage;
+  } catch {
+    customWords = await loadCustomWords();
+    renderTerms();
+    customStatus.textContent = 'save failed';
+  }
+}
+
+async function removeCustomTerm(term: string) {
+  const next = customWords.filter(item => item.toLocaleLowerCase() !== term.toLocaleLowerCase());
+  await persistCustomWords(next, `Removed ${term}`);
+}
+
+async function addCustomTerms() {
+  const candidates = normalizeCustomWords(newTermsInput.value.split('\n'));
+  const accepted = candidates.filter(
+    term => Array.from(term).length <= MAX_CUSTOM_TERM_CODE_POINTS
+  );
+  const rejected = candidates.length - accepted.length;
+  const next = normalizeCustomWords([...customWords, ...accepted]);
+  const added = next.length - customWords.length;
+
+  if (accepted.length === 0) {
+    customStatus.textContent = rejected > 0 ? 'Terms over the length limit were skipped.' : 'Enter a word or phrase first.';
+    return;
+  }
+
+  await persistCustomWords(
+    next,
+    rejected > 0
+      ? `Added ${added}; skipped ${rejected} over the length limit`
+      : added > 0
+        ? `Added ${added} ${added === 1 ? 'term' : 'terms'}`
+        : 'Those terms are already in your list'
+  );
+  newTermsInput.value = '';
+  newTermsInput.focus();
+}
+
+async function reloadState() {
+  const generation = ++stateGeneration;
+  const state = await loadExtensionState();
+  if (generation !== stateGeneration) return;
+
+  settings = state.settings;
+  customWords = [...state.customWords];
+  renderGeneral();
+  renderTerms();
+  renderSites();
+}
+
+activeInput.addEventListener('change', () => {
+  void persistSettings({ ...settings, paused: !activeInput.checked });
+});
+
+defaultEnabledSelect.addEventListener('change', () => {
+  void persistSettings({ ...settings, enabled: defaultEnabledSelect.value === 'on' });
+});
+
+appearanceSelect.addEventListener('change', () => {
+  void persistSettings({
+    ...settings,
+    appearance: appearanceSelect.value as ExtensionAppearance,
+  });
+});
+
+coverageSelect.addEventListener('change', () => {
+  void persistSettings({
+    ...settings,
+    coverage: coverageSelect.value as ExtensionCoverage,
+  });
+});
+
+revealSelect.addEventListener('change', () => {
+  void persistSettings({
+    ...settings,
+    reveal: revealSelect.value as ExtensionReveal,
+  });
+});
+
+addTermsForm.addEventListener('submit', event => {
+  event.preventDefault();
+  void addCustomTerms();
+});
+
+termFilter.addEventListener('input', renderTerms);
+siteFilter.addEventListener('input', renderSites);
+
+chrome.permissions.onAdded.addListener(() => void renderAccess());
+chrome.permissions.onRemoved.addListener(() => void renderAccess());
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  const syncChanged =
+    areaName === 'sync' && Object.prototype.hasOwnProperty.call(changes, SYNC_SETTINGS_KEY);
+  const localChanged =
+    areaName === 'local' &&
+    (Object.prototype.hasOwnProperty.call(changes, CUSTOM_WORDS_KEY) ||
+      Object.prototype.hasOwnProperty.call(changes, SITE_OVERRIDES_KEY));
+  if (syncChanged || localChanged) void reloadState();
+});
+
+async function initialize() {
+  versionLabel.textContent = `v${chrome.runtime.getManifest().version}`;
+  await Promise.all([reloadState(), renderAccess()]);
+}
+
+void initialize();

--- a/apps/extension/src/popup.css
+++ b/apps/extension/src/popup.css
@@ -19,8 +19,7 @@ body {
 
 button,
 input,
-select,
-textarea {
+select {
   font: inherit;
 }
 
@@ -34,7 +33,7 @@ textarea {
 .peek-card,
 .access-card,
 .settings-grid,
-.custom-words,
+.manage-card,
 footer {
   border-top: 1px solid #171510;
 }
@@ -68,13 +67,14 @@ footer {
 .status-line,
 .access-status,
 .peek-meta,
-.hint,
+.manage-summary,
 footer,
 .switch-row span,
 .settings-grid label > span,
 .save-status,
 .access-actions button,
-.peek-card button {
+.peek-card button,
+.manage-card button {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
@@ -134,17 +134,13 @@ footer,
   opacity: 0.55;
 }
 
-.site-card h1,
-.custom-words h2 {
-  margin: 0;
-  font-family: Georgia, "Times New Roman", serif;
-  font-weight: 600;
-  letter-spacing: -0.035em;
-}
-
 .site-card h1 {
   overflow: hidden;
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
   font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.035em;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -189,7 +185,8 @@ footer,
   box-shadow: inset 0 0 0 1px #f2eddf;
 }
 
-.peek-card button:focus-visible {
+.peek-card button:focus-visible,
+.manage-card button:focus-visible {
   outline: 1px solid #171510;
   outline-offset: 2px;
 }
@@ -236,21 +233,27 @@ footer,
   gap: 5px;
 }
 
-.access-actions button {
-  min-height: 28px;
-  padding: 5px 7px;
+.access-actions button,
+.manage-card button {
   color: inherit;
   background: rgba(255, 255, 255, 0.28);
   border: 1px solid rgba(23, 21, 16, 0.42);
-  font-size: 8px;
-  text-align: left;
   text-transform: uppercase;
   letter-spacing: 0.045em;
   cursor: pointer;
 }
 
+.access-actions button {
+  min-height: 28px;
+  padding: 5px 7px;
+  font-size: 8px;
+  text-align: left;
+}
+
 .access-actions button:hover,
-.access-actions button:focus-visible {
+.access-actions button:focus-visible,
+.manage-card button:hover,
+.manage-card button:focus-visible {
   border-color: #171510;
 }
 
@@ -264,24 +267,19 @@ footer,
   opacity: 0.48;
 }
 
-select,
-textarea {
+select {
   width: 100%;
+  min-height: 34px;
+  padding: 6px 8px;
   color: inherit;
   background: rgba(255, 255, 255, 0.28);
   border: 1px solid rgba(23, 21, 16, 0.42);
   border-radius: 0;
   outline: none;
-}
-
-select {
-  min-height: 34px;
-  padding: 6px 8px;
   font-size: 11px;
 }
 
-select:focus,
-textarea:focus {
+select:focus {
   border-color: #171510;
   box-shadow: 0 0 0 1px #171510;
 }
@@ -302,40 +300,36 @@ textarea:focus {
   letter-spacing: 0.08em;
 }
 
-.custom-words {
-  padding: 14px 0;
-}
-
-.section-label {
+.manage-card {
   display: flex;
-  align-items: end;
+  align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 9px;
+  gap: 14px;
+  padding: 12px 0;
 }
 
-.custom-words h2 {
-  font-size: 16px;
-}
-
-#save-status {
-  min-width: 60px;
-  text-align: right;
-}
-
-textarea {
-  resize: vertical;
-  min-height: 88px;
-  padding: 9px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 10px;
-  line-height: 1.5;
-}
-
-.hint {
-  margin: 5px 0 0;
+.manage-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 11px;
+  margin: 0;
   font-size: 8px;
-  opacity: 0.58;
+  text-transform: uppercase;
+  letter-spacing: 0.045em;
+  opacity: 0.72;
+}
+
+.manage-summary strong {
+  font-size: 11px;
+  opacity: 1;
+}
+
+.manage-card button {
+  min-height: 32px;
+  padding: 6px 10px;
+  font-size: 8px;
+  font-weight: 700;
+  white-space: nowrap;
 }
 
 footer {

--- a/apps/extension/src/popup.ts
+++ b/apps/extension/src/popup.ts
@@ -294,8 +294,14 @@ allSitesAccessButton.addEventListener('click', () => {
 });
 
 openOptionsButton.addEventListener('click', () => {
-  void chrome.runtime.openOptionsPage();
-  window.close();
+  void (async () => {
+    try {
+      await chrome.runtime.openOptionsPage();
+      window.close();
+    } catch {
+      settingsStatus.textContent = 'could not open settings';
+    }
+  })();
 });
 
 async function initialize() {

--- a/apps/extension/src/popup.ts
+++ b/apps/extension/src/popup.ts
@@ -13,7 +13,6 @@ import {
 import { TEMPORARY_REVEAL_COMMAND } from './actions';
 import {
   effectiveEnabled,
-  normalizeCustomWords,
   setSiteMode,
   siteModeFor,
   type ExtensionAppearance,
@@ -22,12 +21,7 @@ import {
   type SiteMode,
   type SyncSettings,
 } from './config';
-import {
-  loadExtensionState,
-  loadSettings,
-  saveCustomWords,
-  saveSettings,
-} from './storage';
+import { loadExtensionState, loadSettings, saveSettings } from './storage';
 
 function required<T extends HTMLElement>(id: string): T {
   const element = document.getElementById(id);
@@ -51,20 +45,21 @@ const revealSelect = required<HTMLSelectElement>('reveal');
 const revealPageButton = required<HTMLButtonElement>('reveal-page');
 const revealShortcut = required<HTMLElement>('reveal-shortcut');
 const revealStatus = required<HTMLSpanElement>('reveal-status');
-const customWordsInput = required<HTMLTextAreaElement>('custom-words');
 const siteHeading = required<HTMLHeadingElement>('site-heading');
 const effectiveStatus = required<HTMLParagraphElement>('effective-status');
 const accessStatus = required<HTMLParagraphElement>('access-status');
 const siteAccessButton = required<HTMLButtonElement>('site-access');
 const allSitesAccessButton = required<HTMLButtonElement>('all-sites-access');
 const settingsStatus = required<HTMLSpanElement>('settings-status');
-const saveStatus = required<HTMLSpanElement>('save-status');
+const customCount = required<HTMLElement>('custom-count');
+const siteExceptionCount = required<HTMLElement>('site-exception-count');
+const openOptionsButton = required<HTMLButtonElement>('open-options');
 
 let settings: SyncSettings;
 let page: ActivePage | null = null;
 let persistentAccess = false;
 let allHostsAccess = false;
-let wordSaveTimer: number | null = null;
+let customWordCount = 0;
 let settingsSaveQueue = Promise.resolve();
 
 async function currentPage(): Promise<ActivePage | null> {
@@ -140,6 +135,11 @@ function renderRevealAction() {
   revealPageButton.disabled = !page || !persistentAccess || !enabledHere;
 }
 
+function renderManageSummary() {
+  customCount.textContent = String(customWordCount);
+  siteExceptionCount.textContent = String(Object.keys(settings.siteOverrides).length);
+}
+
 function renderSettings() {
   activeInput.checked = !settings.paused;
   defaultEnabledSelect.value = settings.enabled ? 'on' : 'off';
@@ -149,6 +149,7 @@ function renderSettings() {
   renderEffectiveStatus();
   renderAccess();
   renderRevealAction();
+  renderManageSummary();
 }
 
 async function refreshAccess() {
@@ -197,32 +198,6 @@ async function persistSettings(next: SyncSettings) {
   settingsSaveQueue = queued.catch(() => undefined);
   await queued.catch(() => undefined);
   await ensureCurrentPageRuntime();
-}
-
-function wordsFromTextarea() {
-  return normalizeCustomWords(customWordsInput.value.split('\n'));
-}
-
-async function persistWords() {
-  if (wordSaveTimer !== null) {
-    window.clearTimeout(wordSaveTimer);
-    wordSaveTimer = null;
-  }
-
-  saveStatus.textContent = 'saving…';
-  try {
-    await saveCustomWords(wordsFromTextarea());
-    saveStatus.textContent = 'saved';
-    await ensureCurrentPageRuntime();
-  } catch {
-    saveStatus.textContent = 'save failed';
-  }
-}
-
-function scheduleWordSave() {
-  if (wordSaveTimer !== null) window.clearTimeout(wordSaveTimer);
-  saveStatus.textContent = 'editing';
-  wordSaveTimer = window.setTimeout(() => void persistWords(), 250);
 }
 
 activeInput.addEventListener('change', () => {
@@ -318,8 +293,10 @@ allSitesAccessButton.addEventListener('click', () => {
   })();
 });
 
-customWordsInput.addEventListener('input', scheduleWordSave);
-customWordsInput.addEventListener('change', () => void persistWords());
+openOptionsButton.addEventListener('click', () => {
+  void chrome.runtime.openOptionsPage();
+  window.close();
+});
 
 async function initialize() {
   const [state, activePage] = await Promise.all([
@@ -328,8 +305,8 @@ async function initialize() {
   ]);
 
   settings = state.settings;
+  customWordCount = state.customWords.length;
   page = activePage;
-  customWordsInput.value = state.customWords.join('\n');
   await Promise.all([refreshAccess(), renderAssignedShortcut()]);
   await ensureCurrentPageRuntime();
 }

--- a/apps/extension/vite.popup.config.ts
+++ b/apps/extension/vite.popup.config.ts
@@ -7,7 +7,10 @@ export default defineConfig({
     outDir: 'dist',
     sourcemap: true,
     rollupOptions: {
-      input: fileURLToPath(new URL('./popup.html', import.meta.url)),
+      input: {
+        popup: fileURLToPath(new URL('./popup.html', import.meta.url)),
+        options: fileURLToPath(new URL('./options.html', import.meta.url)),
+      },
     },
   },
 });

--- a/tests/browser/browser.spec.ts
+++ b/tests/browser/browser.spec.ts
@@ -124,6 +124,41 @@ test('built extension registers granted hosts and handles page interaction in Ch
       .toBeNull();
     await expect(initialRoot).toHaveCount(1);
 
+    // Full-tab Options uses the real engine for its specimen and edits the live custom list.
+    const optionsUrl = await worker.evaluate(() => chrome.runtime.getURL('options.html'));
+    const options = await context.newPage();
+    await options.goto(optionsUrl);
+    await expect(options.getByRole('heading', { name: 'Custom terms' })).toBeVisible();
+    await expect(
+      options.locator('#preview-stage [data-scrawlix-cover]')
+    ).toHaveText('othb');
+
+    await options.locator('#new-terms').fill('Mothbit');
+    await options.getByRole('button', { name: 'add terms', exact: true }).click();
+    await expect(options.locator('#term-list')).toContainText('Mothbit');
+    await expect(options.locator('#custom-count')).toHaveText('1 term');
+
+    await page.evaluate(() => {
+      const paragraph = document.createElement('p');
+      paragraph.id = 'custom-term-copy';
+      paragraph.textContent = 'Mothbit arrived';
+      document.querySelector('main')?.append(paragraph);
+    });
+    await expect(
+      page.locator('#custom-term-copy [data-scrawlix-dom-root]')
+    ).toHaveCount(1);
+    await expect(
+      page.locator('#custom-term-copy [data-scrawlix-cover]')
+    ).toHaveText('othb');
+
+    await options.getByRole('button', { name: 'Remove Mothbit' }).click();
+    await expect(options.locator('#term-list')).not.toContainText('Mothbit');
+    await expect(options.locator('#custom-count')).toHaveText('0 terms');
+    await expect(
+      page.locator('#custom-term-copy [data-scrawlix-dom-root]')
+    ).toHaveCount(0);
+    await options.close();
+
     await page.locator('#native-link').click();
     await expect(page).toHaveURL('http://127.0.0.1:4174/clicked.html');
     await expect(page.locator('#clicked')).toHaveText('native link worked');


### PR DESCRIPTION
## What changed

- register a full-tab MV3 `options.html` page and include it in the extension build/validation contract
- move custom-term editing out of the popup into explicit Add/Remove actions in Options
- add searchable custom-term and site-exception managers
- keep persistent browser host grants read-only in Options until multi-tab revocation cleanup is centralized
- add General preferences to Options with a live **Mothbit** specimen rendered by the real core coverage engine and extension appearance/reveal CSS
- collapse Chrome's paired all-HTTP/all-HTTPS host patterns into one human-readable all-websites grant in the Options summary
- replace the popup custom-term editor with compact custom-term/site-exception counts plus **Manage…**
- open Options through `chrome.runtime.openOptionsPage()` and keep the popup visible if opening fails
- extend build validation so the store build must contain/register `options.html` as a full-tab page
- extend real Chromium smoke so an Options Add immediately censors the term on an already-open page and Remove restores it again
- update extension docs for the popup/Options responsibility split

## Product behavior

The popup stays focused on the current page: master active state, current-site policy, temporary reveal, browser access, treatment controls, and a compact handoff to durable settings.

Options owns collections and slower configuration. Custom-term edits are explicit writes in a persistent tab, removing the popup-close/debounce data-loss hazard. Site exceptions become visible/searchable instead of being hidden behind the hostname currently open in the browser.

The live specimen makes **Censor style**, **How much to hide**, and **Reveal** visually legible using the same matching/coverage/mask code as the extension page runtime.

## Validation

CI is green on the final head:

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Chromium demo smoke
- Chromium extension smoke, including the Options add/remove round-trip against an already-open censored page
- `pnpm smoke:packages`

## Stack

This PR is intentionally based on `copper/reveal-actions` / #82 so reviewers see only the Options/popup-ergonomics slice.

Progresses #51 and #23.