### PR TITLE
Configure React tests for clean act semantics

### DIFF
--- a/packages/react/src/test.setup.ts
+++ b/packages/react/src/test.setup.ts
@@ -1,0 +1,2 @@
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;

--- a/packages/react/src/test.setup.ts
+++ b/packages/react/src/test.setup.ts
@@ -1,2 +1,0 @@
-(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
-  .IS_REACT_ACT_ENVIRONMENT = true;

--- a/packages/react/test.setup.ts
+++ b/packages/react/test.setup.ts
@@ -1,0 +1,2 @@
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    setupFiles: ['./src/test.setup.ts'],
+  },
+});

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    setupFiles: ['./src/test.setup.ts'],
+    setupFiles: ['./test.setup.ts'],
   },
 });


### PR DESCRIPTION
## Summary

This is based on #37.

- add a package-local Vitest config for `@scrawlix/react`
- load one test-only setup file that sets `IS_REACT_ACT_ENVIRONMENT = true`
- keep the setup file beside `vitest.config.ts`, outside `src`, so it never enters the runtime build or package tarball
- eliminate the repeated React warning that the test environment is not configured for `act(...)`

## Verification

The latest branch head is green across typecheck, unit tests, workspace build, demo Chromium smoke, extension Chromium smoke, and packed-package consumer smoke.

The CI test log now runs the React suite cleanly with a Vitest setup phase and no `act()` environment warnings. The packed `@scrawlix/react` tarball contains only `dist/index.*`, `dist/styles.css`, and `package.json`; the test setup is absent.

This is test hygiene only and does not change runtime behavior or public types.

Depends on #37