### PR TITLE
Make package source maps resolve inside tarballs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ When intentionally changing dependencies, run the pinned pnpm install normally, 
 
 Repository CI uses Node 22 and frozen installs. The demo and extension builds are part of the workspace build. The packed-package smoke suite installs tarballs into consumers outside the workspace dependency graph, strictly typechecks Scrawlix declarations through React 18 and React 19, production-builds both majors, and production-builds the documented Next.js App Router client-wrapper path.
 
+Public package builds emit JavaScript and declaration source maps. Each package manifest deliberately includes only the implementation source files those maps target; source tests stay out of tarballs. When adding or splitting a public implementation entrypoint, update the package `files` list so every local `.js.map` / `.d.ts.map` source remains available after packing. `pnpm smoke:packages` parses the packed archives and fails on unresolved local map targets, path escapes, or packed `*.test.*` sources.
+
 The npm publication workflow uses Node 24 so its OIDC runner comfortably satisfies trusted-publishing runtime requirements. Published runtime compatibility and workspace-tooling expectations live in `docs/compatibility.md`. Release classification and public-contract rules live in `docs/versioning.md`.
 
 ## Invariants
@@ -187,6 +189,6 @@ Scrawlix is pre-release, so breaking changes are still possible. Use that freedo
 
 The documented package exports, rule ids, option defaults, adapter data attributes, ignore attributes, and React CSS/render attributes are public contracts. Keep application-only browser-extension state private unless a document explicitly promotes it to a public contract.
 
-Packed-package smoke tests are a release gate: external consumers must receive compiled JavaScript, declarations, CSS exports, and valid package metadata rather than workspace-only source imports. Every new public package belongs in `scripts/smoke-packages.mjs` and the relevant external consumer fixture.
+Packed-package smoke tests are a release gate: external consumers must receive compiled JavaScript, declarations, CSS exports, valid package metadata, and source-map targets that resolve inside the tarball. Every new public package belongs in `scripts/smoke-packages.mjs` and the relevant external consumer fixture.
 
 Human quickstarts live in the root/package READMEs. Agent quickstarts live in the demo `llms.txt`. Keep those surfaces synchronized whenever public names, defaults, package selection, required side-effect imports, or framework boundaries change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added a framework-neutral renderer recipe with plain-DOM, Vue, Svelte, and Solid sketches plus a threshold for when a dedicated adapter package is worth maintaining.
 - Added explicit runtime compatibility and pre-1.0 versioning/public-contract policies.
 - Declared Node 18+ in every public package manifest and Node 22+ in the private workspace manifest so package-manager metadata matches the documented runtime/tooling baselines.
+- Publish curated implementation sources alongside JS/declaration maps and verify every local map target against packed tarball contents while excluding source tests.
 - Added explicit privacy/output vocabulary for visual covers, presentation/screenshot guarantees, assistive-tech concealment, and sanitized export.
 - Aligned `README.md`, `AGENTS.md`, `llms.txt`, demo, extension, tests, and smoke consumers on the canonical pre-release public names and conservative defaults.
 - Committed a pnpm 10.34.5 lockfile, pinned the workspace package manager, and switched CI to frozen installs.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -40,7 +40,7 @@ pnpm build
 pnpm smoke:packages
 ```
 
-The packed-package smoke test is a hard release gate. It packs every public package, installs those tarballs into consumers outside the pnpm workspace, typechecks published declarations through React 18 and React 19 consumers, production-builds both React majors, and production-builds the documented Next.js App Router integration.
+The packed-package smoke test is a hard release gate. It packs every public package, validates every emitted JS/declaration map against the actual tarball contents, rejects packed source tests, installs those tarballs into consumers outside the pnpm workspace, typechecks published declarations through React 18 and React 19 consumers, production-builds both React majors, and production-builds the documented Next.js App Router integration.
 
 Confirm the real Chromium demo/extension smoke tests have also passed in CI on the exact release commit.
 
@@ -82,11 +82,12 @@ Review the file list reported by every dry run. Verify:
 
 - JS entry points exist
 - declaration entry points exist
-- source/declaration maps point somewhere useful
+- every local JS/declaration source-map target exists in the tarball (the package smoke enforces this)
+- curated implementation sources are present while `*.test.*` sources are absent
 - `@scrawlix/en/corpus` exists
 - `@scrawlix/react/styles.css` exists
 - each package README is included
-- tests, workspace fixtures, demo files, and extension files are absent from package tarballs
+- workspace fixtures, demo files, and extension files are absent from package tarballs
 - workspace dependency specs are converted into publishable registry ranges by pnpm
 
 ## 3. Verify registry identity before any write

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,12 @@
     "node": ">=18"
   },
   "sideEffects": false,
-  "files": ["dist"],
+  "files": [
+    "dist",
+    "src/index.ts",
+    "src/targeted-obfuscated.ts",
+    "src/repeated-obfuscated.ts"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -7,7 +7,10 @@
     "node": ">=18"
   },
   "sideEffects": false,
-  "files": ["dist"],
+  "files": [
+    "dist",
+    "src/index.ts"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/en/package.json
+++ b/packages/en/package.json
@@ -7,7 +7,12 @@
     "node": ">=18"
   },
   "sideEffects": false,
-  "files": ["dist"],
+  "files": [
+    "dist",
+    "src/index.ts",
+    "src/corpus.ts",
+    "src/corpus-data"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,7 +7,10 @@
     "node": ">=18"
   },
   "sideEffects": ["./dist/styles.css"],
-  "files": ["dist"],
+  "files": [
+    "dist",
+    "src/index.tsx"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/rehype/package.json
+++ b/packages/rehype/package.json
@@ -7,7 +7,10 @@
     "node": ">=18"
   },
   "sideEffects": false,
-  "files": ["dist"],
+  "files": [
+    "dist",
+    "src/index.ts"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/scripts/smoke-packages.mjs
+++ b/scripts/smoke-packages.mjs
@@ -9,8 +9,9 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join, posix, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
+import { gunzipSync } from 'node:zlib';
 
 const root = process.cwd();
 const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
@@ -33,6 +34,98 @@ function run(args, cwd = root) {
   }
 }
 
+function readTarString(buffer, start, length) {
+  const slice = buffer.subarray(start, start + length);
+  const terminator = slice.indexOf(0);
+  return slice
+    .subarray(0, terminator === -1 ? slice.length : terminator)
+    .toString('utf8')
+    .trim();
+}
+
+function tarEntries(tarball) {
+  const archive = gunzipSync(readFileSync(tarball));
+  const entries = new Map();
+  let offset = 0;
+
+  while (offset + 512 <= archive.length) {
+    const header = archive.subarray(offset, offset + 512);
+    if (header.every(byte => byte === 0)) break;
+
+    const name = readTarString(header, 0, 100);
+    const prefix = readTarString(header, 345, 155);
+    const entryPath = prefix ? `${prefix}/${name}` : name;
+    const sizeText = readTarString(header, 124, 12);
+    const size = sizeText ? Number.parseInt(sizeText, 8) : 0;
+    const type = header[156];
+    const dataStart = offset + 512;
+    const dataEnd = dataStart + size;
+
+    if (type === 0 || type === 48) {
+      entries.set(entryPath, archive.subarray(dataStart, dataEnd));
+    }
+
+    offset = dataStart + Math.ceil(size / 512) * 512;
+  }
+
+  return entries;
+}
+
+function verifyPackedSourceMaps(tarball, packageDirectory) {
+  const entries = tarEntries(tarball);
+  const mapPaths = [...entries.keys()].filter(
+    path => path.startsWith('package/dist/') && path.endsWith('.map')
+  );
+
+  if (mapPaths.length === 0) {
+    throw new Error(`${packageDirectory} packed no source/declaration maps to verify.`);
+  }
+
+  const packedTests = [...entries.keys()].filter(
+    path => path.startsWith('package/src/') && /\.test\.[cm]?[jt]sx?$/.test(path)
+  );
+  if (packedTests.length > 0) {
+    throw new Error(
+      `${packageDirectory} unexpectedly packed source tests: ${packedTests.join(', ')}`
+    );
+  }
+
+  for (const mapPath of mapPaths) {
+    const sourceMap = JSON.parse(entries.get(mapPath).toString('utf8'));
+    const sources = Array.isArray(sourceMap.sources) ? sourceMap.sources : [];
+    const sourcesContent = Array.isArray(sourceMap.sourcesContent)
+      ? sourceMap.sourcesContent
+      : [];
+    const sourceRoot = typeof sourceMap.sourceRoot === 'string' ? sourceMap.sourceRoot : '';
+
+    for (const [index, source] of sources.entries()) {
+      if (typeof source !== 'string') continue;
+      if (/^(?:[a-z]+:|\/\/)/i.test(source)) continue;
+      if (sourcesContent[index] != null) continue;
+
+      const packedSourcePath = posix.normalize(
+        posix.join(posix.dirname(mapPath), sourceRoot, source)
+      );
+
+      if (!packedSourcePath.startsWith('package/')) {
+        throw new Error(
+          `${packageDirectory} ${mapPath} source escapes the package: ${source}`
+        );
+      }
+
+      if (!entries.has(packedSourcePath)) {
+        throw new Error(
+          `${packageDirectory} ${mapPath} points to unavailable source ${source} (expected ${packedSourcePath} in the tarball).`
+        );
+      }
+    }
+  }
+
+  console.log(
+    `${packageDirectory} source-map verification passed (${mapPaths.length} map files).`
+  );
+}
+
 function packPackage(packageDirectory) {
   const before = new Set(
     existsSync(packDirectory)
@@ -52,7 +145,9 @@ function packPackage(packageDirectory) {
     );
   }
 
-  return join(packDirectory, created[0]);
+  const tarball = join(packDirectory, created[0]);
+  verifyPackedSourceMaps(tarball, packageDirectory);
+  return tarball;
 }
 
 const asFileDependency = path => `file:${path.replaceAll('\\', '/')}`;


### PR DESCRIPTION
## Summary

Fixes the publish-time source-map ergonomics tracked in #107 without dropping JS/declaration maps.

### Curated source publication
- `@scrawlix/core`: publish mapped implementation sources for the root entry plus `targeted-obfuscated`, `repeated-obfuscated`, and `width-obfuscated`
- `@scrawlix/en`: publish `src/index.ts`, `src/corpus.ts`, and corpus data
- React/rehype/DOM: publish their mapped implementation source
- keep `*.test.*` sources outside package tarballs

### Tarball verification
`smoke:packages` now parses each packed `.tgz` directly and:
- inspects every `.js.map` and `.d.ts.map` in `dist`
- accepts embedded `sourcesContent` when available
- otherwise resolves each local source path against the tarball and requires that file to exist
- rejects map paths that escape the package
- rejects accidentally packed source test files

The gate has already caught two concurrent core entrypoints (`repeated-obfuscated` and `width-obfuscated`) as they landed on `main`; the branch now merges current `main` and includes the mapped sources for both.

The existing React 18/19 and Next external consumers still run after map validation.

### Release / maintainer docs
- make resolvable map targets and curated implementation sources explicit dry-run checks
- teach maintainers/coding agents to update package `files` whenever a public implementation entrypoint creates new maps
- record the package-source policy in the changelog

Closes #107.