### PR TITLE
Restore open pages before revoking host access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ Storage changes should perform the minimum page work. Policy changes that leave 
 
 Extension reveal interaction must avoid stealing native page controls. Generated roots inside links, buttons, inputs, or similar controls stay outside the extension's own focus/click-toggle path.
 
-HTTP/HTTPS host access is optional and user-granted. Keep dynamic content-script registration aligned with Chrome's currently granted origin patterns, and keep browser access separate from Scrawlix site policy in both code and UI. Removing access from the extension UI should restore the current page session immediately. Any permission expansion is a browser-product and store-review change that must include its UX and privacy rationale.
+HTTP/HTTPS host access is optional and user-granted. Keep dynamic content-script registration aligned with Chrome's currently granted origin patterns, and keep browser access separate from Scrawlix site policy in both code and UI. Before removing a host grant, restore every matching open Scrawlix page while the permission still permits reliable messaging; after removal, reconcile any affected tabs still covered by an overlapping remaining grant. If Chrome refuses removal, restore the page sessions that were temporarily stopped. Any permission expansion is a browser-product and store-review change that must include its UX and privacy rationale.
 
 ### Add corpus cases for learned linguistic behavior
 

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -61,7 +61,7 @@ Long-lived collections live in a full-tab `options.html` page opened through `ch
 - General preferences with a live specimen rendered by the real Scrawlix core/coverage/mask logic
 - explicit Add/Remove custom-term management with filtering and the same 200-code-point limit used by context-menu additions
 - searchable site exceptions with `always on`, `always off`, and **use default** actions
-- a read-only summary of persistent browser host grants
+- persistent browser host grants with safe removal
 - concise privacy/source/version information
 
 Moving custom terms out of the popup removes the popup-lifecycle debounce hazard: term changes now persist through explicit Add/Remove actions in a durable browser tab.
@@ -73,13 +73,15 @@ The store-facing manifest requests no HTTP/HTTPS host permission at install time
 - allow the current HTTP/HTTPS origin
 - allow all HTTP and HTTPS websites
 
-A small Manifest V3 service worker keeps one dynamic content-script registration aligned with the origins Chrome currently grants to Scrawlix. Dynamic registration persists across browser sessions. Removing browser access updates the registration; removing access from the popup also tells the current page session to restore its source text immediately.
+A small Manifest V3 service worker keeps one dynamic content-script registration aligned with the origins Chrome currently grants to Scrawlix. Dynamic registration persists across browser sessions.
 
 Browser access and Scrawlix policy are separate. A site can be configured `on` while Chrome access is still missing; the popup reports that state directly instead of claiming censorship is already active.
 
 Opening the popup on a persistently granted site also ensures the current page runtime is present. This covers pages that were already open when access changed and keeps the displayed current-site state aligned with the actual page.
 
-The Options page currently summarizes granted sites without removing them. Multi-site access removal belongs there only after revocation can restore every affected open tab before Chrome drops the grant.
+Host revocation is centralized in `access.ts`. Before Chrome drops an origin grant, Scrawlix queries every open tab covered by that grant and asks each page to restore its exact source text. After removal it updates the dynamic content-script registration and immediately reconciles tabs still covered by an overlapping remaining grant. If Chrome refuses to remove a required or policy-controlled permission, those page sessions are restored instead of being left disabled.
+
+This lifecycle lets both the popup and Options remove grants without adding the broad `tabs` permission: an existing host grant is sufficient for URL-filtered tab queries and page messaging while that grant still exists.
 
 ## Quick interactions
 
@@ -151,4 +153,4 @@ See [`docs/extension-privacy.md`](../../docs/extension-privacy.md) for the curre
 - broad HTTP/HTTPS patterns remain optional instead of required host permissions
 - every directly referenced popup/background/options asset exists in `dist`
 
-Unit tests cover preference normalization/reconciliation, browser-access helpers, local-vs-sync storage, and selection normalization. The Chromium smoke build promotes optional host patterns only inside a temporary test copy of the manifest so CI can exercise the same service-worker registration, real content script, temporary page reveal, and Options custom-term round trip without weakening the shipping manifest.
+Unit tests cover preference normalization/reconciliation, browser-access helpers including restore-before-revoke behavior, local-vs-sync storage, and selection normalization. The Chromium smoke build promotes optional host patterns only inside a temporary test copy of the manifest so CI can exercise the same service-worker registration, real content script, temporary page reveal, and Options custom-term round trip without weakening the shipping manifest.

--- a/apps/extension/options.html
+++ b/apps/extension/options.html
@@ -144,9 +144,10 @@
           </div>
           <span id="access-count" class="count-label"></span>
         </div>
-        <p class="section-copy">Grant or remove access for the page you are browsing from the Scrawlix popup. Chrome also exposes site-access controls in the extension menu.</p>
+        <p class="section-copy">Grant access for the page you are browsing from the Scrawlix popup. Removing a grant here restores Scrawlix-owned text in matching open tabs before Chrome drops that access.</p>
         <ul id="access-list" class="access-list"></ul>
         <p id="access-empty" class="empty-state">Scrawlix has no persistent website access yet.</p>
+        <p id="access-action-status" class="save-status" aria-live="polite"></p>
       </section>
 
       <section class="panel privacy-panel" aria-labelledby="privacy-heading">

--- a/apps/extension/src/access.test.ts
+++ b/apps/extension/src/access.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ALL_HOST_PATTERNS,
   contentScriptMatches,
   originPatternForUrl,
+  removeHostAccess,
 } from './access';
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('extension browser access helpers', () => {
   it('turns an HTTP(S) page into the narrow origin permission pattern', () => {
@@ -27,5 +32,91 @@ describe('extension browser access helpers', () => {
 
   it('declares both web schemes for the explicit all-sites action', () => {
     expect(ALL_HOST_PATTERNS).toEqual(['http://*/*', 'https://*/*']);
+  });
+
+  it('restores affected tabs before removal and reactivates overlapping grants', async () => {
+    let permissionRemoved = false;
+    const messages: Array<[number, unknown]> = [];
+
+    const contains = vi.fn(async ({ origins }: { origins?: string[] }) => {
+      const pattern = origins?.[0] ?? '';
+      if (!permissionRemoved) return true;
+      return pattern === 'https://keep.example/*';
+    });
+    const remove = vi.fn(async () => {
+      permissionRemoved = true;
+      return true;
+    });
+    const getAll = vi.fn(async () => ({
+      origins: permissionRemoved ? ['https://keep.example/*'] : ['https://*/*'],
+    }));
+    const query = vi.fn(async () => [
+      { id: 1, url: 'https://keep.example/page' },
+      { id: 2, url: 'https://gone.example/page' },
+    ]);
+    const get = vi.fn(async (tabId: number) => ({
+      id: tabId,
+      url: tabId === 1 ? 'https://keep.example/page' : 'https://gone.example/page',
+    }));
+    const sendMessage = vi.fn(async (tabId: number, message: unknown) => {
+      messages.push([tabId, message]);
+    });
+    const updateContentScripts = vi.fn(async () => undefined);
+
+    vi.stubGlobal('chrome', {
+      permissions: { contains, remove, getAll },
+      tabs: { query, get, sendMessage },
+      scripting: {
+        getRegisteredContentScripts: vi.fn(async () => [{ id: 'scrawlix-page' }]),
+        updateContentScripts,
+        unregisterContentScripts: vi.fn(async () => undefined),
+        registerContentScripts: vi.fn(async () => undefined),
+        insertCSS: vi.fn(async () => undefined),
+        executeScript: vi.fn(async () => undefined),
+      },
+    });
+
+    await expect(removeHostAccess(['https://*/*'])).resolves.toBe(true);
+
+    expect(query).toHaveBeenCalledWith({ url: ['https://*/*'] });
+    expect(messages).toContainEqual([1, { type: 'scrawlix-disable' }]);
+    expect(messages).toContainEqual([2, { type: 'scrawlix-disable' }]);
+    expect(messages).toContainEqual([1, { type: 'scrawlix-reconcile' }]);
+    expect(messages).not.toContainEqual([2, { type: 'scrawlix-reconcile' }]);
+    expect(updateContentScripts).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'scrawlix-page',
+        matches: ['https://keep.example/*'],
+      }),
+    ]);
+  });
+
+  it('puts tabs back when Chrome refuses to remove a permission', async () => {
+    const messages: Array<[number, unknown]> = [];
+    const sendMessage = vi.fn(async (tabId: number, message: unknown) => {
+      messages.push([tabId, message]);
+    });
+
+    vi.stubGlobal('chrome', {
+      permissions: {
+        contains: vi.fn(async () => true),
+        remove: vi.fn(async () => false),
+      },
+      tabs: {
+        query: vi.fn(async () => [{ id: 7, url: 'https://example.com/page' }]),
+        get: vi.fn(async () => ({ id: 7, url: 'https://example.com/page' })),
+        sendMessage,
+      },
+      scripting: {
+        insertCSS: vi.fn(async () => undefined),
+        executeScript: vi.fn(async () => undefined),
+      },
+    });
+
+    await expect(removeHostAccess(['https://example.com/*'])).resolves.toBe(false);
+    expect(messages).toEqual([
+      [7, { type: 'scrawlix-disable' }],
+      [7, { type: 'scrawlix-reconcile' }],
+    ]);
   });
 });

--- a/apps/extension/src/access.ts
+++ b/apps/extension/src/access.ts
@@ -74,12 +74,6 @@ export async function requestHostAccess(origins: readonly string[]) {
   return granted;
 }
 
-export async function removeHostAccess(origins: readonly string[]) {
-  const removed = await chrome.permissions.remove({ origins: [...origins] });
-  if (removed) await syncContentScriptRegistration();
-  return removed;
-}
-
 async function sendContentMessage(tabId: number, message: ScrawlixContentMessage) {
   try {
     await chrome.tabs.sendMessage(tabId, message);
@@ -104,6 +98,56 @@ export async function activateTab(tabId: number) {
 
 export async function deactivateTab(tabId: number) {
   await sendContentMessage(tabId, { type: 'scrawlix-disable' });
+}
+
+async function currentTabUrl(tabId: number) {
+  try {
+    return (await chrome.tabs.get(tabId)).url ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function reactivateTabIfStillGranted(tabId: number) {
+  const url = await currentTabUrl(tabId);
+  if (!url || !(await hasPersistentAccess(url))) return;
+
+  try {
+    await activateTab(tabId);
+  } catch {
+    // The tab may navigate or close between the permission check and injection.
+  }
+}
+
+export async function removeHostAccess(origins: readonly string[]) {
+  const patterns = contentScriptMatches(origins);
+  if (patterns.length === 0) return false;
+
+  const granted = await chrome.permissions.contains({ origins: patterns });
+  if (!granted) return false;
+
+  // Host permission makes URL-filtered tabs.query available without the broad `tabs` permission.
+  const affectedTabs = await chrome.tabs.query({ url: patterns });
+  const tabIds = affectedTabs.flatMap(tab =>
+    tab.id === undefined ? [] : [tab.id]
+  );
+
+  // Restore exact source while the permission still allows reliable page messaging.
+  await Promise.all(tabIds.map(tabId => deactivateTab(tabId)));
+
+  const removed = await chrome.permissions.remove({ origins: patterns });
+  if (!removed) {
+    // Required/policy-controlled permissions cannot be removed. Put any page sessions back.
+    await Promise.all(tabIds.map(tabId => reactivateTabIfStillGranted(tabId)));
+    return false;
+  }
+
+  await syncContentScriptRegistration();
+
+  // An overlapping remaining grant may still cover some tabs (for example a narrow
+  // origin grant after removing all-sites access). Reconcile those tabs immediately.
+  await Promise.all(tabIds.map(tabId => reactivateTabIfStillGranted(tabId)));
+  return true;
 }
 
 export async function revealTabFor(

--- a/apps/extension/src/options.css
+++ b/apps/extension/src/options.css
@@ -323,7 +323,8 @@ button:focus-visible {
   opacity: 0.58;
 }
 
-#custom-status {
+#custom-status,
+#access-action-status {
   display: block;
   margin: 8px 0 0;
 }
@@ -375,8 +376,13 @@ button:focus-visible {
   font-size: 13px;
 }
 
-.hostname {
+.hostname,
+.access-value {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.access-value {
+  font-size: 10px;
 }
 
 .quiet-button {
@@ -407,13 +413,6 @@ button:focus-visible {
 .empty-state {
   margin: 14px 0 0;
   opacity: 0.58;
-}
-
-.access-list li {
-  padding: 9px 0;
-  border-bottom: 1px solid rgba(23, 21, 16, 0.2);
-  font-size: 10px;
-  overflow-wrap: anywhere;
 }
 
 .privacy-panel p:not(.eyebrow) {

--- a/apps/extension/src/options.ts
+++ b/apps/extension/src/options.ts
@@ -1,6 +1,7 @@
 import { censorRuleFromWords, createScrawlix } from '@scrawlix/core';
 import './content.css';
 import './options.css';
+import { removeHostAccess } from './access';
 import { MAX_CUSTOM_TERM_CODE_POINTS } from './actions';
 import {
   CUSTOM_WORDS_KEY,
@@ -25,6 +26,11 @@ import {
 
 const PREVIEW_TERM = 'Mothbit';
 const previewRule = censorRuleFromWords('options-preview', [PREVIEW_TERM]);
+
+type AccessDisplayEntry = {
+  label: string;
+  origins: string[];
+};
 
 function required<T extends HTMLElement>(id: string): T {
   const element = document.getElementById(id);
@@ -58,6 +64,7 @@ const siteEmpty = required<HTMLParagraphElement>('site-empty');
 const accessCount = required<HTMLSpanElement>('access-count');
 const accessList = required<HTMLUListElement>('access-list');
 const accessEmpty = required<HTMLParagraphElement>('access-empty');
+const accessActionStatus = required<HTMLParagraphElement>('access-action-status');
 
 let settings: SyncSettings;
 let customWords: string[] = [];
@@ -230,20 +237,42 @@ function humanAccessPattern(pattern: string) {
   return pattern.replace(/\/\*$/, '');
 }
 
-function accessDisplayEntries(origins: readonly string[]) {
+function accessDisplayEntries(origins: readonly string[]): AccessDisplayEntry[] {
   const set = new Set(origins.filter(origin => /^https?:\/\//.test(origin)));
-  const entries: string[] = [];
+  const entries: AccessDisplayEntry[] = [];
   const allHttp = set.delete('http://*/*');
   const allHttps = set.delete('https://*/*');
 
-  if (allHttp && allHttps) entries.push('All HTTP and HTTPS websites');
-  else {
-    if (allHttp) entries.push('All HTTP websites');
-    if (allHttps) entries.push('All HTTPS websites');
+  if (allHttp && allHttps) {
+    entries.push({
+      label: 'All HTTP and HTTPS websites',
+      origins: ['http://*/*', 'https://*/*'],
+    });
+  } else {
+    if (allHttp) entries.push({ label: 'All HTTP websites', origins: ['http://*/*'] });
+    if (allHttps) entries.push({ label: 'All HTTPS websites', origins: ['https://*/*'] });
   }
 
-  entries.push(...[...set].sort().map(humanAccessPattern));
+  entries.push(
+    ...[...set].sort().map(origin => ({
+      label: humanAccessPattern(origin),
+      origins: [origin],
+    }))
+  );
   return entries;
+}
+
+async function removeAccess(entry: AccessDisplayEntry) {
+  accessActionStatus.textContent = `removing ${entry.label}…`;
+  try {
+    const removed = await removeHostAccess(entry.origins);
+    await renderAccess();
+    accessActionStatus.textContent = removed
+      ? `Removed ${entry.label}`
+      : `Chrome kept ${entry.label}`;
+  } catch {
+    accessActionStatus.textContent = `Could not remove ${entry.label}`;
+  }
 }
 
 async function renderAccess() {
@@ -254,9 +283,22 @@ async function renderAccess() {
   accessList.replaceChildren();
 
   for (const entry of entries) {
-    const item = document.createElement('li');
-    item.textContent = entry;
-    accessList.append(item);
+    const row = document.createElement('li');
+    row.className = 'managed-row access-row';
+
+    const label = document.createElement('span');
+    label.className = 'managed-value access-value';
+    label.textContent = entry.label;
+
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'quiet-button';
+    remove.textContent = 'remove';
+    remove.setAttribute('aria-label', `Remove access for ${entry.label}`);
+    remove.addEventListener('click', () => void removeAccess(entry));
+
+    row.append(label, remove);
+    accessList.append(row);
   }
 
   accessEmpty.hidden = entries.length > 0;

--- a/apps/extension/src/popup.ts
+++ b/apps/extension/src/popup.ts
@@ -2,7 +2,6 @@ import './popup.css';
 import {
   ALL_HOST_PATTERNS,
   activateTab,
-  deactivateTab,
   hasAllHostsAccess,
   hasPersistentAccess,
   originPatternForUrl,
@@ -261,7 +260,6 @@ siteAccessButton.addEventListener('click', () => {
     accessStatus.textContent = persistentAccess ? 'removing access…' : 'requesting access…';
     try {
       if (persistentAccess) {
-        await deactivateTab(page.tabId);
         await removeHostAccess([page.originPattern]);
       } else {
         const granted = await requestHostAccess([page.originPattern]);
@@ -279,9 +277,7 @@ allSitesAccessButton.addEventListener('click', () => {
     accessStatus.textContent = allHostsAccess ? 'removing all-sites access…' : 'requesting all-sites access…';
     try {
       if (allHostsAccess) {
-        if (page) await deactivateTab(page.tabId);
         await removeHostAccess(ALL_HOST_PATTERNS);
-        if (page && (await hasPersistentAccess(page.url))) await activateTab(page.tabId);
       } else {
         const granted = await requestHostAccess(ALL_HOST_PATTERNS);
         if (granted && page) await activateTab(page.tabId);


### PR DESCRIPTION
## What changed

- centralize HTTP/HTTPS host revocation in `access.ts`
- before Chrome removes a grant, query every matching open tab while the host permission still permits URL filtering and reliable messaging
- send `scrawlix-disable` to those tabs so Scrawlix-owned DOM restores exact source text before permission loss
- update the persistent dynamic content-script registration after removal
- immediately reconcile affected tabs still covered by an overlapping remaining grant
- if Chrome refuses to remove a required/policy-controlled permission, reactivate the page sessions that were temporarily stopped
- make popup site/all-sites removal use the centralized lifecycle
- add Remove controls for persistent grants in the full-tab Options page
- keep the manifest permission set unchanged; existing host grants provide the tab URL/query access needed for cleanup
- add unit regressions for restore-before-revoke, overlap reactivation, and removal refusal
- strengthen maintainer/docs invariants around multi-tab permission removal

## Product behavior

Removing browser access no longer risks leaving already-open background tabs with stale Scrawlix wrappers after the extension loses permission to reach them. The page cleanup happens while access still exists, then Chrome's grant is removed.

A broad grant and a narrower overlapping grant can coexist. When the broad grant is removed, pages still covered by the narrow grant are reconciled immediately instead of staying restored until their next navigation.

## Validation

CI is green on the final head:

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Chromium demo smoke
- Chromium extension smoke
- `pnpm smoke:packages`

## Stack

This PR is intentionally based on `copper/options-page` / #101 so reviewers see only the permission-revocation lifecycle.

Progresses #50 and #23.