### PR TITLE
Add data-first rule pack authoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ A change in one layer should rarely require logic in another.
 ## Workspace map
 
 - `packages/core` — language-neutral matching, segmentation, generic coverage, custom-term helpers
+- `packages/core/src/pack-authoring.ts` — opt-in manifest + lexicon + matching-profile authoring helpers, exported as `@scrawlix/core/pack-authoring`
 - `packages/en` — English strong-profanity rules, English-specific coverage helpers, English regression corpus
 - `packages/react` — React renderer and appearance/reveal behavior
 - `packages/rehype` — HAST/rehype transformer for syntax-tree prose
@@ -35,6 +36,8 @@ Use these names in code, docs, examples, and agent-generated changes:
 - `createScrawlix`
 - `censorRuleFromTerms`
 - `rulesFromPacks`
+- `defineLexiconPack`
+- `compileLexiconRules`
 - `englishStrongProfanityRules`
 - `englishStrongProfanityPack`
 - `englishVowelCoverage`
@@ -46,6 +49,8 @@ Use these names in code, docs, examples, and agent-generated changes:
 Core defaults to `coverage: 'full'`. React defaults to `appearance="scrawl"` and `reveal="never"`. Partial coverage and reveal behavior are deliberate caller choices.
 
 The reusable packages use named runtime exports as the canonical API. `@scrawlix/rehype` and `@scrawlix/dom` do not carry duplicate default exports.
+
+Focused core helpers may live on documented subpaths while their contracts are exercised. `@scrawlix/core/pack-authoring` is the data-first authoring path; ordinary matching imports remain on `@scrawlix/core`.
 
 Do not invent convenience packages, automatic English selection, compatibility aliases, or alternate spellings for the public API.
 
@@ -81,6 +86,16 @@ Do not add profanity lists, locale-specific morphology, or language-specific cha
 
 Generic coverage belongs in core. A behavior such as “cover English vowels” belongs in `@scrawlix/en`.
 
+### Keep authored packs data-first
+
+`@scrawlix/core/pack-authoring` compiles inspectable manifest/lexicon/profile data into the existing runtime `CensorRulePack` contract. Keep manifest metadata plain. Prefer explicit attested forms. Keep language-specific morphology generators inside the pack that understands them.
+
+A lexical form may name one unique semantic-target substring inside the full attested form. Reject ambiguous or grapheme-splitting targets instead of guessing. One lexical entry can participate in several matching profiles while retaining one stable semantic rule id; `match.profile` identifies the path.
+
+Canonical authoring profiles reuse current core boundary/normalization/case behavior. Aggressive authoring profiles reuse reviewed transform tables and explicit budgets from the bounded aggressive helpers. Do not create a second matching engine inside the authoring layer.
+
+Presentation recommendations in pack manifests are metadata hints. Core must not import React/extension presentation types or execute appearance/reveal policy.
+
 ### Require deliberate rule selection
 
 `createScrawlix()` with zero rules is a no-op. Adapters should receive rules explicitly. Avoid hidden language detection or surprise bundled moderation behavior.
@@ -96,6 +111,8 @@ The engine compiles its own RegExp copies. Never mutate a caller's `lastIndex`. 
 ### Keep semantic targets explicit
 
 When a larger match contains the meaningful censored core, use a named capture group and `target: { group: '...' }`. Coverage should operate on the target, not blindly on the full inflected or compound match.
+
+Data-authored packs can express the equivalent with a unique `target` substring on an attested lexical form.
 
 ### Treat accessibility as source truth
 
@@ -158,6 +175,8 @@ When a bug or rule change teaches a durable positive or false-positive example, 
 7. Document dialect/severity assumptions. Do not imply complete language coverage from a small pack.
 8. Give the package README an exact install command and canonical consumer snippet.
 
+For packs whose ordinary behavior fits explicit attested forms, prefer `defineLexiconPack()` and keep the manifest/lexicon/profile data inspectable. Use explicit rule collections or custom matchers when the behavior genuinely requires code. Carry positive and ordinary-text negative corpus cases for every aggressive transform class a pack enables.
+
 ## Adding a visual appearance
 
 1. Coordinate with the shared appearance contract tracked in issue #26.
@@ -188,5 +207,7 @@ Scrawlix is pre-release, so breaking changes are still possible. Use that freedo
 The documented package exports, rule ids, option defaults, adapter data attributes, ignore attributes, and React CSS/render attributes are public contracts. Keep application-only browser-extension state private unless a document explicitly promotes it to a public contract.
 
 Packed-package smoke tests are a release gate: external consumers must receive compiled JavaScript, declarations, CSS exports, and valid package metadata rather than workspace-only source imports. Every new public package belongs in `scripts/smoke-packages.mjs` and the relevant external consumer fixture.
+
+Every new public subpath must also be imported by at least one packed external consumer so tarball omissions are caught before release.
 
 Human quickstarts live in the root/package READMEs. Agent quickstarts live in the demo `llms.txt`. Keep those surfaces synchronized whenever public names, defaults, package selection, required side-effect imports, or framework boundaries change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added custom coverage callbacks and per-rule coverage overrides.
 - Added Unicode-aware custom term/phrase rules through `censorRuleFromTerms()` with explicit `word` and `substring` boundary modes.
 - Added rule-pack composition and caller-safe compiled RegExp handling.
+- Added `@scrawlix/core/pack-authoring` with typed manifests, reviewable lexical entries, reusable canonical/aggressive matching profiles, semantic-target forms, and compilation into ordinary `CensorRulePack` rules.
 - Added a custom matcher escape hatch that can return exact original-source match/target ranges for pack-owned normalization, segmentation, or other matching algorithms.
 - Validate custom matcher ranges instead of silently clamping malformed source offsets.
 - Preserve source-pack provenance in composed rules, matches, and coverage callbacks.
-- Reject configured semantic target groups that are unavailable for a produced match instead of silently widening coverage.
+- Reject configured semantic target groups that are unavailable for a produced match instead of silently widening the target to the full match.
 - Treat combining marks, Unicode connector punctuation, ZWNJ, and ZWJ as continuing word context for custom term/phrase boundaries.
 - Added deterministic source-preservation and cursor-state regressions.
 
@@ -66,6 +67,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 
 - Added compiled ESM/declaration artifacts for public packages.
 - Added external tarball consumer smoke tests as a CI release gate, with strict declaration checking, React 18/19 production builds, and a Next.js 16 App Router production build using the documented client-wrapper boundary.
+- Added a non-profanity authored-pack fixture plus packed runtime/typecheck coverage for `@scrawlix/core/pack-authoring`.
 - Added package-local READMEs for every public package, exact install commands, a top-level integration chooser, a docs index, React CSS troubleshooting, Next.js client-boundary guidance, and clearer source/accessibility notes.
 - Added a framework-neutral renderer recipe with plain-DOM, Vue, Svelte, and Solid sketches plus a threshold for when a dedicated adapter package is worth maintaining.
 - Added explicit runtime compatibility and pre-1.0 versioning/public-contract policies.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The same word can become `████`, `f███`, `f██k`, `f█ck`, `f*
 | transform Markdown / HAST | `@scrawlix/rehype @scrawlix/en` | `rehypeScrawlix` |
 | transform an existing webpage / DOM | `@scrawlix/dom @scrawlix/en` | `createDomScrawlix` |
 | match/segment text or build your own renderer | `@scrawlix/core` plus rules | `createScrawlix` |
+| author a reviewable lexical rule pack | `@scrawlix/core` | `defineLexiconPack` from `@scrawlix/core/pack-authoring` |
 | use packaged English strong-profanity rules | `@scrawlix/en` | `englishStrongProfanityRules` |
 
 The five packages stay deliberately small: core contains no hidden language policy, and adapters receive rules explicitly.
@@ -186,7 +187,46 @@ The English package currently exports:
 - `englishVowelCoverage`
 - a regression corpus at `@scrawlix/en/corpus`
 
-Future language packs can carry their own rules, locale metadata, coverage helpers, and regression corpora. Consumers can combine packs with `rulesFromPacks(...)`. See [`docs/language-packs.md`](docs/language-packs.md).
+For reviewable lexical packs, use the opt-in authoring subpath:
+
+```ts
+import { rulesFromPacks } from '@scrawlix/core';
+import { defineLexiconPack } from '@scrawlix/core/pack-authoring';
+
+const exhibitPack = defineLexiconPack({
+  manifest: {
+    id: 'museum-exhibits',
+    version: '1.0.0',
+    name: 'Museum Exhibit Labels',
+    locale: 'en',
+    reviewStatus: 'reviewed',
+  },
+  matchingProfiles: [
+    { id: 'canonical', mode: 'canonical', boundary: 'unicode-word' },
+    {
+      id: 'aggressive',
+      mode: 'obfuscated',
+      substitutions: { a: ['@'] },
+      maxSubstitutions: 1,
+    },
+  ],
+  lexicon: [
+    {
+      id: 'blue-lantern',
+      lemma: 'Blue Lantern',
+      profiles: ['canonical', 'aggressive'],
+      forms: [
+        { text: 'Blue Lantern', kind: 'base' },
+        { text: 'Blue Lantern Annex', kind: 'compound', target: 'Blue Lantern' },
+      ],
+    },
+  ],
+});
+
+const rules = rulesFromPacks(exhibitPack);
+```
+
+`AuthoredRulePack` stays compatible with `CensorRulePack` while retaining its manifest, lexicon, and matching-profile metadata for apps that want to present pack details. One lexical entry can participate in canonical and reviewed aggressive profiles while retaining the same semantic rule id. See [`docs/language-packs.md`](docs/language-packs.md).
 
 ## Browser extension
 

--- a/apps/demo/public/llms.txt
+++ b/apps/demo/public/llms.txt
@@ -6,6 +6,7 @@ Source: https://github.com/teamleaderleo/scrawlix
 
 Packages:
 - @scrawlix/core — language-neutral matching and segmentation
+- @scrawlix/core/pack-authoring — opt-in manifest + lexicon + matching-profile authoring helpers
 - @scrawlix/en — English strong-profanity rules, English vowel coverage, regression corpus
 - @scrawlix/react — React renderer and visual/reveal presets
 - @scrawlix/rehype — HAST/rehype transformer for Markdown-rendered prose
@@ -88,6 +89,47 @@ const privateTerms = censorRuleFromTerms('private', [
   'Mothbit',
 ]);
 ```
+
+Pack authoring:
+
+```ts
+import { rulesFromPacks } from '@scrawlix/core';
+import { defineLexiconPack } from '@scrawlix/core/pack-authoring';
+
+const pack = defineLexiconPack({
+  manifest: {
+    id: 'museum-exhibits',
+    version: '1.0.0',
+    name: 'Museum Exhibit Labels',
+    locale: 'en',
+    reviewStatus: 'reviewed',
+  },
+  matchingProfiles: [
+    { id: 'canonical', mode: 'canonical', boundary: 'unicode-word' },
+    {
+      id: 'aggressive',
+      mode: 'obfuscated',
+      substitutions: { a: ['@'] },
+      maxSubstitutions: 1,
+    },
+  ],
+  lexicon: [
+    {
+      id: 'blue-lantern',
+      lemma: 'Blue Lantern',
+      profiles: ['canonical', 'aggressive'],
+      forms: [
+        { text: 'Blue Lantern', kind: 'base' },
+        { text: 'Blue Lantern Annex', kind: 'compound', target: 'Blue Lantern' },
+      ],
+    },
+  ],
+});
+
+const rules = rulesFromPacks(pack);
+```
+
+Use `defineLexiconPack()` when explicit attested lexical data can express the pack. A manifest stays plain app-facing data. Lexical `target` substrings are explicit semantic targets. One lexical entry can participate in several named matching profiles while retaining one stable rule id; `match.profile` identifies the path. Presentation recommendation strings are metadata hints; core does not execute appearance/reveal policy.
 
 Canonical rehype usage:
 

--- a/docs/language-packs.md
+++ b/docs/language-packs.md
@@ -36,6 +36,68 @@ const engine = createScrawlix({
 
 Scrawlix deliberately avoids automatic language detection. Applications know more about their content and can choose one pack, several packs, or caller-authored rules.
 
+## Manifest + lexicon authoring
+
+Reviewable lexical packs can use `@scrawlix/core/pack-authoring`. The authoring model is **manifest + lexicon + matching profiles + corpus**. The compiled result remains an ordinary `CensorRulePack`.
+
+```ts
+import { defineLexiconPack } from '@scrawlix/core/pack-authoring';
+
+export const exhibitPack = defineLexiconPack({
+  manifest: {
+    id: 'museum-exhibits',
+    version: '1.0.0',
+    name: 'Museum Exhibit Labels',
+    locale: 'en',
+    categories: ['exhibits'],
+    reviewStatus: 'reviewed',
+    attribution: [{ label: 'Example fixture', license: 'CC0-1.0' }],
+    recommended: { coverage: 'full', appearance: 'bar', reveal: 'never' },
+  },
+  matchingProfiles: [
+    { id: 'canonical', mode: 'canonical', boundary: 'unicode-word' },
+    {
+      id: 'aggressive',
+      mode: 'obfuscated',
+      boundary: 'unicode-word',
+      substitutions: { a: ['@'] },
+      maxSubstitutions: 1,
+    },
+  ],
+  defaultProfile: 'canonical',
+  lexicon: [
+    {
+      id: 'blue-lantern',
+      lemma: 'Blue Lantern',
+      profiles: ['canonical', 'aggressive'],
+      categories: ['exhibit-name'],
+      reviewStatus: 'reviewed',
+      provenance: { source: 'curated exhibit list' },
+      forms: [
+        { text: 'Blue Lantern', kind: 'base' },
+        {
+          text: 'Blue Lantern Annex',
+          kind: 'compound',
+          target: 'Blue Lantern',
+        },
+      ],
+    },
+  ],
+});
+```
+
+The manifest is plain app-facing data: id, version, human name/description, locale, categories/tags, review status, attribution, and optional presentation recommendations. Core treats `appearance` and `reveal` recommendation values as opaque adapter/application ids.
+
+Lexical entries use stable semantic ids and explicit attested forms. A form kind can be `base`, `inflection`, `derivation`, `compound`, `slang`, `dialect`, `spelling-variant`, or `phrase`. Entries may also record locale/register, provenance, review status, coarse pack-relative severity, descriptive categories, and a coverage override.
+
+A larger attested form can name one exact canonical `target` substring. The target must occur exactly once and align to extended-grapheme boundaries. This keeps compounds/inflections reviewable as data while preserving the semantic-target runtime contract.
+
+One semantic entry can select several matching profile ids. Canonical profiles delegate to `censorRuleFromTerms()` and can choose any current boundary strategy, normalization policy, and case policy. Aggressive profiles delegate to the bounded targeted-obfuscated helper and carry the same reviewed transform tables and explicit budgets described below. `match.profile` identifies which path produced a match while the stable lexical `ruleId` stays the same.
+
+Prefer explicit forms and a few evidence-backed profiles over a universal morphology DSL. Productive language-specific generators can still live inside the pack that understands them.
+
+`defineLexiconPack()` returns an `AuthoredRulePack`: an ordinary runtime pack plus the original manifest, lexicon, and profile definitions for apps that want to inspect/present metadata. A hosted registry or remote-code system is outside this contract.
+
 ## Canonical Unicode matching
 
 `censorRuleFromTerms()` normalizes both declared terms and an internal source shadow to NFC by default. Canonically equivalent spellings therefore match even when their UTF-16 lengths differ:
@@ -49,6 +111,8 @@ engine.find('cafe\u0301');
 ```
 
 The source string itself stays unchanged. Scrawlix builds the normalized shadow one extended grapheme at a time and maps every accepted shadow boundary back to the corresponding original-source boundary. `{ normalization: 'none' }` is available for rules that intentionally distinguish canonical forms.
+
+Canonical authored profiles reuse that execution path. Their semantic-target mapping likewise returns exact caller-source slices when an NFC form matches NFD input.
 
 Raw regex rules and custom matchers keep their own matching policy. Core validates the ranges they produce and throws when a full match or semantic target cuts through an extended grapheme cluster.
 
@@ -127,6 +191,8 @@ const rule = {
 ```
 
 Coverage runs against `core`, while `find()` still reports the full match and both full/target ranges. A declared target group is part of the rule contract: if a produced match cannot resolve that named group, Scrawlix throws a descriptive error instead of widening the target to the full match.
+
+Authored lexical forms offer the data equivalent with `{ text: 'full form', target: 'semantic root' }`. The compiler routes canonical and aggressive profiles through their existing source-mapped helpers.
 
 ## Custom matcher escape hatch
 
@@ -216,7 +282,7 @@ Add `--json` for machine-readable output. The diff joins cases by package plus s
 
 Pull-request CI runs the same command against the PR's exact base SHA and prints the report before the test suite. Checkout uses full git history so the comparison is reproducible from the workflow log.
 
-Useful corpora contain positive matches, semantic targets, casing and punctuation variants, compounds and inflections, false-positive traps, Unicode context, and dialect or severity cases when relevant. Every matcher expansion should ideally arrive with the newly caught form plus plausible clean neighbors that could regress.
+Useful corpora contain positive matches, semantic targets, casing and punctuation variants, compounds and inflections, false-positive traps, Unicode context, dialect or severity cases, and every aggressive transform class enabled by a pack. Every matcher expansion should ideally arrive with the newly caught form plus plausible clean neighbors that could regress.
 
 A corpus is evidence about expected behavior, not a claim of linguistic completeness. Pack docs should say which dialect, register, severity band, and edge cases the pack intentionally covers.
 
@@ -227,7 +293,7 @@ Prefer narrowly described packs over giant universal lists. Examples:
 - `en-strong-profanity`
 - `en-mild-profanity`
 - `ja-example-profanity`
-- an application-owned private-name pack
+- an application-owned name/phrase pack
 
 A caller can compose several packs. Smaller packs keep policy choices visible and make corpus regressions easier to understand.
 
@@ -236,11 +302,12 @@ A caller can compose several packs. Smaller packs keep policy choices visible an
 A publishable third-party pack should contain:
 
 1. a dependency on `@scrawlix/core`
-2. one or more named rule collections plus a `CensorRulePack` export
-3. locale and scope/severity notes
-4. positive and clean/false-positive regression data
-5. tests for semantic targets, casing, punctuation, compounds/inflections, Unicode context, known ambiguity, and every enabled obfuscation class
-6. explicit transform tables and budgets for any aggressive profile
-7. an ordinary package README with an install command and copy/paste consumer example
+2. an inspectable manifest with id/version/name/locale/scope plus review/provenance information
+3. reviewable lexical data through `defineLexiconPack()` when explicit attested forms fit the domain, and explicit rule code/custom matchers where they do not
+4. named matching profiles for boundary/normalization/case policy and any reviewed aggressive transform tables/budgets
+5. one or more `CensorRulePack` exports
+6. positive and clean/false-positive regression data
+7. tests for semantic targets, casing, punctuation, compounds/inflections, Unicode context, known ambiguity, and every enabled aggressive transform class
+8. an ordinary package README with an install command and copy/paste consumer example
 
-Keep pack-specific presentation and application state outside the pack. Matching policy should remain inspectable as ordinary code/data.
+Keep application state outside the pack. Presentation recommendations may travel as manifest metadata, while matching behavior stays inspectable as ordinary code/data.

--- a/fixtures/consumer/runtime.mjs
+++ b/fixtures/consumer/runtime.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import { createScrawlix } from '@scrawlix/core';
+import { createScrawlix, rulesFromPacks } from '@scrawlix/core';
+import { defineLexiconPack } from '@scrawlix/core/pack-authoring';
 import { censorRuleFromRepeatedObfuscatedTerms } from '@scrawlix/core/repeated-obfuscated';
 import { censorRuleFromTargetedObfuscatedTerms } from '@scrawlix/core/targeted-obfuscated';
 import { censorRuleFromWidthObfuscatedTerms } from '@scrawlix/core/width-obfuscated';
@@ -25,6 +26,48 @@ assert.equal(matches.length, 1);
 assert.equal(matches[0]?.targetText.toLowerCase(), 'fuck');
 assert.equal(matches[0]?.profile, 'canonical');
 assert.ok(englishProfanityCorpus.some(testCase => testCase.id === 'fuck-base'));
+
+const authoredPack = defineLexiconPack({
+  manifest: {
+    id: 'runtime-exhibit-labels',
+    version: '1.0.0',
+    name: 'Runtime Exhibit Labels',
+    locale: 'en',
+  },
+  matchingProfiles: [
+    { id: 'canonical', mode: 'canonical', boundary: 'unicode-word' },
+    {
+      id: 'aggressive',
+      mode: 'obfuscated',
+      boundary: 'unicode-word',
+      substitutions: { a: ['@'] },
+      maxSubstitutions: 1,
+    },
+  ],
+  lexicon: [
+    {
+      id: 'blue-lantern',
+      lemma: 'Blue Lantern',
+      profiles: ['canonical', 'aggressive'],
+      forms: [
+        {
+          text: 'Blue Lantern Annex',
+          kind: 'compound',
+          target: 'Blue Lantern',
+        },
+      ],
+    },
+  ],
+});
+const authoredEngine = createScrawlix({ rules: rulesFromPacks(authoredPack) });
+const authoredCanonical = authoredEngine.find('Visit the Blue Lantern Annex.')[0];
+const authoredAggressive = authoredEngine.find('Visit the Blue L@ntern Annex.')[0];
+assert.equal(authoredPack.manifest.name, 'Runtime Exhibit Labels');
+assert.equal(authoredCanonical?.targetText, 'Blue Lantern');
+assert.equal(authoredCanonical?.profile, 'canonical');
+assert.equal(authoredAggressive?.targetText, 'Blue L@ntern');
+assert.equal(authoredAggressive?.profile, 'aggressive');
+assert.equal(authoredAggressive?.packId, 'runtime-exhibit-labels');
 
 const obfuscatedEngine = createScrawlix({
   rules: englishObfuscatedStrongProfanityRules,

--- a/fixtures/consumer/src/main.tsx
+++ b/fixtures/consumer/src/main.tsx
@@ -1,4 +1,4 @@
-import { createScrawlix } from '@scrawlix/core';
+import { createScrawlix, rulesFromPacks } from '@scrawlix/core';
 import { createDomScrawlix } from '@scrawlix/dom';
 import { englishStrongProfanityRules } from '@scrawlix/en';
 import { englishProfanityCorpus } from '@scrawlix/en/corpus';
@@ -7,6 +7,7 @@ import { CensoredText } from '@scrawlix/react';
 import '@scrawlix/react/styles.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { referenceExhibitPack } from './reference-pack';
 
 const engine = createScrawlix({
   rules: englishStrongProfanityRules,
@@ -16,6 +17,21 @@ const engine = createScrawlix({
 const matches = engine.find('well, fuck');
 if (matches.length !== 1 || matches[0]?.targetText.toLowerCase() !== 'fuck') {
   throw new Error('Scrawlix core/English package smoke assertion failed.');
+}
+
+const exhibitEngine = createScrawlix({
+  rules: rulesFromPacks(referenceExhibitPack),
+});
+const exhibitCanonical = exhibitEngine.find('Visit the Blue Lantern Annex.')[0];
+const exhibitAggressive = exhibitEngine.find('Visit the Blue L@ntern Annex.')[0];
+if (
+  referenceExhibitPack.manifest.name !== 'Reference Exhibit Labels' ||
+  exhibitCanonical?.targetText !== 'Blue Lantern' ||
+  exhibitCanonical.profile !== 'canonical' ||
+  exhibitAggressive?.targetText !== 'Blue L@ntern' ||
+  exhibitAggressive.profile !== 'aggressive'
+) {
+  throw new Error('Scrawlix pack-authoring subpath smoke assertion failed.');
 }
 
 const corpusCase = englishProfanityCorpus.find(entry => entry.id === 'fuck-base');

--- a/fixtures/consumer/src/reference-pack.ts
+++ b/fixtures/consumer/src/reference-pack.ts
@@ -1,0 +1,58 @@
+import { defineLexiconPack } from '@scrawlix/core/pack-authoring';
+
+/** Reference third-party-style pack using fictional museum exhibit names. */
+export const referenceExhibitPack = defineLexiconPack({
+  manifest: {
+    id: 'reference-exhibit-labels',
+    version: '1.0.0',
+    name: 'Reference Exhibit Labels',
+    description: 'Example fictional exhibit vocabulary authored as lexical data.',
+    locale: 'en',
+    categories: ['reference', 'exhibits'],
+    reviewStatus: 'reviewed',
+    attribution: [{ label: 'Scrawlix fixture', license: 'CC0-1.0' }],
+    recommended: {
+      coverage: 'full',
+      appearance: 'bar',
+      reveal: 'never',
+    },
+  },
+  matchingProfiles: [
+    {
+      id: 'canonical',
+      mode: 'canonical',
+      boundary: 'unicode-word',
+      normalization: 'NFC',
+    },
+    {
+      id: 'aggressive',
+      mode: 'obfuscated',
+      boundary: 'unicode-word',
+      substitutions: { a: ['@'] },
+      maxSubstitutions: 1,
+    },
+  ],
+  lexicon: [
+    {
+      id: 'blue-lantern',
+      lemma: 'Blue Lantern',
+      profiles: ['canonical', 'aggressive'],
+      categories: ['exhibit-name'],
+      reviewStatus: 'reviewed',
+      provenance: { source: 'fictional fixture data' },
+      forms: [
+        { text: 'Blue Lantern', kind: 'base' },
+        {
+          text: 'Blue Lantern Annex',
+          kind: 'compound',
+          target: 'Blue Lantern',
+        },
+      ],
+    },
+    {
+      id: 'moth-glass',
+      lemma: 'Moth Glass',
+      forms: [{ text: 'Moth Glass', kind: 'base' }],
+    },
+  ],
+});

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -207,6 +207,58 @@ Rules can carry an optional `profile` string. `find()` exposes it as `match.prof
 
 Profile names describe the matching path. Packs still own linguistic scope, reviewed transform tables, budgets, and regression negatives.
 
+## Pack authoring
+
+Pack authors can opt into `@scrawlix/core/pack-authoring` when explicit lexical data can describe the pack:
+
+```ts
+import { createScrawlix, rulesFromPacks } from '@scrawlix/core';
+import { defineLexiconPack } from '@scrawlix/core/pack-authoring';
+
+const exhibitPack = defineLexiconPack({
+  manifest: {
+    id: 'museum-exhibits',
+    version: '1.0.0',
+    name: 'Museum Exhibit Labels',
+    locale: 'en',
+    categories: ['exhibits'],
+    reviewStatus: 'reviewed',
+    recommended: { coverage: 'full', appearance: 'bar', reveal: 'never' },
+  },
+  matchingProfiles: [
+    { id: 'canonical', mode: 'canonical', boundary: 'unicode-word' },
+    {
+      id: 'aggressive',
+      mode: 'obfuscated',
+      boundary: 'unicode-word',
+      substitutions: { a: ['@'] },
+      maxSubstitutions: 1,
+    },
+  ],
+  lexicon: [
+    {
+      id: 'blue-lantern',
+      lemma: 'Blue Lantern',
+      profiles: ['canonical', 'aggressive'],
+      forms: [
+        { text: 'Blue Lantern', kind: 'base' },
+        { text: 'Blue Lantern Annex', kind: 'compound', target: 'Blue Lantern' },
+      ],
+    },
+  ],
+});
+
+const engine = createScrawlix({ rules: rulesFromPacks(exhibitPack) });
+```
+
+The authoring model is **manifest + lexicon + matching profiles**. `defineLexiconPack()` compiles those values into the same runtime helpers: canonical profiles delegate to `censorRuleFromTerms()`, aggressive profiles delegate to the targeted bounded-obfuscation helper, and the stable lexical id is reused across emitted profiles.
+
+A lexical form can name one exact semantic-target substring inside a larger attested form. The target must occur once and align to extended-grapheme boundaries. One lexical entry may opt into several named profiles, so canonical and reviewed aggressive matching share a single semantic row instead of duplicating the lexicon.
+
+`AuthoredRulePack` keeps the original manifest, lexicon, and profile definitions beside its ordinary `CensorRulePack` fields. Applications can display pack name, version, locale, categories, review status, attribution, and presentation recommendations without bespoke metadata wiring. Presentation recommendation strings are hints for adapters/apps; core does not interpret appearance or reveal ids.
+
+Prefer explicit attested forms by default. Language-specific generators remain appropriate inside the pack that understands the productive paradigm; the authoring helper deliberately avoids a universal affix/morphology DSL.
+
 ## Public concepts
 
 - **matching** finds a term or phrase
@@ -219,6 +271,7 @@ Profile names describe the matching path. Packs still own linguistic scope, revi
 - targeted aggressive matching can preserve a smaller semantic root through `@scrawlix/core/targeted-obfuscated`
 - repeated-letter matching is opt-in through `@scrawlix/core/repeated-obfuscated`
 - reviewed fullwidth ASCII matching is opt-in through `@scrawlix/core/width-obfuscated`
+- data-authored packs can compile manifest/lexicon/profile data through `@scrawlix/core/pack-authoring`
 - every exposed match, target, and covered segment respects extended-grapheme boundaries
 
 Scrawlix deliberately has no built-in language or hidden profanity list. Callers select rules explicitly.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,11 @@
       "types": "./dist/width-obfuscated.d.ts",
       "import": "./dist/width-obfuscated.js",
       "default": "./dist/width-obfuscated.js"
+    },
+    "./pack-authoring": {
+      "types": "./dist/pack-authoring.d.ts",
+      "import": "./dist/pack-authoring.js",
+      "default": "./dist/pack-authoring.js"
     }
   },
   "repository": {

--- a/packages/core/src/pack-authoring.test.ts
+++ b/packages/core/src/pack-authoring.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest';
+import { createScrawlix, rulesFromPacks } from './index';
+import { compileLexiconRules, defineLexiconPack } from './pack-authoring';
+
+const referencePack = defineLexiconPack({
+  manifest: {
+    id: 'reference-exhibit-labels',
+    version: '1.0.0',
+    name: 'Reference Exhibit Labels',
+    description: 'Fictional exhibit vocabulary for pack authoring tests.',
+    locale: ['en'],
+    categories: ['reference', 'exhibits'],
+    tags: ['fixture'],
+    reviewStatus: 'reviewed',
+    attribution: [{ label: 'Scrawlix test fixture', license: 'CC0-1.0' }],
+    recommended: { coverage: 'full', appearance: 'bar', reveal: 'never' },
+  },
+  matchingProfiles: [
+    {
+      id: 'canonical',
+      mode: 'canonical',
+      boundary: 'unicode-word',
+      normalization: 'NFC',
+    },
+    {
+      id: 'aggressive',
+      mode: 'obfuscated',
+      boundary: 'unicode-word',
+      normalization: 'NFC',
+      substitutions: { a: ['@'] },
+      maxSubstitutions: 1,
+    },
+    {
+      id: 'exact-case',
+      mode: 'canonical',
+      boundary: 'unicode-word',
+      normalization: 'NFC',
+      caseSensitive: true,
+    },
+  ],
+  defaultProfile: 'canonical',
+  lexicon: [
+    {
+      id: 'blue-lantern',
+      lemma: 'Blue Lantern',
+      profiles: ['canonical', 'aggressive'],
+      categories: ['exhibit-name'],
+      reviewStatus: 'reviewed',
+      provenance: { source: 'fictional fixture data' },
+      forms: [
+        { text: 'Blue Lantern', kind: 'base' },
+        {
+          text: 'Blue Lantern Annex',
+          kind: 'compound',
+          target: 'Blue Lantern',
+        },
+      ],
+    },
+    {
+      id: 'moth-glass',
+      lemma: 'Moth Glass',
+      profiles: ['exact-case'],
+      forms: ['Moth Glass'],
+    },
+  ],
+});
+
+describe('pack authoring', () => {
+  it('keeps app-facing metadata on an ordinary rule pack', () => {
+    expect(referencePack.id).toBe('reference-exhibit-labels');
+    expect(referencePack.locale).toEqual(['en']);
+    expect(referencePack.manifest.name).toBe('Reference Exhibit Labels');
+    expect(referencePack.manifest.recommended).toEqual({
+      coverage: 'full',
+      appearance: 'bar',
+      reveal: 'never',
+    });
+    expect(referencePack.lexicon[0]?.provenance?.source).toBe(
+      'fictional fixture data'
+    );
+    expect(referencePack.matchingProfiles.map(profile => profile.id)).toEqual([
+      'canonical',
+      'aggressive',
+      'exact-case',
+    ]);
+  });
+
+  it('compiles attested forms with semantic targets and pack/profile provenance', () => {
+    const engine = createScrawlix({
+      rules: rulesFromPacks(referencePack),
+      coverage: 'full',
+    });
+
+    expect(engine.find('Visit the Blue Lantern Annex.')).toEqual([
+      {
+        ruleId: 'blue-lantern',
+        packId: 'reference-exhibit-labels',
+        profile: 'canonical',
+        text: 'Blue Lantern Annex',
+        start: 10,
+        end: 28,
+        targetText: 'Blue Lantern',
+        targetStart: 10,
+        targetEnd: 22,
+      },
+    ]);
+
+    expect(engine.segment('Visit the Blue Lantern Annex.')).toEqual([
+      { text: 'Visit the ', covered: false, ruleIds: [] },
+      { text: 'Blue Lantern', covered: true, ruleIds: ['blue-lantern'] },
+      { text: ' Annex.', covered: false, ruleIds: [] },
+    ]);
+  });
+
+  it('reuses one lexical entry across canonical and bounded aggressive profiles', () => {
+    const engine = createScrawlix({ rules: rulesFromPacks(referencePack) });
+
+    const canonical = engine.find('Blue Lantern Annex')[0];
+    expect(canonical?.ruleId).toBe('blue-lantern');
+    expect(canonical?.profile).toBe('canonical');
+    expect(canonical?.targetText).toBe('Blue Lantern');
+
+    const aggressive = engine.find('Blue L@ntern Annex')[0];
+    expect(aggressive?.ruleId).toBe('blue-lantern');
+    expect(aggressive?.profile).toBe('aggressive');
+    expect(aggressive?.text).toBe('Blue L@ntern Annex');
+    expect(aggressive?.targetText).toBe('Blue L@ntern');
+  });
+
+  it('maps canonical Unicode targets back to exact caller source', () => {
+    const pack = defineLexiconPack({
+      manifest: {
+        id: 'canonical-reference',
+        version: '1.0.0',
+        name: 'Canonical reference',
+        locale: 'fr',
+      },
+      lexicon: [
+        {
+          id: 'cafe-file',
+          lemma: 'café',
+          forms: [
+            {
+              text: 'café dossier',
+              kind: 'phrase',
+              target: 'café',
+            },
+          ],
+        },
+      ],
+    });
+    const source = 'Open cafe\u0301 dossier now.';
+    const match = createScrawlix({ rules: rulesFromPacks(pack) }).find(source)[0];
+
+    expect(match?.text).toBe('cafe\u0301 dossier');
+    expect(match?.targetText).toBe('cafe\u0301');
+    expect(source.slice(match!.targetStart, match!.targetEnd)).toBe('cafe\u0301');
+  });
+
+  it('passes named case-sensitive profiles through to canonical matching', () => {
+    const engine = createScrawlix({ rules: rulesFromPacks(referencePack) });
+
+    expect(engine.find('Moth Glass moth glass')).toHaveLength(1);
+    expect(engine.find('Moth Glass moth glass')[0]?.text).toBe('Moth Glass');
+    expect(engine.find('Moth Glass moth glass')[0]?.profile).toBe('exact-case');
+  });
+
+  it('rejects ambiguous targets, duplicate ids/profiles, and missing profiles', () => {
+    expect(() =>
+      compileLexiconRules([
+        {
+          id: 'repeat',
+          lemma: 'foo',
+          forms: [{ text: 'foo foo', target: 'foo' }],
+        },
+      ])
+    ).toThrow(/occurs more than once/);
+
+    expect(() =>
+      compileLexiconRules([
+        { id: 'same', lemma: 'one', forms: ['one'] },
+        { id: 'same', lemma: 'two', forms: ['two'] },
+      ])
+    ).toThrow(/Duplicate lexical entry id/);
+
+    expect(() =>
+      compileLexiconRules(
+        [{ id: 'profiled', lemma: 'term', forms: ['term'] }],
+        {
+          matchingProfiles: [
+            { id: 'same', mode: 'canonical' },
+            { id: 'same', mode: 'canonical' },
+          ],
+        }
+      )
+    ).toThrow(/Duplicate matching profile id/);
+
+    expect(() =>
+      compileLexiconRules(
+        [
+          {
+            id: 'profiled',
+            lemma: 'term',
+            profiles: ['missing'],
+            forms: ['term'],
+          },
+        ],
+        { matchingProfiles: [{ id: 'canonical', mode: 'canonical' }] }
+      )
+    ).toThrow(/unknown matching profile/);
+  });
+});

--- a/packages/core/src/pack-authoring.ts
+++ b/packages/core/src/pack-authoring.ts
@@ -1,0 +1,527 @@
+import {
+  censorRuleFromTerms,
+  graphemeRanges,
+  type CensorMatcherMatch,
+  type CensorRule,
+  type CensorRulePack,
+  type CoveragePreset,
+  type CoverageSelector,
+  type ObfuscatedTermOptions,
+  type TermBoundaryStrategy,
+  type UnicodeNormalization,
+} from './index.js';
+import {
+  censorRuleFromTargetedObfuscatedTerms,
+  type TargetedObfuscatedTerm,
+} from './targeted-obfuscated.js';
+
+export type PackReviewStatus = 'draft' | 'reviewed' | 'maintained';
+export type PackSeverity = 'mild' | 'moderate' | 'strong';
+
+export type PackAttribution = {
+  label: string;
+  url?: string;
+  license?: string;
+};
+
+export type PackRecommendation = {
+  coverage?: CoveragePreset;
+  /** Adapter/application presentation id, for example `bar` or `blur`. */
+  appearance?: string;
+  /** Adapter/application reveal id, for example `never` or `click`. */
+  reveal?: string;
+};
+
+export type RulePackManifest = {
+  id: string;
+  version: string;
+  name: string;
+  description?: string;
+  locale?: string | readonly string[];
+  categories?: readonly string[];
+  tags?: readonly string[];
+  reviewStatus?: PackReviewStatus;
+  attribution?: readonly PackAttribution[];
+  recommended?: PackRecommendation;
+};
+
+export type LexicalFormKind =
+  | 'base'
+  | 'inflection'
+  | 'derivation'
+  | 'compound'
+  | 'slang'
+  | 'dialect'
+  | 'spelling-variant'
+  | 'phrase';
+
+export type LexicalForm = {
+  text: string;
+  kind?: LexicalFormKind;
+  /**
+   * Exact canonical substring of `text` used as the semantic target. Omit to
+   * target the complete attested form. The substring must occur exactly once
+   * and align to extended-grapheme boundaries.
+   */
+  target?: string;
+};
+
+export type LexicalEntryProvenance = {
+  source: string;
+  url?: string;
+  note?: string;
+};
+
+export type PackLexicalEntry = {
+  /** Stable semantic id reused across emitted matching profiles. */
+  id: string;
+  lemma: string;
+  forms: readonly (string | LexicalForm)[];
+  /** Matching profile ids. Omit to use the pack default profile. */
+  profiles?: readonly string[];
+  locale?: string | readonly string[];
+  register?: string | readonly string[];
+  categories?: readonly string[];
+  severity?: PackSeverity;
+  reviewStatus?: PackReviewStatus;
+  provenance?: LexicalEntryProvenance;
+  coverage?: CoverageSelector;
+};
+
+export type CanonicalPackMatchingProfile = {
+  id: string;
+  mode?: 'canonical';
+  boundary?: TermBoundaryStrategy;
+  normalization?: UnicodeNormalization;
+  caseSensitive?: boolean;
+};
+
+export type ObfuscatedPackMatchingProfile = {
+  id: string;
+  mode: 'obfuscated';
+} & Omit<ObfuscatedTermOptions, 'coverage' | 'profile'>;
+
+export type PackMatchingProfile =
+  | CanonicalPackMatchingProfile
+  | ObfuscatedPackMatchingProfile;
+
+export type DefineLexiconPackInput = {
+  manifest: RulePackManifest;
+  lexicon: readonly PackLexicalEntry[];
+  matchingProfiles?: readonly PackMatchingProfile[];
+  defaultProfile?: string;
+};
+
+export type AuthoredRulePack = CensorRulePack & {
+  manifest: RulePackManifest;
+  lexicon: readonly PackLexicalEntry[];
+  matchingProfiles: readonly PackMatchingProfile[];
+  defaultProfile: string;
+};
+
+type PreparedForm = {
+  text: string;
+  target?: string;
+  targetStart: number;
+  targetEnd: number;
+};
+
+type CandidateMatch = {
+  start: number;
+  end: number;
+  targetStart: number;
+  targetEnd: number;
+};
+
+const DEFAULT_PROFILE_ID = 'canonical';
+
+function requiredText(value: string, label: string) {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`${label} must be a non-empty string.`);
+  return normalized;
+}
+
+function uniqueStrings(values: readonly string[] | undefined) {
+  if (!values) return undefined;
+  return [...new Set(values.map(value => value.trim()).filter(Boolean))];
+}
+
+function validateManifest(manifest: RulePackManifest): RulePackManifest {
+  const id = requiredText(manifest.id, 'Pack manifest id');
+  const version = requiredText(manifest.version, 'Pack manifest version');
+  const name = requiredText(manifest.name, 'Pack manifest name');
+  const locale =
+    typeof manifest.locale === 'string'
+      ? manifest.locale.trim() || undefined
+      : uniqueStrings(manifest.locale);
+
+  return {
+    ...manifest,
+    id,
+    version,
+    name,
+    ...(manifest.description?.trim()
+      ? { description: manifest.description.trim() }
+      : {}),
+    ...(locale ? { locale } : {}),
+    ...(manifest.categories
+      ? { categories: uniqueStrings(manifest.categories) }
+      : {}),
+    ...(manifest.tags ? { tags: uniqueStrings(manifest.tags) } : {}),
+    ...(manifest.attribution
+      ? {
+          attribution: manifest.attribution.map((item, index) => ({
+            ...item,
+            label: requiredText(item.label, `Pack attribution ${index + 1} label`),
+            ...(item.url?.trim() ? { url: item.url.trim() } : {}),
+            ...(item.license?.trim() ? { license: item.license.trim() } : {}),
+          })),
+        }
+      : {}),
+  };
+}
+
+function defaultMatchingProfile(): CanonicalPackMatchingProfile {
+  return {
+    id: DEFAULT_PROFILE_ID,
+    mode: 'canonical',
+    boundary: 'word',
+    normalization: 'NFC',
+    caseSensitive: false,
+  };
+}
+
+function prepareProfiles(
+  profiles: readonly PackMatchingProfile[] | undefined,
+  defaultProfile: string | undefined
+) {
+  const prepared = profiles?.length ? [...profiles] : [defaultMatchingProfile()];
+  const byId = new Map<string, PackMatchingProfile>();
+
+  for (const profile of prepared) {
+    const id = requiredText(profile.id, 'Matching profile id');
+    if (byId.has(id)) throw new Error(`Duplicate matching profile id "${id}".`);
+    byId.set(id, { ...profile, id });
+  }
+
+  const selectedDefault = defaultProfile?.trim() || prepared[0]!.id;
+  if (!byId.has(selectedDefault)) {
+    throw new Error(`Unknown default matching profile "${selectedDefault}".`);
+  }
+
+  return {
+    profiles: [...byId.values()],
+    byId,
+    defaultProfile: selectedDefault,
+  };
+}
+
+function normalizationFor(profile: PackMatchingProfile) {
+  return profile.normalization ?? 'NFC';
+}
+
+function prepareForm(
+  raw: string | LexicalForm,
+  entryId: string,
+  normalization: UnicodeNormalization
+): PreparedForm {
+  const form = typeof raw === 'string' ? { text: raw } : raw;
+  const text = requiredText(form.text, `Lexical form for "${entryId}"`);
+  const canonicalText =
+    normalization === 'none' ? text : text.normalize(normalization);
+  const target = form.target?.trim();
+
+  if (!target) {
+    return {
+      text,
+      targetStart: 0,
+      targetEnd: canonicalText.length,
+    };
+  }
+
+  const canonicalTarget =
+    normalization === 'none' ? target : target.normalize(normalization);
+  const first = canonicalText.indexOf(canonicalTarget);
+  const second =
+    first < 0
+      ? -1
+      : canonicalText.indexOf(
+          canonicalTarget,
+          first + canonicalTarget.length
+        );
+  if (first < 0) {
+    throw new Error(
+      `Target "${target}" is absent from lexical form "${text}" for entry "${entryId}".`
+    );
+  }
+  if (second >= 0) {
+    throw new Error(
+      `Target "${target}" occurs more than once in lexical form "${text}" for entry "${entryId}"; make the semantic target unambiguous.`
+    );
+  }
+
+  const targetEnd = first + canonicalTarget.length;
+  const boundaries = new Set<number>([0, canonicalText.length]);
+  for (const range of graphemeRanges(canonicalText)) {
+    boundaries.add(range.start);
+    boundaries.add(range.end);
+  }
+  if (!boundaries.has(first) || !boundaries.has(targetEnd)) {
+    throw new Error(
+      `Target "${target}" splits an extended grapheme in lexical form "${text}" for entry "${entryId}".`
+    );
+  }
+
+  return {
+    text,
+    target,
+    targetStart: first,
+    targetEnd,
+  };
+}
+
+function sourceOffsetsForCanonicalMatch(
+  source: string,
+  normalization: UnicodeNormalization
+) {
+  if (normalization === 'none') {
+    const offsets = new Map<number, number>([[0, 0], [source.length, source.length]]);
+    for (const range of graphemeRanges(source)) {
+      offsets.set(range.start, range.start);
+      offsets.set(range.end, range.end);
+    }
+    return offsets;
+  }
+
+  let shadowOffset = 0;
+  const offsets = new Map<number, number>([[0, 0]]);
+  for (const range of graphemeRanges(source)) {
+    offsets.set(shadowOffset, range.start);
+    shadowOffset += source
+      .slice(range.start, range.end)
+      .normalize(normalization).length;
+    offsets.set(shadowOffset, range.end);
+  }
+  return offsets;
+}
+
+function executeBaseRule(rule: CensorRule, text: string): CensorMatcherMatch[] {
+  if (rule.matcher) return [...rule.matcher.find(text)];
+
+  const flags = new Set(rule.pattern.flags.replaceAll('y', '').split(''));
+  flags.add('g');
+  const pattern = new RegExp(rule.pattern.source, [...flags].join(''));
+  const matches: CensorMatcherMatch[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
+    if (!match[0]) {
+      pattern.lastIndex = match.index + 1;
+      continue;
+    }
+    matches.push({ start: match.index, end: match.index + match[0].length });
+  }
+  return matches;
+}
+
+function canonicalCandidate(
+  text: string,
+  match: CensorMatcherMatch,
+  form: PreparedForm,
+  normalization: UnicodeNormalization
+): CandidateMatch | null {
+  if (form.targetStart === 0 && form.targetEnd === (normalization === 'none' ? form.text.length : form.text.normalize(normalization).length)) {
+    return {
+      start: match.start,
+      end: match.end,
+      targetStart: match.start,
+      targetEnd: match.end,
+    };
+  }
+
+  const sourceSlice = text.slice(match.start, match.end);
+  const offsets = sourceOffsetsForCanonicalMatch(sourceSlice, normalization);
+  const relativeTargetStart = offsets.get(form.targetStart);
+  const relativeTargetEnd = offsets.get(form.targetEnd);
+  if (relativeTargetStart === undefined || relativeTargetEnd === undefined) {
+    return null;
+  }
+
+  return {
+    start: match.start,
+    end: match.end,
+    targetStart: match.start + relativeTargetStart,
+    targetEnd: match.start + relativeTargetEnd,
+  };
+}
+
+function dedupeLongestCandidates(candidates: CandidateMatch[]) {
+  candidates.sort(
+    (left, right) =>
+      left.start - right.start ||
+      right.end - left.end ||
+      left.targetStart - right.targetStart ||
+      right.targetEnd - left.targetEnd
+  );
+
+  const accepted: CandidateMatch[] = [];
+  const seen = new Set<string>();
+  let acceptedEnd = -1;
+  for (const candidate of candidates) {
+    const key = `${candidate.start}:${candidate.end}:${candidate.targetStart}:${candidate.targetEnd}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    if (candidate.start < acceptedEnd) continue;
+    accepted.push(candidate);
+    acceptedEnd = candidate.end;
+  }
+  return accepted;
+}
+
+function canonicalRule(
+  entry: PackLexicalEntry,
+  profile: CanonicalPackMatchingProfile,
+  forms: readonly PreparedForm[]
+): CensorRule {
+  const normalization = normalizationFor(profile);
+  const baseRules = forms.map(form => ({
+    form,
+    rule: censorRuleFromTerms(entry.id, [form.text], {
+      caseSensitive: profile.caseSensitive ?? false,
+      boundary: profile.boundary ?? 'word',
+      normalization,
+      profile: profile.id,
+    }),
+  }));
+
+  return {
+    id: entry.id,
+    profile: profile.id,
+    ...(entry.coverage ? { coverage: entry.coverage } : {}),
+    matcher: {
+      *find(text) {
+        const candidates: CandidateMatch[] = [];
+        for (const prepared of baseRules) {
+          for (const match of executeBaseRule(prepared.rule, text)) {
+            const candidate = canonicalCandidate(
+              text,
+              match,
+              prepared.form,
+              normalization
+            );
+            if (candidate) candidates.push(candidate);
+          }
+        }
+        yield* dedupeLongestCandidates(candidates);
+      },
+    },
+  };
+}
+
+function targetedEntries(forms: readonly PreparedForm[]): TargetedObfuscatedTerm[] {
+  return forms.map(form =>
+    form.target
+      ? { term: form.text, target: form.target }
+      : form.text
+  );
+}
+
+function obfuscatedRule(
+  entry: PackLexicalEntry,
+  profile: ObfuscatedPackMatchingProfile,
+  forms: readonly PreparedForm[]
+): CensorRule {
+  return censorRuleFromTargetedObfuscatedTerms(
+    entry.id,
+    targetedEntries(forms),
+    {
+      caseSensitive: profile.caseSensitive ?? false,
+      boundary: profile.boundary ?? 'word',
+      normalization: normalizationFor(profile),
+      profile: profile.id,
+      ...(profile.substitutions
+        ? { substitutions: profile.substitutions }
+        : {}),
+      ...(profile.ignored ? { ignored: profile.ignored } : {}),
+      ...(profile.maxSubstitutions !== undefined
+        ? { maxSubstitutions: profile.maxSubstitutions }
+        : {}),
+      ...(profile.maxIgnored !== undefined
+        ? { maxIgnored: profile.maxIgnored }
+        : {}),
+      ...(profile.maxChanges !== undefined
+        ? { maxChanges: profile.maxChanges }
+        : {}),
+      ...(entry.coverage ? { coverage: entry.coverage } : {}),
+    }
+  );
+}
+
+export function compileLexiconRules(
+  lexicon: readonly PackLexicalEntry[],
+  {
+    matchingProfiles,
+    defaultProfile,
+  }: {
+    matchingProfiles?: readonly PackMatchingProfile[];
+    defaultProfile?: string;
+  } = {}
+): CensorRule[] {
+  const profiles = prepareProfiles(matchingProfiles, defaultProfile);
+  const seenIds = new Set<string>();
+  const rules: CensorRule[] = [];
+
+  for (const entry of lexicon) {
+    const id = requiredText(entry.id, 'Lexical entry id');
+    requiredText(entry.lemma, `Lexical entry "${id}" lemma`);
+    if (seenIds.has(id)) throw new Error(`Duplicate lexical entry id "${id}".`);
+    seenIds.add(id);
+    if (entry.forms.length === 0) {
+      throw new Error(`Lexical entry "${id}" needs at least one attested form.`);
+    }
+
+    const selectedIds = entry.profiles
+      ? uniqueStrings(entry.profiles) ?? []
+      : [profiles.defaultProfile];
+    if (selectedIds.length === 0) {
+      throw new Error(`Lexical entry "${id}" needs at least one matching profile.`);
+    }
+
+    for (const profileId of selectedIds) {
+      const profile = profiles.byId.get(profileId);
+      if (!profile) {
+        throw new Error(
+          `Lexical entry "${id}" references unknown matching profile "${profileId}".`
+        );
+      }
+      const forms = entry.forms.map(form =>
+        prepareForm(form, id, normalizationFor(profile))
+      );
+      rules.push(
+        profile.mode === 'obfuscated'
+          ? obfuscatedRule({ ...entry, id }, profile, forms)
+          : canonicalRule({ ...entry, id }, profile, forms)
+      );
+    }
+  }
+
+  return rules;
+}
+
+export function defineLexiconPack(input: DefineLexiconPackInput): AuthoredRulePack {
+  const manifest = validateManifest(input.manifest);
+  const profiles = prepareProfiles(input.matchingProfiles, input.defaultProfile);
+  const rules = compileLexiconRules(input.lexicon, {
+    matchingProfiles: profiles.profiles,
+    defaultProfile: profiles.defaultProfile,
+  });
+
+  return {
+    id: manifest.id,
+    ...(manifest.locale ? { locale: manifest.locale } : {}),
+    rules,
+    manifest,
+    lexicon: input.lexicon,
+    matchingProfiles: profiles.profiles,
+    defaultProfile: profiles.defaultProfile,
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
       "@scrawlix/core/width-obfuscated": [
         "packages/core/src/width-obfuscated.ts"
       ],
+      "@scrawlix/core/pack-authoring": ["packages/core/src/pack-authoring.ts"],
       "@scrawlix/en": ["packages/en/src/index.ts"],
       "@scrawlix/en/corpus": ["packages/en/src/corpus.ts"],
       "@scrawlix/react": ["packages/react/src/index.tsx"],


### PR DESCRIPTION
## What

Adds an opt-in `@scrawlix/core/pack-authoring` subpath for third-party-style rule packs built from inspectable data instead of bespoke regex wiring.

- typed pack manifest: id/version/name/description, locale, categories/tags, review status, attribution, presentation recommendations
- lexical entries with stable semantic ids, lemmas, explicit attested forms, form kinds, provenance/review metadata, coarse severity/categories, optional coverage
- explicit semantic `target` substring inside larger attested forms
- named matching profiles
  - canonical profiles delegate to current `censorRuleFromTerms()` boundary/NFC/case behavior
  - aggressive profiles delegate to the current targeted bounded-obfuscation helper and keep reviewed transforms/budgets explicit
- one lexical entry can participate in several profiles while retaining one stable rule id; `match.profile` identifies the path
- `AuthoredRulePack` remains an ordinary `CensorRulePack` while keeping manifest/lexicon/profile data available to apps

## Pressure test

Adds a harmless fictional **Reference Exhibit Labels** pack in the external consumer fixture. It exercises:

- human/app-readable metadata
- canonical matching
- a compound form with a smaller semantic target
- the same lexical entry through a reviewed aggressive `a -> @` profile
- pack + profile provenance
- runtime and TypeScript imports from a packed `@scrawlix/core/pack-authoring` tarball

## Design boundary

This implements the `manifest + lexicon + matching profiles + corpus` direction from #33 while keeping corpus data in the existing validated corpus system.

It deliberately avoids a universal morphology DSL, registry/marketplace, accounts, remote code distribution, or application state in core. Presentation recommendations are opaque metadata hints; core does not interpret appearance/reveal ids.

## Validation target

CI should cover workspace typecheck/tests/builds, existing browser smokes, and packed external consumers. New core tests cover semantic targets, NFC/NFD source mapping, multi-profile lexical entries, case-sensitive profiles, and invalid/ambiguous authoring data.

Closes #33