### PR TITLE
Declare package Node runtime requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added package-local READMEs for every public package, exact install commands, a top-level integration chooser, a docs index, React CSS troubleshooting, Next.js client-boundary guidance, and clearer source/accessibility notes.
 - Added a framework-neutral renderer recipe with plain-DOM, Vue, Svelte, and Solid sketches plus a threshold for when a dedicated adapter package is worth maintaining.
 - Added explicit runtime compatibility and pre-1.0 versioning/public-contract policies.
+- Declared Node 18+ in every public package manifest and Node 22+ in the private workspace manifest so package-manager metadata matches the documented runtime/tooling baselines.
 - Added explicit privacy/output vocabulary for visual covers, presentation/screenshot guarantees, assistive-tech concealment, and sanitized export.
 - Aligned `README.md`, `AGENTS.md`, `llms.txt`, demo, extension, tests, and smoke consumers on the canonical pre-release public names and conservative defaults.
 - Committed a pnpm 10.34.5 lockfile, pinned the workspace package manager, and switched CI to frozen installs.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -13,9 +13,9 @@ Scrawlix publishes ESM and TypeScript declarations targeting modern JavaScript. 
 - RegExp match indices (`d` flag)
 - `Intl.Segmenter` with grapheme segmentation
 
-For published-package execution in Node, **Node 18 and newer** is the supported baseline for core/rehype and SSR contexts that execute package code directly.
+For published-package execution in Node, **Node 18 and newer** is the supported baseline for core/rehype and SSR contexts that execute package code directly. Every public `@scrawlix/*` manifest declares `engines.node: ">=18"` so package managers can surface that requirement before install.
 
-Repository CI and ordinary development verification use **Node 22**. The OIDC npm publication job uses **Node 24** so its release runner comfortably satisfies npm trusted-publishing runtime requirements. The workspace includes current build/test tools with their own Node requirements, so contributors should follow the CI/toolchain baseline instead of treating the package-runtime minimum as the repository-development minimum.
+Repository CI and ordinary development verification use **Node 22**. The private root workspace declares `engines.node: ">=22"`. The OIDC npm publication job uses **Node 24** so its release runner comfortably satisfies npm trusted-publishing runtime requirements. The workspace includes current build/test tools with their own Node requirements, so contributors should follow the CI/toolchain baseline instead of treating the package-runtime minimum as the repository-development minimum.
 
 For browsers, support is capability-based during pre-1.0: the consuming browser must support the features above. Scrawlix's browser CI exercises current Chromium. Add explicit Firefox/Safari version claims only alongside CI or targeted compatibility tests that enforce them.
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "scrawlix-workspace",
   "private": true,
   "packageManager": "pnpm@10.34.5",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "build": "pnpm build:packages && pnpm --filter scrawlix-demo build && pnpm --filter scrawlix-extension build",
     "build:packages": "pnpm --filter @scrawlix/core build && pnpm --filter @scrawlix/en build && pnpm --filter @scrawlix/react build && pnpm --filter @scrawlix/rehype build && pnpm --filter @scrawlix/dom build",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "Language-neutral matching and coverage engine for Scrawlix.",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "sideEffects": false,
   "files": ["dist"],
   "main": "./dist/index.js",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "DOM text-node adapter for applying Scrawlix to arbitrary webpages and dynamic content.",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "sideEffects": false,
   "files": ["dist"],
   "main": "./dist/index.js",

--- a/packages/en/package.json
+++ b/packages/en/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "English strong-profanity rules, coverage helpers, and regression corpora for Scrawlix.",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "sideEffects": false,
   "files": ["dist"],
   "main": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "React rendering, appearances, and reveal behavior for Scrawlix.",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "sideEffects": ["./dist/styles.css"],
   "files": ["dist"],
   "main": "./dist/index.js",

--- a/packages/rehype/package.json
+++ b/packages/rehype/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "HAST/rehype adapter for applying Scrawlix coverage throughout Markdown-rendered prose.",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "sideEffects": false,
   "files": ["dist"],
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Makes the documented Node compatibility split visible to package managers.

### Public packages
- add `engines.node: ">=18"` to `@scrawlix/core`
- add the same runtime floor to `@scrawlix/en`, `@scrawlix/react`, `@scrawlix/rehype`, and `@scrawlix/dom`

### Repository tooling
- add `engines.node: ">=22"` to the private root workspace manifest
- keep the Node 24 npm publication runner as a workflow concern rather than raising the published runtime floor

### Docs
- align `docs/compatibility.md` with the machine-readable metadata
- record the metadata in the changelog

This changes metadata only; the supported runtime policy itself is already documented. The full frozen-install/browser/tarball matrix will verify that package metadata and lockfile remain compatible.

Closes #103.