### PR TITLE
Preserve page-owned Text nodes in the DOM adapter

### DIFF
--- a/apps/demo/src/OwnershipFixture.tsx
+++ b/apps/demo/src/OwnershipFixture.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+
+export function OwnershipFixture() {
+  const [count, setCount] = useState(0);
+  const [mounted, setMounted] = useState(true);
+  const [textMounted, setTextMounted] = useState(true);
+
+  return (
+    <main data-scrawlix-ownership-fixture>
+      <button id="react-increment" type="button" onClick={() => setCount(value => value + 1)}>
+        increment
+      </button>
+      <button id="react-toggle-text" type="button" onClick={() => setTextMounted(value => !value)}>
+        toggle text
+      </button>
+      <button id="react-toggle" type="button" onClick={() => setMounted(value => !value)}>
+        toggle
+      </button>
+      {mounted ? (
+        <p id="react-owned">
+          <span>state: </span>
+          {textMounted ? `fuck ${count}` : null}
+        </p>
+      ) : (
+        <p id="react-unmounted">unmounted</p>
+      )}
+    </main>
+  );
+}

--- a/apps/demo/src/main.tsx
+++ b/apps/demo/src/main.tsx
@@ -2,13 +2,18 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import '@scrawlix/react/styles.css';
 import { App } from './App';
+import { OwnershipFixture } from './OwnershipFixture';
 import './styles.css';
 import './poetry.css';
 import './spoilers.css';
 import './privacy.css';
 
+const fixtureMode = new URLSearchParams(window.location.search).has(
+  'ownership-fixture'
+);
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    {fixtureMode ? <OwnershipFixture /> : <App />}
   </React.StrictMode>
 );

--- a/docs/dom.md
+++ b/docs/dom.md
@@ -23,19 +23,21 @@ censor.apply(document.body);
 
 Core coverage defaults to `full`. Pass another `coverage` selector explicitly when the page should use partial coverage.
 
-Only text nodes containing covered ranges are replaced. Each transformed text node gets one `data-scrawlix-dom-root` wrapper. Covered fragments inside it carry `data-scrawlix-cover` and `data-scrawlix-rules`; their text content remains the original source substring.
+Only text nodes containing covered ranges get generated output. The original page-owned `Text` node stays in its original parent as an empty ownership anchor while Scrawlix renders the source through a sibling `data-scrawlix-dom-root` wrapper. Covered fragments inside the wrapper carry `data-scrawlix-cover` and `data-scrawlix-rules`; their text content remains the original source substring.
+
+Keeping the original `Text` object in place lets frameworks such as React retain ownership of the node they created. When page code writes new character data to that node, observation mirrors the latest source into the sibling wrapper and clears the anchor again while coverage is still needed.
 
 The returned result reports `transformedTextNodes` and `coveredSegments`.
 
 ## Restore
 
-A controller records the exact source strings for wrappers it creates:
+A controller records the latest page-owned source string for each wrapper it creates:
 
 ```ts
 censor.restore(document.body);
 ```
 
-Restoration only touches wrappers owned by that controller. Author-authored elements that happen to carry similar data attributes remain intact.
+Restoration only touches wrappers owned by that controller. When the page-owned anchor and its wrapper still share a parent, restoration removes the wrapper and restores the source onto that same `Text` object. Author-authored elements that happen to carry similar data attributes remain intact.
 
 ## Dynamic pages
 
@@ -45,7 +47,7 @@ For SPAs, feeds, chats, and infinite-scroll pages:
 const observation = censor.observe(document.body);
 ```
 
-Observation applies to the initial subtree by default, then watches `childList` and `characterData` mutations. Mutation work is queued from the nodes delivered by `MutationObserver`; the adapter does not rescan the complete document after every update.
+Observation applies to the initial subtree by default, then watches `childList` and `characterData` mutations. Mutation work is queued from the nodes delivered by `MutationObserver`; the adapter does not rescan the complete document after every update. Overlapping mutation roots are collapsed, detached queued roots are discarded, and Scrawlix-generated wrappers are skipped when their own mutations come back through the observer.
 
 To observe only future changes:
 
@@ -59,7 +61,7 @@ To disable censorship safely while observation is active:
 observation.restore();
 ```
 
-`observation.restore()` disconnects the observer, clears queued work, and restores controller-owned source text as one lifecycle operation. `disconnect()` leaves current transformed output in place.
+`observation.restore()` first drains pending mutation records so an immediately preceding page/framework text write is preserved, then disconnects observation, clears queued discovery work, and restores controller-owned source text. `disconnect()` also drains already-delivered ownership updates, then leaves current transformed output in place.
 
 ## Safe default exclusions
 

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -97,6 +97,13 @@ function isGeneratedRoot(node: Node) {
   );
 }
 
+function isWithinGeneratedRoot(node: Node) {
+  if (isGeneratedRoot(node)) return true;
+  const element =
+    node.nodeType === ELEMENT_NODE ? (node as Element) : node.parentElement;
+  return element?.closest('[data-scrawlix-dom-root]') !== null;
+}
+
 function hasGeneratedAncestor(node: Text) {
   let element = node.parentElement;
   while (element) {
@@ -184,21 +191,16 @@ export function createDomScrawlix(
   };
 
   const ownedRoots = new WeakSet<Element>();
-  const originalText = new WeakMap<Element, string>();
+  const sourceNodes = new WeakMap<Element, Text>();
+  const ownedSources = new WeakMap<Text, Element>();
+  const sourceText = new WeakMap<Text, string>();
 
-  function transformTextNode(
-    node: Text,
-    knownEligible = false
-  ): DomApplyResult {
-    if (!knownEligible && !isEligibleText(node, prepared)) return emptyResult();
-
-    const segments = engine.segment(node.data);
-    const coveredSegments = segments.filter(segment => segment.covered).length;
-    if (coveredSegments === 0) return emptyResult();
-
-    const document = node.ownerDocument;
-    const wrapper = document.createElement('span');
-    wrapper.setAttribute('data-scrawlix-dom-root', '');
+  function renderWrapper(
+    wrapper: Element,
+    segments: readonly ScrawlixSegment[]
+  ) {
+    const document = wrapper.ownerDocument;
+    wrapper.replaceChildren();
 
     for (const segment of segments) {
       if (segment.covered) {
@@ -207,10 +209,64 @@ export function createDomScrawlix(
         wrapper.append(document.createTextNode(segment.text));
       }
     }
+  }
+
+  function forgetOwnedSource(source: Text, wrapper: Element) {
+    ownedSources.delete(source);
+    sourceNodes.delete(wrapper);
+    sourceText.delete(source);
+    ownedRoots.delete(wrapper);
+  }
+
+  function syncOwnedSource(source: Text) {
+    const wrapper = ownedSources.get(source);
+    if (!wrapper) return;
+
+    const nextSource = source.data;
+    if (!nextSource) {
+      forgetOwnedSource(source, wrapper);
+      wrapper.remove();
+      return;
+    }
+
+    const segments = engine.segment(nextSource);
+    const coveredSegments = segments.filter(segment => segment.covered).length;
+
+    if (coveredSegments === 0) {
+      forgetOwnedSource(source, wrapper);
+      wrapper.remove();
+      return;
+    }
+
+    sourceText.set(source, nextSource);
+    renderWrapper(wrapper, segments);
+    source.data = '';
+  }
+
+  function transformTextNode(
+    node: Text,
+    knownEligible = false
+  ): DomApplyResult {
+    if (ownedSources.has(node)) return emptyResult();
+    if (!knownEligible && !isEligibleText(node, prepared)) return emptyResult();
+
+    const source = node.data;
+    const segments = engine.segment(source);
+    const coveredSegments = segments.filter(segment => segment.covered).length;
+    if (coveredSegments === 0) return emptyResult();
+
+    const document = node.ownerDocument;
+    const wrapper = document.createElement('span');
+    wrapper.setAttribute('data-scrawlix-dom-root', '');
+    renderWrapper(wrapper, segments);
 
     ownedRoots.add(wrapper);
-    originalText.set(wrapper, node.data);
-    node.replaceWith(wrapper);
+    sourceNodes.set(wrapper, node);
+    ownedSources.set(node, wrapper);
+    sourceText.set(node, source);
+
+    node.data = '';
+    node.after(wrapper);
 
     return { transformedTextNodes: 1, coveredSegments };
   }
@@ -266,9 +322,19 @@ export function createDomScrawlix(
 
     for (const wrapper of generatedRootsWithin(root)) {
       if (!ownedRoots.has(wrapper)) continue;
-      const document = wrapper.ownerDocument;
-      const source = originalText.get(wrapper) ?? wrapper.textContent ?? '';
-      wrapper.replaceWith(document.createTextNode(source));
+
+      const source = sourceNodes.get(wrapper);
+      if (!source) continue;
+      const value = sourceText.get(source) ?? wrapper.textContent ?? '';
+      const sharesParent = source.parentNode === wrapper.parentNode;
+      forgetOwnedSource(source, wrapper);
+
+      if (sharesParent) {
+        wrapper.remove();
+        source.data = value;
+      } else {
+        wrapper.replaceWith(wrapper.ownerDocument.createTextNode(value));
+      }
       restored += 1;
     }
 
@@ -289,7 +355,7 @@ export function createDomScrawlix(
     let scheduled = false;
 
     const queue = (node: Node) => {
-      if (isGeneratedRoot(node)) return;
+      if (isWithinGeneratedRoot(node)) return;
 
       for (const existing of pending) {
         if (existing === node || existing.contains(node)) return;
@@ -326,19 +392,65 @@ export function createDomScrawlix(
       });
     };
 
-    const observer = new MutationObserverConstructor(records => {
+    const processRecords = (records: MutationRecord[]) => {
+      const ownedCharacterData = new Map<Text, MutationRecord[]>();
+
       for (const record of records) {
         if (record.type === 'characterData') {
-          queue(record.target);
+          const source = record.target as Text;
+          if (ownedSources.has(source)) {
+            const sourceRecords = ownedCharacterData.get(source) ?? [];
+            sourceRecords.push(record);
+            ownedCharacterData.set(source, sourceRecords);
+          } else {
+            queue(source);
+          }
           continue;
+        }
+
+        for (const removed of Array.from(record.removedNodes)) {
+          if (removed.nodeType === TEXT_NODE) {
+            const source = removed as Text;
+            const wrapper = ownedSources.get(source);
+            if (wrapper) {
+              const value = sourceText.get(source) ?? wrapper.textContent ?? '';
+              forgetOwnedSource(source, wrapper);
+              wrapper.remove();
+              source.data = value;
+            }
+            continue;
+          }
+
+          if (isGeneratedRoot(removed)) {
+            const wrapper = removed as Element;
+            const source = sourceNodes.get(wrapper);
+            if (source && source.parentNode) {
+              const value = sourceText.get(source) ?? wrapper.textContent ?? '';
+              forgetOwnedSource(source, wrapper);
+              source.data = value;
+            }
+          }
         }
 
         for (const added of Array.from(record.addedNodes)) {
           queue(added);
         }
       }
+
+      for (const [source, sourceRecords] of ownedCharacterData) {
+        const expectedInternalOldValue = sourceText.get(source);
+        const internalClearOnly =
+          source.data === '' &&
+          expectedInternalOldValue !== undefined &&
+          sourceRecords.every(record => record.oldValue === expectedInternalOldValue);
+
+        if (!internalClearOnly) syncOwnedSource(source);
+      }
+
       if (pending.size > 0) schedule();
-    });
+    };
+
+    const observer = new MutationObserverConstructor(processRecords);
 
     const initialResult =
       observeOptions.initial === false ? emptyResult() : apply(root);
@@ -347,13 +459,18 @@ export function createDomScrawlix(
       subtree: true,
       childList: true,
       characterData: true,
+      characterDataOldValue: true,
     });
 
     return {
       initialResult,
       flush,
-      disconnect: stop,
+      disconnect() {
+        processRecords(observer.takeRecords());
+        stop();
+      },
       restore() {
+        processRecords(observer.takeRecords());
         stop();
         return restore(root);
       },

--- a/packages/dom/src/ownership.test.ts
+++ b/packages/dom/src/ownership.test.ts
@@ -1,0 +1,129 @@
+/** @vitest-environment jsdom */
+
+import { censorRuleFromTerms } from '@scrawlix/core';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createDomScrawlix } from './index';
+
+const rules = [censorRuleFromTerms('fuck', ['fuck'])] as const;
+
+function controller() {
+  return createDomScrawlix({ rules, coverage: 'middle' });
+}
+
+function tick() {
+  return new Promise<void>(resolve => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('DOM source ownership', () => {
+  it('keeps the original Text node in its page-owned parent and restores its identity', () => {
+    document.body.innerHTML = '<p id="copy">fuck</p>';
+    const paragraph = document.querySelector('#copy')!;
+    const source = paragraph.firstChild as Text;
+    const scrawlix = controller();
+
+    scrawlix.apply(paragraph);
+
+    expect(paragraph.firstChild).toBe(source);
+    expect(source.data).toBe('');
+    expect(source.nextSibling).toMatchObject({ nodeType: Node.ELEMENT_NODE });
+    expect(paragraph.querySelector('[data-scrawlix-dom-root]')).not.toBeNull();
+    expect(paragraph.textContent).toBe('fuck');
+
+    expect(scrawlix.restore(paragraph)).toBe(1);
+    expect(paragraph.firstChild).toBe(source);
+    expect(source.data).toBe('fuck');
+    expect(paragraph.querySelector('[data-scrawlix-dom-root]')).toBeNull();
+  });
+
+  it('mirrors page-owned character-data updates and restores the latest source', async () => {
+    document.body.innerHTML = '<p id="copy">fuck 0</p>';
+    const paragraph = document.querySelector('#copy')!;
+    const source = paragraph.firstChild as Text;
+    const observation = controller().observe(document.body);
+
+    expect(source.data).toBe('');
+    source.data = 'fuck 1';
+
+    await tick();
+
+    expect(paragraph.textContent).toBe('fuck 1');
+    expect(source.data).toBe('');
+    expect(paragraph.querySelector('[data-scrawlix-cover]')?.textContent).toBe('uc');
+
+    expect(observation.restore()).toBe(1);
+    expect(paragraph.firstChild).toBe(source);
+    expect(source.data).toBe('fuck 1');
+  });
+
+  it('drains a pending page write before immediate restore', () => {
+    document.body.innerHTML = '<p id="copy">fuck 0</p>';
+    const paragraph = document.querySelector('#copy')!;
+    const source = paragraph.firstChild as Text;
+    const observation = controller().observe(document.body);
+
+    source.data = 'fuck 1';
+
+    expect(observation.restore()).toBe(1);
+    expect(paragraph.firstChild).toBe(source);
+    expect(source.data).toBe('fuck 1');
+    expect(paragraph.textContent).toBe('fuck 1');
+    expect(paragraph.querySelector('[data-scrawlix-dom-root]')).toBeNull();
+  });
+
+  it('releases the wrapper when page-owned text becomes safe', async () => {
+    document.body.innerHTML = '<p id="copy">fuck</p>';
+    const paragraph = document.querySelector('#copy')!;
+    const source = paragraph.firstChild as Text;
+    const observation = controller().observe(document.body);
+
+    source.data = 'safe';
+    await tick();
+
+    expect(paragraph.firstChild).toBe(source);
+    expect(source.data).toBe('safe');
+    expect(paragraph.querySelector('[data-scrawlix-dom-root]')).toBeNull();
+    observation.disconnect();
+  });
+
+  it('removes generated siblings when the page removes its owned Text node', async () => {
+    document.body.innerHTML = '<p id="copy"><span>state: </span>fuck</p>';
+    const paragraph = document.querySelector('#copy')!;
+    const source = paragraph.lastChild as Text;
+    const observation = controller().observe(document.body);
+
+    expect(paragraph.querySelector('[data-scrawlix-dom-root]')).not.toBeNull();
+    source.remove();
+    await tick();
+
+    expect(source.data).toBe('fuck');
+    expect(paragraph.textContent).toBe('state: ');
+    expect(paragraph.querySelector('[data-scrawlix-dom-root]')).toBeNull();
+    observation.disconnect();
+  });
+
+  it('preserves and recensores a page-owned Text node moved between parents', async () => {
+    document.body.innerHTML = '<p id="from">fuck</p><p id="to"></p>';
+    const from = document.querySelector('#from')!;
+    const to = document.querySelector('#to')!;
+    const source = from.firstChild as Text;
+    const observation = controller().observe(document.body);
+
+    expect(from.querySelector('[data-scrawlix-dom-root]')).not.toBeNull();
+    to.append(source);
+
+    await tick();
+    await tick();
+
+    expect(from.textContent).toBe('');
+    expect(from.querySelector('[data-scrawlix-dom-root]')).toBeNull();
+    expect(to.firstChild).toBe(source);
+    expect(source.data).toBe('');
+    expect(to.textContent).toBe('fuck');
+    expect(to.querySelector('[data-scrawlix-dom-root]')).not.toBeNull();
+    observation.disconnect();
+  });
+});

--- a/tests/browser/react-ownership.spec.ts
+++ b/tests/browser/react-ownership.spec.ts
@@ -1,0 +1,62 @@
+import { chromium, expect, test } from '@playwright/test';
+import { resolve } from 'node:path';
+
+const extensionPath = resolve(process.cwd(), 'apps/extension/dist');
+
+test('built extension follows React-owned HostText updates, removals, and remounts', async ({}, testInfo) => {
+  const context = await chromium.launchPersistentContext(
+    testInfo.outputPath('extension-react-ownership'),
+    {
+      channel: 'chromium',
+      headless: true,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+      ],
+    }
+  );
+
+  try {
+    const page = context.pages()[0] ?? (await context.newPage());
+    const browserErrors: string[] = [];
+    page.on('console', message => {
+      if (
+        message.type() === 'error' &&
+        !message.text().startsWith('Failed to load resource:')
+      ) {
+        browserErrors.push(message.text());
+      }
+    });
+    page.on('pageerror', error => browserErrors.push(error.message));
+
+    await page.goto('http://127.0.0.1:4173/?ownership-fixture');
+
+    const owned = page.locator('#react-owned');
+    await expect(owned.locator('[data-scrawlix-dom-root]')).toHaveCount(1);
+    await expect(owned).toHaveText('state: fuck 0');
+
+    await page.locator('#react-increment').click();
+    await expect(owned).toHaveText('state: fuck 1');
+    await expect(owned.locator('[data-scrawlix-dom-root]')).toHaveCount(1);
+
+    await page.locator('#react-toggle-text').click();
+    await expect(owned).toHaveText('state: ');
+    await expect(owned.locator('[data-scrawlix-dom-root]')).toHaveCount(0);
+
+    await page.locator('#react-toggle-text').click();
+    await expect(owned).toHaveText('state: fuck 1');
+    await expect(owned.locator('[data-scrawlix-dom-root]')).toHaveCount(1);
+
+    await page.locator('#react-toggle').click();
+    await expect(page.locator('#react-unmounted')).toHaveText('unmounted');
+    await page.locator('#react-toggle').click();
+    await expect(page.locator('#react-owned')).toHaveText('state: fuck 1');
+    await expect(
+      page.locator('#react-owned [data-scrawlix-dom-root]')
+    ).toHaveCount(1);
+
+    expect(browserErrors).toEqual([]);
+  } finally {
+    await context.close();
+  }
+});


### PR DESCRIPTION
## Failure reproduced

The real Chromium fixture proved the wrapper-replacement model breaks React-owned HostText updates: after React increments `fuck 0` to `fuck 1`, React mutates the Text object it owns while the visible Scrawlix wrapper remains stuck at `fuck 0`.

## Fix

- keep the original page-owned Text node in its original parent as an empty ownership anchor
- render Scrawlix output through a sibling `data-scrawlix-dom-root` wrapper
- mirror later character-data writes from the page-owned node into that wrapper
- remove the wrapper when the source becomes safe
- preserve/re-censor the same Text object when page code moves it between parents
- drain pending MutationObserver records before disconnect/restore so an immediate page write wins over the previous snapshot
- remove generated siblings when the page removes its Text node
- restore the same Text object with the latest page-owned source value
- document the ownership-anchor lifecycle in `docs/dom.md`

## Regression coverage

Unit tests assert Text-node identity, latest-source restoration, immediate-disable draining, safe-text release, source removal, and moving/reusing the same Text object. The real Chromium fixture exercises HostText update, direct HostText removal/re-add under the same parent, whole-subtree unmount/remount, persistent censorship, and browser/page errors.

The delayed-pre-hydration case was also reproduced: active content eventually recovers, but mutating server markup before `hydrateRoot()` produces React hydration error #418. That distinct pre-hydration problem is tracked in #110 instead of blocking this live-ownership fix.

Refs #54.