### PR TITLE
Add bounded repeated letters to the English aggressive pack

### DIFF
--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -21,6 +21,12 @@ export default defineConfig({
         replacement: workspaceFile('../../packages/en/src/index.ts'),
       },
       {
+        find: '@scrawlix/core/repeated-obfuscated',
+        replacement: workspaceFile(
+          '../../packages/core/src/repeated-obfuscated.ts'
+        ),
+      },
+      {
         find: '@scrawlix/core/targeted-obfuscated',
         replacement: workspaceFile(
           '../../packages/core/src/targeted-obfuscated.ts'

--- a/fixtures/consumer/runtime.mjs
+++ b/fixtures/consumer/runtime.mjs
@@ -55,6 +55,17 @@ assert.equal(obfuscatedCompound?.targetText, 'fuck');
 assert.equal(obfuscatedCompound?.targetStart, 7);
 assert.equal(obfuscatedCompound?.targetEnd, 11);
 
+const englishRepeated = obfuscatedEngine.find('shittting')[0];
+assert.equal(englishRepeated?.text, 'shittting');
+assert.equal(englishRepeated?.targetText, 'shit');
+assert.equal(englishRepeated?.targetStart, 0);
+assert.equal(englishRepeated?.targetEnd, 4);
+assert.ok(
+  englishObfuscatedProfanityCorpus.some(
+    testCase => testCase.id === 'obfuscated-repeat-shit-inflection-t'
+  )
+);
+
 const targetedEngine = createScrawlix({
   rules: [
     censorRuleFromTargetedObfuscatedTerms(

--- a/packages/en/README.md
+++ b/packages/en/README.md
@@ -43,7 +43,7 @@ The package also exports a separate aggressive pack:
 - `englishObfuscatedStrongProfanityRules`
 - `englishObfuscatedStrongProfanityPack`
 
-It catches a small reviewed set of one-change evasions across the same inflection and compound families declared by the canonical pack for `fuck`, `shit`, `bitch`, `asshole`, and `cunt`. The pack allows one reviewed symbol/digit substitution **or** one internal `.`, `-`, or zero-width-space insertion per candidate.
+It catches a small reviewed set of one-change evasions across the same inflection and compound families declared by the canonical pack for `fuck`, `shit`, `bitch`, `asshole`, and `cunt`. Each candidate may use one reviewed symbol/digit substitution, one internal `.`, `-`, or zero-width-space insertion, **or** one excess repeated letter. The total budget stays one transform.
 
 ```ts
 import { createScrawlix, rulesFromPacks } from '@scrawlix/core';
@@ -60,11 +60,13 @@ const scrawlix = createScrawlix({
 });
 ```
 
-Examples include base forms such as `f*ck` and `sh1t`, inflections such as `f*cking`, `b!tches`, `assh0les`, and `c*nts`, and compounds such as `motherf*cker`, `mother-fucker`, and `bullsh1t`. Matches from this pack expose `profile: 'obfuscated'` and `packId: 'en-strong-profanity-obfuscated'` when composed through `rulesFromPacks()`.
+Examples include substitutions such as `f*ck` and `sh1t`, inserted separators such as `mother-fucker`, and bounded repetitions such as `fuuck`, `fuckking`, `motherfuucker`, `shittting`, `bittches`, `assshole`, and `cunnt`. Matches from this pack expose `profile: 'obfuscated'` and `packId: 'en-strong-profanity-obfuscated'` when composed through `rulesFromPacks()`.
 
-Full obfuscated forms preserve the canonical semantic root. For example, `f*cking` reports full match text `f*cking` with target text `f*ck`; `mother-fucker` reports the full compound with target text `fuck`; and an inserted separator inside the root, as in `motherf-ucker`, stays inside target text `f-uck`. Coverage therefore follows the same semantic profanity root as the canonical regex pack.
+Full obfuscated forms preserve the canonical semantic root. For example, `f*cking` reports target text `f*ck`; `mother-fucker` targets `fuck`; `motherfuucker` targets `fuuck`; and `shittting` still targets `shit` because the excess `t` belongs to the final canonical `t` in the `shitting` run, outside the root boundary. Coverage therefore follows the same semantic profanity root as the canonical regex pack.
 
-The pack deliberately caps each candidate at one transform. The reviewed table lives in ordinary package code, and its positives plus false-positive/over-budget cases live in JSON corpora. New morphology is added only alongside explicit corpus examples and ordinary-word/boundary negatives.
+Canonical repeated runs remain meaningful. The declared `ss` in `asshole` is the minimum accepted run; `assshole` consumes one repetition budget while `ashole` stays clean. Two excess letters, or a repetition combined with another transform, exceed this pack's one-change policy.
+
+The reviewed tables and form families live in ordinary package code, and positive plus false-positive/over-budget cases live in JSON corpora. New aggressive behavior arrives with explicit corpus examples and ordinary-word/boundary negatives.
 
 ## Regression data
 

--- a/packages/en/src/corpus-data/obfuscated-clean.json
+++ b/packages/en/src/corpus-data/obfuscated-clean.json
@@ -125,5 +125,61 @@
     "profile": "obfuscated",
     "tags": ["false-positive", "word-boundary", "inflection"],
     "matches": []
+  },
+  {
+    "id": "obfuscated-clean-repeat-two-extra",
+    "text": "fuuuck",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "repetition", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-repeat-plus-substitution",
+    "text": "fu*ck",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "repetition", "substitution", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-repeat-plus-separator",
+    "text": "fuu-ck",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "repetition", "punctuation-insertion", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-repeat-canonical-double-over-budget",
+    "text": "asssshole",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "repetition", "canonical-double", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-repeat-canonical-double-under-run",
+    "text": "ashole",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "canonical-double"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-repeat-fuckery-boundary",
+    "text": "fuuckery",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "repetition", "word-boundary"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-repeat-assholeish-boundary",
+    "text": "asssholeish",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "repetition", "word-boundary"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-clean-repeat-country",
+    "text": "cuuntry",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "repetition", "word-boundary", "ordinary-word"],
+    "matches": []
   }
 ]

--- a/packages/en/src/corpus-data/obfuscated.json
+++ b/packages/en/src/corpus-data/obfuscated.json
@@ -322,5 +322,142 @@
         "targetEnd": 4
       }
     ]
+  },
+  {
+    "id": "obfuscated-repeat-fuck-u",
+    "text": "fuuck",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "repetition"],
+    "matches": [
+      {
+        "ruleId": "fuck-obfuscated",
+        "text": "fuuck",
+        "start": 0,
+        "end": 5,
+        "targetText": "fuuck",
+        "targetStart": 0,
+        "targetEnd": 5
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-repeat-fuck-inflection-k",
+    "text": "fuckking",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "repetition", "inflection", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "fuck-obfuscated",
+        "text": "fuckking",
+        "start": 0,
+        "end": 8,
+        "targetText": "fuckk",
+        "targetStart": 0,
+        "targetEnd": 5
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-repeat-fuck-compound-u",
+    "text": "motherfuucker",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "repetition", "compound", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "fuck-obfuscated",
+        "text": "motherfuucker",
+        "start": 0,
+        "end": 13,
+        "targetText": "fuuck",
+        "targetStart": 6,
+        "targetEnd": 11
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-repeat-shit-i",
+    "text": "shiit",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "repetition"],
+    "matches": [
+      {
+        "ruleId": "shit-obfuscated",
+        "text": "shiit",
+        "start": 0,
+        "end": 5,
+        "targetText": "shiit",
+        "targetStart": 0,
+        "targetEnd": 5
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-repeat-shit-inflection-t",
+    "text": "shittting",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "repetition", "inflection", "semantic-target"],
+    "note": "The extra t attaches to the final canonical t in shitting, outside the shit semantic target.",
+    "matches": [
+      {
+        "ruleId": "shit-obfuscated",
+        "text": "shittting",
+        "start": 0,
+        "end": 9,
+        "targetText": "shit",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-repeat-bitch-plural-t",
+    "text": "bittches",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "repetition", "plural", "inflection", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "bitch-obfuscated",
+        "text": "bittches",
+        "start": 0,
+        "end": 8,
+        "targetText": "bittch",
+        "targetStart": 0,
+        "targetEnd": 6
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-repeat-asshole-canonical-double",
+    "text": "assshole",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "repetition", "canonical-double"],
+    "matches": [
+      {
+        "ruleId": "asshole-obfuscated",
+        "text": "assshole",
+        "start": 0,
+        "end": 8,
+        "targetText": "assshole",
+        "targetStart": 0,
+        "targetEnd": 8
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-repeat-cunt-n",
+    "text": "cunnt",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "repetition"],
+    "matches": [
+      {
+        "ruleId": "cunt-obfuscated",
+        "text": "cunnt",
+        "start": 0,
+        "end": 5,
+        "targetText": "cunnt",
+        "targetStart": 0,
+        "targetEnd": 5
+      }
+    ]
   }
 ]

--- a/packages/en/src/index.test.ts
+++ b/packages/en/src/index.test.ts
@@ -79,6 +79,10 @@ describe('@scrawlix/en', () => {
     expect(marked(obfuscatedEngine.segment('motherf-ucker'))).toBe(
       'mother[f-uck]er'
     );
+    expect(marked(obfuscatedEngine.segment('fuckking motherfuucker'))).toBe(
+      '[fuckk]ing mother[fuuck]er'
+    );
+    expect(marked(obfuscatedEngine.segment('shittting'))).toBe('[shit]tting');
   });
 
   it('exports composable canonical and opt-in obfuscated packs', () => {

--- a/packages/en/src/index.ts
+++ b/packages/en/src/index.ts
@@ -4,10 +4,8 @@ import {
   type CensorRulePack,
   type CoverageSelector,
 } from '@scrawlix/core';
-import {
-  censorRuleFromTargetedObfuscatedTerms,
-  type TargetedObfuscatedTerm,
-} from '@scrawlix/core/targeted-obfuscated';
+import { censorRuleFromRepeatedObfuscatedTerms } from '@scrawlix/core/repeated-obfuscated';
+import type { TargetedObfuscatedTerm } from '@scrawlix/core/targeted-obfuscated';
 
 /**
  * Covers orthographic English vowels (a/e/i/o/u) inside the semantic target.
@@ -122,12 +120,13 @@ const englishCuntForms = targetedForms('cunt', ['cunt', 'cunts']);
 /**
  * Conservative opt-in evasions mirroring the canonical pack's declared forms.
  *
- * Each candidate may use one reviewed substitution OR one reviewed internal
- * separator/zero-width insertion. Full inflections/compounds are matched, while
+ * Each candidate may use one reviewed substitution, one reviewed internal
+ * separator/zero-width insertion, or one excess repeated letter. The combined
+ * budget remains one transform. Full inflections/compounds are matched while
  * coverage and target metadata stay attached to the canonical profanity root.
  */
 export const englishObfuscatedStrongProfanityRules: readonly CensorRule[] = [
-  censorRuleFromTargetedObfuscatedTerms('fuck-obfuscated', englishFuckForms, {
+  censorRuleFromRepeatedObfuscatedTerms('fuck-obfuscated', englishFuckForms, {
     substitutions: {
       u: ['*'],
       c: ['('],
@@ -135,9 +134,10 @@ export const englishObfuscatedStrongProfanityRules: readonly CensorRule[] = [
     ignored: englishObfuscatedIgnored,
     maxSubstitutions: 1,
     maxIgnored: 1,
+    maxRepetitions: 1,
     maxChanges: 1,
   }),
-  censorRuleFromTargetedObfuscatedTerms('shit-obfuscated', englishShitForms, {
+  censorRuleFromRepeatedObfuscatedTerms('shit-obfuscated', englishShitForms, {
     substitutions: {
       s: ['$', '5'],
       i: ['1', '!', '*'],
@@ -146,9 +146,10 @@ export const englishObfuscatedStrongProfanityRules: readonly CensorRule[] = [
     ignored: englishObfuscatedIgnored,
     maxSubstitutions: 1,
     maxIgnored: 1,
+    maxRepetitions: 1,
     maxChanges: 1,
   }),
-  censorRuleFromTargetedObfuscatedTerms('bitch-obfuscated', englishBitchForms, {
+  censorRuleFromRepeatedObfuscatedTerms('bitch-obfuscated', englishBitchForms, {
     substitutions: {
       i: ['1', '!', '*'],
       t: ['7'],
@@ -156,9 +157,10 @@ export const englishObfuscatedStrongProfanityRules: readonly CensorRule[] = [
     ignored: englishObfuscatedIgnored,
     maxSubstitutions: 1,
     maxIgnored: 1,
+    maxRepetitions: 1,
     maxChanges: 1,
   }),
-  censorRuleFromTargetedObfuscatedTerms('asshole-obfuscated', englishAssholeForms, {
+  censorRuleFromRepeatedObfuscatedTerms('asshole-obfuscated', englishAssholeForms, {
     substitutions: {
       a: ['@'],
       s: ['$', '5'],
@@ -167,15 +169,17 @@ export const englishObfuscatedStrongProfanityRules: readonly CensorRule[] = [
     ignored: englishObfuscatedIgnored,
     maxSubstitutions: 1,
     maxIgnored: 1,
+    maxRepetitions: 1,
     maxChanges: 1,
   }),
-  censorRuleFromTargetedObfuscatedTerms('cunt-obfuscated', englishCuntForms, {
+  censorRuleFromRepeatedObfuscatedTerms('cunt-obfuscated', englishCuntForms, {
     substitutions: {
       u: ['*'],
     },
     ignored: englishObfuscatedIgnored,
     maxSubstitutions: 1,
     maxIgnored: 1,
+    maxRepetitions: 1,
     maxChanges: 1,
   }),
 ] as const;


### PR DESCRIPTION
## Summary
Dogfood the repeated-letter core helper in the opt-in English aggressive pack while keeping the existing one-change policy.

- switch English aggressive rules to `censorRuleFromRepeatedObfuscatedTerms()`
- add `maxRepetitions: 1` while keeping `maxChanges: 1`, so each candidate may use one substitution OR one ignored separator OR one excess repeated letter
- keep the existing reviewed substitution and ignored-grapheme tables unchanged
- preserve the canonical pack's inflection/compound semantic roots
- add 8 repeated-letter positive corpus cases across base forms, inflections, compounds, canonical doubles, and plurals
- add 8 clean regressions for two extras, repeat+substitution, repeat+separator, canonical-double over/under runs, boundary traps, and the ordinary word `cuuntry`
- assert root-only coverage for repeated inflections/compounds, including the target boundary inside canonical `shitting`
- document the one-repeat policy and canonical-run-minimum behavior
- wire the demo source alias for `@scrawlix/core/repeated-obfuscated`
- exercise repeated English target metadata through installed-tarball runtime smoke

## Review expectation
`corpus:diff` should report exactly 16 new cases: 8 newly matching + 8 added clean regressions. Existing substitution/insertion corpus cases should remain behaviorally unchanged.

## Policy
Canonical adjacent letter runs remain minima. For example, canonical `asshole` keeps `ss`; `assshole` uses one repetition budget; `ashole` stays clean. A repetition combined with another transform exceeds this pack's one-change policy.

Depends on merged #109.
Progress on #38