### PR TITLE
Add bounded repeated-letter obfuscation

### DIFF
--- a/fixtures/consumer/runtime.mjs
+++ b/fixtures/consumer/runtime.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { createScrawlix } from '@scrawlix/core';
+import { censorRuleFromRepeatedObfuscatedTerms } from '@scrawlix/core/repeated-obfuscated';
 import { censorRuleFromTargetedObfuscatedTerms } from '@scrawlix/core/targeted-obfuscated';
 import { createDomScrawlix } from '@scrawlix/dom';
 import {
@@ -70,6 +71,20 @@ const targetedMatch = targetedEngine.find('f*cking')[0];
 assert.equal(targetedMatch?.text, 'f*cking');
 assert.equal(targetedMatch?.targetText, 'f*ck');
 assert.equal(targetedMatch?.profile, 'obfuscated');
+
+const repeatedEngine = createScrawlix({
+  rules: [
+    censorRuleFromRepeatedObfuscatedTerms(
+      'repeated-smoke',
+      [{ term: 'motherfucker', target: 'fuck' }],
+      { maxRepetitions: 1 }
+    ),
+  ],
+});
+const repeatedMatch = repeatedEngine.find('motherfuucker')[0];
+assert.equal(repeatedMatch?.text, 'motherfuucker');
+assert.equal(repeatedMatch?.targetText, 'fuuck');
+assert.equal(repeatedMatch?.profile, 'obfuscated');
 
 const tree = {
   type: 'root',

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -136,11 +136,43 @@ Each object entry declares a full canonical `term` and one unique exact canonica
 
 String entries are also accepted and use the complete term as their semantic target. This helper lives on a focused subpath while the API is exercised by language packs before a wider pre-1.0 barrel decision.
 
+### Bounded repeated letters
+
+Repeated-letter evasions use another focused subpath while their semantics are reviewed:
+
+```ts
+import { createScrawlix } from '@scrawlix/core';
+import { censorRuleFromRepeatedObfuscatedTerms } from '@scrawlix/core/repeated-obfuscated';
+
+const repeated = censorRuleFromRepeatedObfuscatedTerms(
+  'example-repeat',
+  [
+    'fuck',
+    { term: 'motherfucker', target: 'fuck' },
+  ],
+  {
+    maxRepetitions: 1,
+  }
+);
+
+const engine = createScrawlix({ rules: [repeated] });
+engine.find('fuuck')[0]?.targetText; // "fuuck"
+engine.find('motherfuucker')[0]?.targetText; // "fuuck"
+```
+
+Only canonical Unicode letter graphemes are repeatable. Canonical run lengths act as minima, so a real double in a declared spelling stays intact: `asshole` contains a canonical `ss` run, `assshole` costs one repetition, and `ashole` cannot satisfy the term. Every extra source grapheme beyond the canonical run length costs one repetition.
+
+The helper filters zero-change canonical forms, defaults to `profile: 'obfuscated'`, and preserves exact original-source ranges. It accepts the same reviewed `substitutions`, `ignored`, boundary, normalization, and coverage options as the earlier aggressive helper. `maxRepetitions` is always explicit. When repetition is combined with substitutions or ignored graphemes, `maxChanges` is also required and counts all enabled transform classes together.
+
+Semantic targets are supported directly. Extra source graphemes in a repeated run attach to the final canonical grapheme of that run. That rule keeps target mapping deterministic even when a semantic boundary falls inside a canonical double, such as the `shit` target inside canonical `shitting`.
+
+This first repetition path is intentionally bounded and corpus-driven. It does not perform blanket edit-distance matching, phonetic equivalence, transliteration, or universal confusable folding.
+
 ## Match profiles
 
 Rules can carry an optional `profile` string. `find()` exposes it as `match.profile`, and coverage callbacks receive the same value in their context. This lets packs distinguish conservative and aggressive matching paths in diagnostics and policy code.
 
-`censorRuleFromTerms()` labels its rules `canonical` by default, while `censorRuleFromObfuscatedTerms()` and the targeted obfuscated helper label their rules `obfuscated` by default.
+`censorRuleFromTerms()` labels its rules `canonical` by default, while the obfuscated helpers label their rules `obfuscated` by default.
 
 Profile names describe the matching path. Packs still own linguistic scope, reviewed transform tables, budgets, and regression negatives.
 
@@ -152,8 +184,9 @@ Profile names describe the matching path. Packs still own linguistic scope, revi
 - `segment(text)` returns source-preserving covered/uncovered segments
 - generic coverage presets are `full`, `tail`, `middle`, and `inner`
 - literal/custom-term matching defaults to NFC canonical equivalence and `profile: 'canonical'`
-- bounded aggressive term matching is opt-in through `censorRuleFromObfuscatedTerms()`
+- bounded aggressive substitution/insertion matching is opt-in through `censorRuleFromObfuscatedTerms()`
 - targeted aggressive matching can preserve a smaller semantic root through `@scrawlix/core/targeted-obfuscated`
+- repeated-letter matching is opt-in through `@scrawlix/core/repeated-obfuscated`
 - every exposed match, target, and covered segment respects extended-grapheme boundaries
 
 Scrawlix deliberately has no built-in language or hidden profanity list. Callers select rules explicitly.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,11 @@
       "types": "./dist/targeted-obfuscated.d.ts",
       "import": "./dist/targeted-obfuscated.js",
       "default": "./dist/targeted-obfuscated.js"
+    },
+    "./repeated-obfuscated": {
+      "types": "./dist/repeated-obfuscated.d.ts",
+      "import": "./dist/repeated-obfuscated.js",
+      "default": "./dist/repeated-obfuscated.js"
     }
   },
   "repository": {

--- a/packages/core/src/repeated-obfuscated.test.ts
+++ b/packages/core/src/repeated-obfuscated.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+import { createScrawlix } from './index';
+import { censorRuleFromRepeatedObfuscatedTerms } from './repeated-obfuscated';
+
+describe('repeated obfuscated terms', () => {
+  it('matches one excess repeated letter with exact source ranges', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromRepeatedObfuscatedTerms('fuck-repeat', ['fuck'], {
+          maxRepetitions: 1,
+        }),
+      ],
+    });
+
+    expect(engine.find('fuuck')).toEqual([
+      {
+        ruleId: 'fuck-repeat',
+        profile: 'obfuscated',
+        text: 'fuuck',
+        start: 0,
+        end: 5,
+        targetText: 'fuuck',
+        targetStart: 0,
+        targetEnd: 5,
+      },
+    ]);
+    expect(engine.find('fuck')).toEqual([]);
+    expect(engine.find('fuuuck')).toEqual([]);
+  });
+
+  it('treats canonical repeated runs as minima and charges only excess letters', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromRepeatedObfuscatedTerms('asshole-repeat', ['asshole'], {
+          maxRepetitions: 1,
+        }),
+      ],
+    });
+
+    expect(engine.find('asshole')).toEqual([]);
+    expect(engine.find('ashole')).toEqual([]);
+    expect(engine.find('assshole')[0]).toMatchObject({
+      text: 'assshole',
+      targetText: 'assshole',
+      start: 0,
+      end: 8,
+    });
+  });
+
+  it('preserves a semantic root when a repeated run sits inside the root', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromRepeatedObfuscatedTerms(
+          'fuck-repeat',
+          [{ term: 'motherfucker', target: 'fuck' }],
+          { maxRepetitions: 1 }
+        ),
+      ],
+      coverage: 'full',
+    });
+
+    expect(engine.find('motherfuucker')).toEqual([
+      {
+        ruleId: 'fuck-repeat',
+        profile: 'obfuscated',
+        text: 'motherfuucker',
+        start: 0,
+        end: 13,
+        targetText: 'fuuck',
+        targetStart: 6,
+        targetEnd: 11,
+      },
+    ]);
+    expect(engine.segment('motherfuucker')).toEqual([
+      { text: 'mother', covered: false, ruleIds: [] },
+      { text: 'fuuck', covered: true, ruleIds: ['fuck-repeat'] },
+      { text: 'er', covered: false, ruleIds: [] },
+    ]);
+  });
+
+  it('maps excess letters deterministically when a target ends inside a canonical run', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromRepeatedObfuscatedTerms(
+          'shit-repeat',
+          [{ term: 'shitting', target: 'shit' }],
+          { maxRepetitions: 1 }
+        ),
+      ],
+    });
+
+    expect(engine.find('shittting')).toEqual([
+      {
+        ruleId: 'shit-repeat',
+        profile: 'obfuscated',
+        text: 'shittting',
+        start: 0,
+        end: 9,
+        targetText: 'shit',
+        targetStart: 0,
+        targetEnd: 4,
+      },
+    ]);
+  });
+
+  it('combines one repetition with one reviewed substitution under a total budget', () => {
+    const combined = createScrawlix({
+      rules: [
+        censorRuleFromRepeatedObfuscatedTerms('shit-repeat', ['shit'], {
+          substitutions: { i: ['1'] },
+          maxSubstitutions: 1,
+          maxRepetitions: 1,
+          maxChanges: 2,
+        }),
+      ],
+    });
+    const tight = createScrawlix({
+      rules: [
+        censorRuleFromRepeatedObfuscatedTerms('shit-repeat', ['shit'], {
+          substitutions: { i: ['1'] },
+          maxSubstitutions: 1,
+          maxRepetitions: 1,
+          maxChanges: 1,
+        }),
+      ],
+    });
+
+    expect(combined.find('shh1t')[0]).toMatchObject({
+      text: 'shh1t',
+      targetText: 'shh1t',
+    });
+    expect(tight.find('shh1t')).toEqual([]);
+  });
+
+  it('combines a contiguous repeated run with an ignored separator elsewhere', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromRepeatedObfuscatedTerms('fuck-repeat', ['fuck'], {
+          ignored: ['-'],
+          maxIgnored: 1,
+          maxRepetitions: 1,
+          maxChanges: 2,
+        }),
+      ],
+    });
+
+    expect(engine.find('fuu-ck')[0]).toMatchObject({
+      text: 'fuu-ck',
+      targetText: 'fuu-ck',
+    });
+  });
+
+  it('keeps ordinary word boundaries around repeated candidates', () => {
+    const word = createScrawlix({
+      rules: [
+        censorRuleFromRepeatedObfuscatedTerms('fuck-repeat', ['fuck'], {
+          maxRepetitions: 1,
+        }),
+      ],
+    });
+    const substring = createScrawlix({
+      rules: [
+        censorRuleFromRepeatedObfuscatedTerms('fuck-repeat', ['fuck'], {
+          maxRepetitions: 1,
+          boundary: 'substring',
+        }),
+      ],
+    });
+
+    expect(word.find('fuuckery')).toEqual([]);
+    expect(substring.find('fuuckery')[0]).toMatchObject({ text: 'fuuck' });
+  });
+
+  it('matches repeated letters case-insensitively by default', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromRepeatedObfuscatedTerms('fuck-repeat', ['fuck'], {
+          maxRepetitions: 1,
+        }),
+      ],
+    });
+
+    expect(engine.find('FUUCK')[0]).toMatchObject({
+      text: 'FUUCK',
+      targetText: 'FUUCK',
+    });
+  });
+
+  it('requires explicit combined budgets and validates repetition budgets', () => {
+    expect(() =>
+      censorRuleFromRepeatedObfuscatedTerms('bad', ['fuck'], {
+        substitutions: { u: ['*'] },
+        maxSubstitutions: 1,
+        maxRepetitions: 1,
+      })
+    ).toThrow('requires an explicit maxChanges');
+
+    expect(() =>
+      censorRuleFromRepeatedObfuscatedTerms('bad', ['fuck'], {
+        maxRepetitions: -1,
+      })
+    ).toThrow('maxRepetitions must be a non-negative integer');
+  });
+});

--- a/packages/core/src/repeated-obfuscated.ts
+++ b/packages/core/src/repeated-obfuscated.ts
@@ -1,0 +1,601 @@
+import {
+  graphemeRanges,
+  type CensorRule,
+  type ObfuscatedTermOptions,
+  type TermBoundaryStrategy,
+  type UnicodeNormalization,
+} from './index.js';
+import type { TargetedObfuscatedTerm } from './targeted-obfuscated.js';
+
+export type RepeatedObfuscatedTermOptions = ObfuscatedTermOptions & {
+  /** Maximum extra repeated letter graphemes beyond the canonical run lengths. */
+  maxRepetitions: number;
+};
+
+type CompiledRepeatedObfuscation = {
+  substitutionLookup: ReadonlyMap<string, string>;
+  ignored: ReadonlySet<string>;
+  maxSubstitutions: number;
+  maxIgnored: number;
+  maxRepetitions: number;
+  maxChanges: number;
+};
+
+type SourceUnit = {
+  value: string;
+  shadowStart: number;
+  shadowEnd: number;
+  sourceStart: number;
+  sourceEnd: number;
+  substitutionCost: number;
+  ignoredBefore: number;
+};
+
+type SourceShadow = {
+  value: string;
+  units: readonly SourceUnit[];
+};
+
+type CanonicalGrapheme = {
+  value: string;
+  start: number;
+  end: number;
+};
+
+type CanonicalRun = {
+  value: string;
+  startIndex: number;
+  count: number;
+  repeatable: boolean;
+};
+
+type PreparedTerm = {
+  term: string;
+  graphemes: readonly CanonicalGrapheme[];
+  runs: readonly CanonicalRun[];
+  targetStartIndex: number;
+  targetEndIndex: number;
+};
+
+type CandidateMatch = {
+  firstUnit: number;
+  lastUnit: number;
+  start: number;
+  end: number;
+  targetStart: number;
+  targetEnd: number;
+};
+
+const wordContextPattern = /[\p{L}\p{N}\p{M}\p{Pc}\u200C\u200D]/u;
+const letterGraphemePattern = /^\p{L}\p{M}*$/u;
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalize(value: string, normalization: UnicodeNormalization) {
+  return normalization === 'none' ? value : value.normalize(normalization);
+}
+
+function requireSingleGrapheme(
+  value: string,
+  label: string,
+  normalization: UnicodeNormalization
+) {
+  const normalized = normalize(value, normalization);
+  const ranges = graphemeRanges(normalized);
+  if (
+    normalized.length === 0 ||
+    ranges.length !== 1 ||
+    ranges[0]!.start !== 0 ||
+    ranges[0]!.end !== normalized.length
+  ) {
+    throw new Error(`${label} must be exactly one extended grapheme.`);
+  }
+  return normalized;
+}
+
+function requireBudget(name: string, value: number | undefined, enabled: boolean) {
+  if (enabled && value === undefined) {
+    throw new Error(
+      `censorRuleFromRepeatedObfuscatedTerms() requires an explicit ${name} when that transform class is configured.`
+    );
+  }
+  const resolved = value ?? 0;
+  if (!Number.isInteger(resolved) || resolved < 0) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  return resolved;
+}
+
+function compileTransforms(
+  options: RepeatedObfuscatedTermOptions,
+  normalization: UnicodeNormalization
+): CompiledRepeatedObfuscation {
+  const substitutionLookup = new Map<string, string>();
+
+  for (const [canonicalValue, sourceValues] of Object.entries(
+    options.substitutions ?? {}
+  )) {
+    const canonical = requireSingleGrapheme(
+      canonicalValue,
+      `Substitution key ${JSON.stringify(canonicalValue)}`,
+      normalization
+    );
+    for (const sourceValue of sourceValues) {
+      const source = requireSingleGrapheme(
+        sourceValue,
+        `Substitution value ${JSON.stringify(sourceValue)}`,
+        normalization
+      );
+      if (source === canonical) {
+        throw new Error(
+          `Substitution value ${JSON.stringify(sourceValue)} maps to itself; remove it from the obfuscated transform.`
+        );
+      }
+      const previous = substitutionLookup.get(source);
+      if (previous && previous !== canonical) {
+        throw new Error(
+          `Substitution value ${JSON.stringify(sourceValue)} maps to both ${JSON.stringify(previous)} and ${JSON.stringify(canonical)}.`
+        );
+      }
+      substitutionLookup.set(source, canonical);
+    }
+  }
+
+  const ignored = new Set<string>();
+  for (const ignoredValue of options.ignored ?? []) {
+    const source = requireSingleGrapheme(
+      ignoredValue,
+      `Ignored value ${JSON.stringify(ignoredValue)}`,
+      normalization
+    );
+    if (substitutionLookup.has(source)) {
+      throw new Error(
+        `Grapheme ${JSON.stringify(ignoredValue)} cannot be both ignored and substituted.`
+      );
+    }
+    ignored.add(source);
+  }
+
+  const substitutionsEnabled = substitutionLookup.size > 0;
+  const ignoredEnabled = ignored.size > 0;
+  const maxSubstitutions = requireBudget(
+    'maxSubstitutions',
+    options.maxSubstitutions,
+    substitutionsEnabled
+  );
+  const maxIgnored = requireBudget(
+    'maxIgnored',
+    options.maxIgnored,
+    ignoredEnabled
+  );
+  const maxRepetitions = requireBudget(
+    'maxRepetitions',
+    options.maxRepetitions,
+    true
+  );
+
+  if ((substitutionsEnabled || ignoredEnabled) && options.maxChanges === undefined) {
+    throw new Error(
+      'censorRuleFromRepeatedObfuscatedTerms() requires an explicit maxChanges when repeated letters are combined with substitutions or ignored graphemes.'
+    );
+  }
+  const maxChanges = requireBudget(
+    'maxChanges',
+    options.maxChanges ?? maxRepetitions,
+    true
+  );
+
+  return {
+    substitutionLookup,
+    ignored,
+    maxSubstitutions,
+    maxIgnored,
+    maxRepetitions,
+    maxChanges,
+  };
+}
+
+function canonicalGraphemes(value: string): CanonicalGrapheme[] {
+  return graphemeRanges(value).map(range => ({
+    value: value.slice(range.start, range.end),
+    start: range.start,
+    end: range.end,
+  }));
+}
+
+function caseKey(value: string, caseSensitive: boolean) {
+  return caseSensitive ? value : value.toLocaleLowerCase('und');
+}
+
+function canonicalRuns(
+  graphemes: readonly CanonicalGrapheme[],
+  caseSensitive: boolean
+): CanonicalRun[] {
+  const runs: CanonicalRun[] = [];
+
+  for (let index = 0; index < graphemes.length; ) {
+    const value = graphemes[index]!.value;
+    const key = caseKey(value, caseSensitive);
+    let end = index + 1;
+    while (
+      end < graphemes.length &&
+      caseKey(graphemes[end]!.value, caseSensitive) === key
+    ) {
+      end += 1;
+    }
+    runs.push({
+      value,
+      startIndex: index,
+      count: end - index,
+      repeatable: letterGraphemePattern.test(value),
+    });
+    index = end;
+  }
+
+  return runs;
+}
+
+function targetIndices(
+  term: string,
+  targetStart: number,
+  targetEnd: number,
+  graphemes: readonly CanonicalGrapheme[],
+  label: string
+) {
+  const startIndex = graphemes.findIndex(grapheme => grapheme.start === targetStart);
+  const endIndex = graphemes.findIndex(grapheme => grapheme.end === targetEnd);
+  if (startIndex < 0 || endIndex < 0) {
+    throw new Error(
+      `${label} must align to extended-grapheme boundaries inside its term.`
+    );
+  }
+  return { targetStartIndex: startIndex, targetEndIndex: endIndex + 1 };
+}
+
+function prepareTerm(
+  entry: TargetedObfuscatedTerm,
+  normalization: UnicodeNormalization,
+  caseSensitive: boolean
+): PreparedTerm {
+  const rawTerm = typeof entry === 'string' ? entry : entry.term;
+  const term = normalize(rawTerm.trim(), normalization);
+  if (!term) {
+    throw new Error('A repeated obfuscated term needs a non-empty term.');
+  }
+
+  const graphemes = canonicalGraphemes(term);
+  if (typeof entry === 'string') {
+    return {
+      term,
+      graphemes,
+      runs: canonicalRuns(graphemes, caseSensitive),
+      targetStartIndex: 0,
+      targetEndIndex: graphemes.length,
+    };
+  }
+
+  const target = normalize(entry.target.trim(), normalization);
+  if (!target) {
+    throw new Error(
+      `Repeated obfuscated term ${JSON.stringify(rawTerm)} needs a non-empty target.`
+    );
+  }
+  const targetStart = term.indexOf(target);
+  if (targetStart < 0) {
+    throw new Error(
+      `Target ${JSON.stringify(entry.target)} must be an exact substring of term ${JSON.stringify(rawTerm)} after normalization.`
+    );
+  }
+  if (term.indexOf(target, targetStart + 1) >= 0) {
+    throw new Error(
+      `Target ${JSON.stringify(entry.target)} must occur exactly once in term ${JSON.stringify(rawTerm)}.`
+    );
+  }
+  const targetEnd = targetStart + target.length;
+  const indices = targetIndices(
+    term,
+    targetStart,
+    targetEnd,
+    graphemes,
+    `Target ${JSON.stringify(entry.target)}`
+  );
+
+  return {
+    term,
+    graphemes,
+    runs: canonicalRuns(graphemes, caseSensitive),
+    ...indices,
+  };
+}
+
+function prepareTerms(
+  entries: readonly TargetedObfuscatedTerm[],
+  normalization: UnicodeNormalization,
+  caseSensitive: boolean
+) {
+  const preparedByTerm = new Map<string, PreparedTerm>();
+
+  for (const entry of entries) {
+    const prepared = prepareTerm(entry, normalization, caseSensitive);
+    const previous = preparedByTerm.get(prepared.term);
+    if (previous) {
+      if (
+        previous.targetStartIndex !== prepared.targetStartIndex ||
+        previous.targetEndIndex !== prepared.targetEndIndex
+      ) {
+        throw new Error(
+          `Repeated obfuscated term ${JSON.stringify(prepared.term)} was declared with conflicting semantic targets.`
+        );
+      }
+      continue;
+    }
+    preparedByTerm.set(prepared.term, prepared);
+  }
+
+  if (preparedByTerm.size === 0) {
+    throw new Error('A censor rule needs at least one non-empty term.');
+  }
+
+  return [...preparedByTerm.values()].sort(
+    (left, right) =>
+      right.graphemes.length - left.graphemes.length ||
+      right.term.length - left.term.length
+  );
+}
+
+function sourceShadow(
+  text: string,
+  normalization: UnicodeNormalization,
+  config: CompiledRepeatedObfuscation
+): SourceShadow {
+  let shadow = '';
+  let ignoredSincePrevious = 0;
+  const units: SourceUnit[] = [];
+
+  for (const range of graphemeRanges(text)) {
+    const sourceValue = normalize(
+      text.slice(range.start, range.end),
+      normalization
+    );
+    if (config.ignored.has(sourceValue)) {
+      ignoredSincePrevious += 1;
+      continue;
+    }
+
+    const replacement = config.substitutionLookup.get(sourceValue);
+    const value = replacement ?? sourceValue;
+    const shadowStart = shadow.length;
+    shadow += value;
+    units.push({
+      value,
+      shadowStart,
+      shadowEnd: shadow.length,
+      sourceStart: range.start,
+      sourceEnd: range.end,
+      substitutionCost: replacement === undefined ? 0 : 1,
+      ignoredBefore: ignoredSincePrevious,
+    });
+    ignoredSincePrevious = 0;
+  }
+
+  return { value: shadow, units };
+}
+
+function graphemeComparator(caseSensitive: boolean) {
+  const cache = new Map<string, RegExp>();
+  return (source: string, canonical: string) => {
+    if (caseSensitive) return source === canonical;
+    let pattern = cache.get(canonical);
+    if (!pattern) {
+      pattern = new RegExp(`^(?:${escapeRegExp(canonical)})$`, 'iu');
+      cache.set(canonical, pattern);
+    }
+    return pattern.test(source);
+  };
+}
+
+function localeWordBoundaries(value: string, boundary: Exclude<TermBoundaryStrategy, string>) {
+  const locales =
+    typeof boundary.locale === 'string' ? boundary.locale : [...boundary.locale];
+  const segmenter = new Intl.Segmenter(locales, { granularity: 'word' });
+  const boundaries = new Set<number>();
+  for (const part of segmenter.segment(value)) {
+    if (!part.isWordLike) continue;
+    boundaries.add(part.index);
+    boundaries.add(part.index + part.segment.length);
+  }
+  return boundaries;
+}
+
+function wordContextBefore(value: string, index: number) {
+  if (index <= 0) return false;
+  const match = value.slice(0, index).match(/.$/u);
+  return match ? wordContextPattern.test(match[0]) : false;
+}
+
+function wordContextAfter(value: string, index: number) {
+  if (index >= value.length) return false;
+  const match = value.slice(index).match(/^./u);
+  return match ? wordContextPattern.test(match[0]) : false;
+}
+
+function boundaryAccepted(
+  shadow: SourceShadow,
+  firstUnit: number,
+  lastUnit: number,
+  boundary: TermBoundaryStrategy,
+  lexicalBoundaries: ReadonlySet<number> | null
+) {
+  const start = shadow.units[firstUnit]!.shadowStart;
+  const end = shadow.units[lastUnit]!.shadowEnd;
+
+  if (typeof boundary === 'object') {
+    return Boolean(
+      lexicalBoundaries?.has(start) && lexicalBoundaries.has(end)
+    );
+  }
+  if (boundary === 'substring') return true;
+  return !wordContextBefore(shadow.value, start) && !wordContextAfter(shadow.value, end);
+}
+
+function attemptCandidate(
+  shadow: SourceShadow,
+  candidate: PreparedTerm,
+  firstUnit: number,
+  sameGrapheme: (source: string, canonical: string) => boolean,
+  config: CompiledRepeatedObfuscation,
+  boundary: TermBoundaryStrategy,
+  lexicalBoundaries: ReadonlySet<number> | null
+): CandidateMatch | null {
+  let cursor = firstUnit;
+  let repetitions = 0;
+  const canonicalSourceStarts = new Array<number>(candidate.graphemes.length);
+  const canonicalSourceEnds = new Array<number>(candidate.graphemes.length);
+
+  for (const run of candidate.runs) {
+    if (cursor >= shadow.units.length) return null;
+    if (!sameGrapheme(shadow.units[cursor]!.value, run.value)) return null;
+
+    let available = 0;
+    while (
+      cursor + available < shadow.units.length &&
+      sameGrapheme(shadow.units[cursor + available]!.value, run.value)
+    ) {
+      available += 1;
+    }
+    if (available < run.count) return null;
+
+    const consumed = run.repeatable ? available : run.count;
+    if (run.repeatable) repetitions += consumed - run.count;
+
+    for (let runIndex = 0; runIndex < run.count; runIndex += 1) {
+      const canonicalIndex = run.startIndex + runIndex;
+      const sourceIndex = cursor + runIndex;
+      const sourceEndIndex =
+        run.repeatable && runIndex === run.count - 1
+          ? cursor + consumed - 1
+          : sourceIndex;
+      canonicalSourceStarts[canonicalIndex] = shadow.units[sourceIndex]!.sourceStart;
+      canonicalSourceEnds[canonicalIndex] = shadow.units[sourceEndIndex]!.sourceEnd;
+    }
+
+    cursor += consumed;
+  }
+
+  const lastUnit = cursor - 1;
+  let substitutions = 0;
+  let ignored = 0;
+  for (let unitIndex = firstUnit; unitIndex <= lastUnit; unitIndex += 1) {
+    const unit = shadow.units[unitIndex]!;
+    substitutions += unit.substitutionCost;
+    if (unitIndex > firstUnit) ignored += unit.ignoredBefore;
+  }
+  const changes = substitutions + ignored + repetitions;
+
+  if (changes === 0) return null;
+  if (substitutions > config.maxSubstitutions) return null;
+  if (ignored > config.maxIgnored) return null;
+  if (repetitions > config.maxRepetitions) return null;
+  if (changes > config.maxChanges) return null;
+  if (
+    !boundaryAccepted(
+      shadow,
+      firstUnit,
+      lastUnit,
+      boundary,
+      lexicalBoundaries
+    )
+  ) {
+    return null;
+  }
+
+  return {
+    firstUnit,
+    lastUnit,
+    start: shadow.units[firstUnit]!.sourceStart,
+    end: shadow.units[lastUnit]!.sourceEnd,
+    targetStart: canonicalSourceStarts[candidate.targetStartIndex]!,
+    targetEnd: canonicalSourceEnds[candidate.targetEndIndex - 1]!,
+  };
+}
+
+/**
+ * Match bounded excess repetitions of canonical Unicode letter graphemes.
+ *
+ * Canonical run lengths are minima: a declared `ss` run accepts `sss` with one
+ * repetition cost while a single `s` source cannot satisfy that canonical double.
+ * Every extra source grapheme costs one repetition. When an extra run overlaps a
+ * semantic-target boundary inside a canonical run, excess graphemes attach to the
+ * final canonical grapheme in that run, keeping target mapping deterministic.
+ */
+export function censorRuleFromRepeatedObfuscatedTerms(
+  id: string,
+  entries: readonly TargetedObfuscatedTerm[],
+  options: RepeatedObfuscatedTermOptions
+): CensorRule {
+  const caseSensitive = options.caseSensitive ?? false;
+  const normalization = options.normalization ?? 'NFC';
+  const boundary = options.boundary ?? 'word';
+  const profile = options.profile ?? 'obfuscated';
+  const prepared = prepareTerms(entries, normalization, caseSensitive);
+  const config = compileTransforms(options, normalization);
+  const sameGrapheme = graphemeComparator(caseSensitive);
+
+  return {
+    id,
+    profile,
+    coverage: options.coverage,
+    matcher: {
+      *find(text) {
+        const shadow = sourceShadow(text, normalization, config);
+        if (shadow.units.length === 0) return;
+        const lexicalBoundaries =
+          typeof boundary === 'object'
+            ? localeWordBoundaries(shadow.value, boundary)
+            : null;
+        const seen = new Set<string>();
+        let searchStart = 0;
+
+        while (searchStart < shadow.units.length) {
+          let accepted: CandidateMatch | null = null;
+
+          for (
+            let firstUnit = searchStart;
+            firstUnit < shadow.units.length && !accepted;
+            firstUnit += 1
+          ) {
+            for (const candidate of prepared) {
+              const match = attemptCandidate(
+                shadow,
+                candidate,
+                firstUnit,
+                sameGrapheme,
+                config,
+                boundary,
+                lexicalBoundaries
+              );
+              if (!match) continue;
+              accepted = match;
+              break;
+            }
+          }
+
+          if (!accepted) return;
+          const key = `${accepted.start}:${accepted.end}:${accepted.targetStart}:${accepted.targetEnd}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            yield {
+              start: accepted.start,
+              end: accepted.end,
+              targetStart: accepted.targetStart,
+              targetEnd: accepted.targetEnd,
+            };
+          }
+          searchStart = accepted.lastUnit + 1;
+        }
+      },
+    },
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,9 @@
       "@scrawlix/core/targeted-obfuscated": [
         "packages/core/src/targeted-obfuscated.ts"
       ],
+      "@scrawlix/core/repeated-obfuscated": [
+        "packages/core/src/repeated-obfuscated.ts"
+      ],
       "@scrawlix/en": ["packages/en/src/index.ts"],
       "@scrawlix/en/corpus": ["packages/en/src/corpus.ts"],
       "@scrawlix/react": ["packages/react/src/index.tsx"],


### PR DESCRIPTION
## Summary
Add an opt-in repeated-letter matcher as a focused core subpath.

- add `@scrawlix/core/repeated-obfuscated`
- add `censorRuleFromRepeatedObfuscatedTerms()` with required `maxRepetitions`
- treat canonical adjacent letter runs as minima: declared `ss` remains canonical, `sss` costs one repetition, and a shorter source run cannot satisfy the term
- charge one repetition for each excess source grapheme beyond a canonical letter run
- preserve exact original full-match and semantic-target ranges
- support string entries or `{ term, target }` semantic-root entries
- attach excess source graphemes to the final canonical grapheme of a run so target mapping stays deterministic when a target boundary falls inside a canonical double
- compose repetitions with reviewed substitutions/ignored graphemes under explicit per-class budgets and a required combined `maxChanges`
- preserve Unicode normalization, case-insensitive default matching, `word`/`unicode-word`/`substring`/`locale-word` boundary modes, coverage, and `profile: 'obfuscated'`
- limit repeatability to canonical Unicode letter graphemes
- add regressions for exact source ranges, canonical doubles, root-only coverage, target boundaries inside `shitting`, combined budgets, ordinary-word boundaries, case behavior, and constructor validation
- exercise the published subpath through packed-package runtime smoke

## Semantics
This is excess-only repetition, not generic fuzzy matching. A canonical run length is the minimum accepted run length. Every extra letter consumes explicit repetition budget. Zero-change canonical forms remain filtered from this aggressive path.

This helper does not enable edit distance, phonetic matching, transliteration, or blanket confusable folding.

Progress on #38
Next: dogfood the repeated-letter helper in the opt-in English pack with JSON positive/clean corpus cases.