### PR TITLE
Add reviewed fullwidth ASCII obfuscation

### DIFF
--- a/fixtures/consumer/runtime.mjs
+++ b/fixtures/consumer/runtime.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { createScrawlix } from '@scrawlix/core';
 import { censorRuleFromRepeatedObfuscatedTerms } from '@scrawlix/core/repeated-obfuscated';
 import { censorRuleFromTargetedObfuscatedTerms } from '@scrawlix/core/targeted-obfuscated';
+import { censorRuleFromWidthObfuscatedTerms } from '@scrawlix/core/width-obfuscated';
 import { createDomScrawlix } from '@scrawlix/dom';
 import {
   englishObfuscatedStrongProfanityRules,
@@ -96,6 +97,24 @@ const repeatedMatch = repeatedEngine.find('motherfuucker')[0];
 assert.equal(repeatedMatch?.text, 'motherfuucker');
 assert.equal(repeatedMatch?.targetText, 'fuuck');
 assert.equal(repeatedMatch?.profile, 'obfuscated');
+
+const widthEngine = createScrawlix({
+  rules: [
+    censorRuleFromWidthObfuscatedTerms(
+      'width-smoke',
+      [{ term: 'motherfucker', target: 'fuck' }],
+      {
+        widthVariants: { f: ['ｆ'] },
+        maxWidthVariants: 1,
+        maxRepetitions: 0,
+      }
+    ),
+  ],
+});
+const widthMatch = widthEngine.find('motherｆucker')[0];
+assert.equal(widthMatch?.text, 'motherｆucker');
+assert.equal(widthMatch?.targetText, 'ｆuck');
+assert.equal(widthMatch?.profile, 'obfuscated');
 
 const tree = {
   type: 'root',

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -168,6 +168,37 @@ Semantic targets are supported directly. Extra source graphemes in a repeated ru
 
 This first repetition path is intentionally bounded and corpus-driven. It does not perform blanket edit-distance matching, phonetic equivalence, transliteration, or universal confusable folding.
 
+### Reviewed fullwidth ASCII variants
+
+Fullwidth ASCII evasions have a separate budget and a strict mapping contract:
+
+```ts
+import { createScrawlix } from '@scrawlix/core';
+import { censorRuleFromWidthObfuscatedTerms } from '@scrawlix/core/width-obfuscated';
+
+const widthRule = censorRuleFromWidthObfuscatedTerms(
+  'example-width',
+  [{ term: 'motherfucker', target: 'fuck' }],
+  {
+    widthVariants: {
+      f: ['ｆ'],
+      u: ['ｕ'],
+    },
+    maxWidthVariants: 1,
+    maxRepetitions: 0,
+  }
+);
+
+const engine = createScrawlix({ rules: [widthRule] });
+engine.find('motherｆucker')[0]?.targetText; // "ｆuck"
+```
+
+`widthVariants` reads as canonical printable ASCII grapheme → explicitly reviewed fullwidth ASCII source graphemes. Core validates the direct U+FF01–U+FF5E offset relation. That keeps this class limited to true fullwidth ASCII forms. Circled letters, superscripts, ligatures, and other compatibility characters are rejected by this helper even when NFKC would map them to ASCII.
+
+Every accepted fullwidth grapheme costs one `maxWidthVariants` unit. Width mappings remain distinct from ordinary `substitutions`; the same source grapheme cannot belong to both classes. Width can compose with repeated letters, substitutions, or ignored graphemes, and `maxChanges` is required whenever another transform class is active. The total budget counts all classes together while the wrapper also enforces width and ordinary-substitution budgets separately.
+
+The helper delegates source mapping, semantic targets, repetition semantics, normalization, boundary policy, and coverage to the repeated/source-mapped matcher. Zero-change canonical candidates remain filtered and matches expose `profile: 'obfuscated'` by default.
+
 ## Match profiles
 
 Rules can carry an optional `profile` string. `find()` exposes it as `match.profile`, and coverage callbacks receive the same value in their context. This lets packs distinguish conservative and aggressive matching paths in diagnostics and policy code.
@@ -187,6 +218,7 @@ Profile names describe the matching path. Packs still own linguistic scope, revi
 - bounded aggressive substitution/insertion matching is opt-in through `censorRuleFromObfuscatedTerms()`
 - targeted aggressive matching can preserve a smaller semantic root through `@scrawlix/core/targeted-obfuscated`
 - repeated-letter matching is opt-in through `@scrawlix/core/repeated-obfuscated`
+- reviewed fullwidth ASCII matching is opt-in through `@scrawlix/core/width-obfuscated`
 - every exposed match, target, and covered segment respects extended-grapheme boundaries
 
 Scrawlix deliberately has no built-in language or hidden profanity list. Callers select rules explicitly.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,11 @@
       "types": "./dist/repeated-obfuscated.d.ts",
       "import": "./dist/repeated-obfuscated.js",
       "default": "./dist/repeated-obfuscated.js"
+    },
+    "./width-obfuscated": {
+      "types": "./dist/width-obfuscated.d.ts",
+      "import": "./dist/width-obfuscated.js",
+      "default": "./dist/width-obfuscated.js"
     }
   },
   "repository": {

--- a/packages/core/src/width-obfuscated.test.ts
+++ b/packages/core/src/width-obfuscated.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import { createScrawlix } from './index';
+import { censorRuleFromWidthObfuscatedTerms } from './width-obfuscated';
+
+describe('width obfuscated terms', () => {
+  it('matches one reviewed fullwidth ASCII grapheme', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromWidthObfuscatedTerms('fuck-width', ['fuck'], {
+          widthVariants: { f: ['ｆ'], u: ['ｕ'] },
+          maxWidthVariants: 1,
+          maxRepetitions: 0,
+        }),
+      ],
+    });
+
+    expect(engine.find('ｆuck')).toEqual([
+      {
+        ruleId: 'fuck-width',
+        profile: 'obfuscated',
+        text: 'ｆuck',
+        start: 0,
+        end: 4,
+        targetText: 'ｆuck',
+        targetStart: 0,
+        targetEnd: 4,
+      },
+    ]);
+    expect(engine.find('fuck')).toEqual([]);
+    expect(engine.find('ｆｕck')).toEqual([]);
+  });
+
+  it('preserves semantic roots when the width variant is inside or outside the target', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromWidthObfuscatedTerms(
+          'fuck-width',
+          [
+            { term: 'motherfucker', target: 'fuck' },
+            { term: 'fucking', target: 'fuck' },
+          ],
+          {
+            widthVariants: { f: ['ｆ'], i: ['ｉ'] },
+            maxWidthVariants: 1,
+            maxRepetitions: 0,
+          }
+        ),
+      ],
+      coverage: 'full',
+    });
+
+    expect(engine.find('motherｆucker')[0]).toMatchObject({
+      text: 'motherｆucker',
+      targetText: 'ｆuck',
+      targetStart: 6,
+      targetEnd: 10,
+    });
+    expect(engine.find('fuckｉng')[0]).toMatchObject({
+      text: 'fuckｉng',
+      targetText: 'fuck',
+      targetStart: 0,
+      targetEnd: 4,
+    });
+    expect(engine.segment('motherｆucker')).toEqual([
+      { text: 'mother', covered: false, ruleIds: [] },
+      { text: 'ｆuck', covered: true, ruleIds: ['fuck-width'] },
+      { text: 'er', covered: false, ruleIds: [] },
+    ]);
+  });
+
+  it('keeps width and ordinary substitutions on separate budgets', () => {
+    const combined = createScrawlix({
+      rules: [
+        censorRuleFromWidthObfuscatedTerms('fuck-width', ['fuck'], {
+          widthVariants: { f: ['ｆ'] },
+          substitutions: { u: ['*'] },
+          maxWidthVariants: 1,
+          maxSubstitutions: 1,
+          maxRepetitions: 0,
+          maxChanges: 2,
+        }),
+      ],
+    });
+    const tight = createScrawlix({
+      rules: [
+        censorRuleFromWidthObfuscatedTerms('fuck-width', ['fuck'], {
+          widthVariants: { f: ['ｆ'] },
+          substitutions: { u: ['*'] },
+          maxWidthVariants: 1,
+          maxSubstitutions: 1,
+          maxRepetitions: 0,
+          maxChanges: 1,
+        }),
+      ],
+    });
+
+    expect(combined.find('ｆ*ck')[0]).toMatchObject({
+      text: 'ｆ*ck',
+      targetText: 'ｆ*ck',
+    });
+    expect(tight.find('ｆ*ck')).toEqual([]);
+  });
+
+  it('composes a width variant with one repeated letter under the total budget', () => {
+    const combined = createScrawlix({
+      rules: [
+        censorRuleFromWidthObfuscatedTerms('fuck-width', ['fuck'], {
+          widthVariants: { f: ['ｆ'] },
+          maxWidthVariants: 1,
+          maxRepetitions: 1,
+          maxChanges: 2,
+        }),
+      ],
+    });
+    const tight = createScrawlix({
+      rules: [
+        censorRuleFromWidthObfuscatedTerms('fuck-width', ['fuck'], {
+          widthVariants: { f: ['ｆ'] },
+          maxWidthVariants: 1,
+          maxRepetitions: 1,
+          maxChanges: 1,
+        }),
+      ],
+    });
+
+    expect(combined.find('ｆuuck')[0]).toMatchObject({ text: 'ｆuuck' });
+    expect(tight.find('ｆuuck')).toEqual([]);
+  });
+
+  it('preserves ordinary word boundaries after width folding', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromWidthObfuscatedTerms('cunt-width', ['cunt'], {
+          widthVariants: { u: ['ｕ'] },
+          maxWidthVariants: 1,
+          maxRepetitions: 0,
+        }),
+      ],
+    });
+
+    expect(engine.find('cｕnt')).toHaveLength(1);
+    expect(engine.find('cｕntry')).toEqual([]);
+  });
+
+  it('rejects general compatibility characters from the width class', () => {
+    expect(() =>
+      censorRuleFromWidthObfuscatedTerms('bad', ['fuck'], {
+        widthVariants: { f: ['ⓕ'] },
+        maxWidthVariants: 1,
+        maxRepetitions: 0,
+      })
+    ).toThrow('must be the fullwidth ASCII form');
+
+    expect(() =>
+      censorRuleFromWidthObfuscatedTerms('bad', ['fuck'], {
+        widthVariants: { f: ['ᶠ'] },
+        maxWidthVariants: 1,
+        maxRepetitions: 0,
+      })
+    ).toThrow('must be the fullwidth ASCII form');
+  });
+
+  it('rejects width mappings that are also ordinary substitutions', () => {
+    expect(() =>
+      censorRuleFromWidthObfuscatedTerms('bad', ['fuck'], {
+        widthVariants: { f: ['ｆ'] },
+        substitutions: { f: ['ｆ'] },
+        maxWidthVariants: 1,
+        maxSubstitutions: 1,
+        maxRepetitions: 0,
+        maxChanges: 1,
+      })
+    ).toThrow('cannot also be configured as a substitution');
+  });
+
+  it('requires a total budget when width is combined with another transform class', () => {
+    expect(() =>
+      censorRuleFromWidthObfuscatedTerms('bad', ['fuck'], {
+        widthVariants: { f: ['ｆ'] },
+        maxWidthVariants: 1,
+        maxRepetitions: 1,
+      })
+    ).toThrow('requires an explicit maxChanges');
+  });
+});

--- a/packages/core/src/width-obfuscated.ts
+++ b/packages/core/src/width-obfuscated.ts
@@ -1,0 +1,283 @@
+import {
+  graphemeRanges,
+  type CensorMatcher,
+  type CensorRule,
+  type ObfuscatedTermSubstitutions,
+  type UnicodeNormalization,
+} from './index.js';
+import {
+  censorRuleFromRepeatedObfuscatedTerms,
+  type RepeatedObfuscatedTermOptions,
+} from './repeated-obfuscated.js';
+import type { TargetedObfuscatedTerm } from './targeted-obfuscated.js';
+
+export type WidthObfuscatedTermOptions = RepeatedObfuscatedTermOptions & {
+  /** Canonical ASCII grapheme -> reviewed fullwidth ASCII source graphemes. */
+  widthVariants: ObfuscatedTermSubstitutions;
+  /** Maximum reviewed fullwidth source graphemes in one accepted candidate. */
+  maxWidthVariants: number;
+};
+
+type CompiledWidthVariants = {
+  mergedSubstitutions: ObfuscatedTermSubstitutions;
+  widthSources: ReadonlySet<string>;
+  substitutionSources: ReadonlySet<string>;
+  ignored: ReadonlySet<string>;
+  maxWidthVariants: number;
+  maxSubstitutions: number;
+  maxChanges: number;
+};
+
+function normalize(value: string, normalization: UnicodeNormalization) {
+  return normalization === 'none' ? value : value.normalize(normalization);
+}
+
+function requireSingleGrapheme(
+  value: string,
+  label: string,
+  normalization: UnicodeNormalization
+) {
+  const normalized = normalize(value, normalization);
+  const ranges = graphemeRanges(normalized);
+  if (
+    normalized.length === 0 ||
+    ranges.length !== 1 ||
+    ranges[0]!.start !== 0 ||
+    ranges[0]!.end !== normalized.length
+  ) {
+    throw new Error(`${label} must be exactly one extended grapheme.`);
+  }
+  return normalized;
+}
+
+function requireBudget(name: string, value: number | undefined, enabled: boolean) {
+  if (enabled && value === undefined) {
+    throw new Error(
+      `censorRuleFromWidthObfuscatedTerms() requires an explicit ${name} when that transform class is configured.`
+    );
+  }
+  const resolved = value ?? 0;
+  if (!Number.isInteger(resolved) || resolved < 0) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  return resolved;
+}
+
+function fullwidthAsciiFold(value: string) {
+  const codePoints = [...value];
+  if (codePoints.length !== 1) return null;
+  const codePoint = codePoints[0]!.codePointAt(0)!;
+  if (codePoint < 0xff01 || codePoint > 0xff5e) return null;
+  return String.fromCodePoint(codePoint - 0xfee0);
+}
+
+function normalizedSourceSet(
+  substitutions: ObfuscatedTermSubstitutions,
+  normalization: UnicodeNormalization
+) {
+  const values = new Set<string>();
+  for (const sourceValues of Object.values(substitutions)) {
+    for (const sourceValue of sourceValues) {
+      values.add(
+        requireSingleGrapheme(
+          sourceValue,
+          `Substitution value ${JSON.stringify(sourceValue)}`,
+          normalization
+        )
+      );
+    }
+  }
+  return values;
+}
+
+function compileWidthVariants(
+  options: WidthObfuscatedTermOptions,
+  normalization: UnicodeNormalization
+): CompiledWidthVariants {
+  const ordinarySubstitutions = options.substitutions ?? {};
+  const substitutionSources = normalizedSourceSet(
+    ordinarySubstitutions,
+    normalization
+  );
+  const widthSources = new Set<string>();
+  const merged = new Map<string, Set<string>>();
+
+  for (const [canonicalValue, sourceValues] of Object.entries(
+    ordinarySubstitutions
+  )) {
+    const canonical = requireSingleGrapheme(
+      canonicalValue,
+      `Substitution key ${JSON.stringify(canonicalValue)}`,
+      normalization
+    );
+    const bucket = merged.get(canonical) ?? new Set<string>();
+    for (const sourceValue of sourceValues) {
+      bucket.add(normalize(sourceValue, normalization));
+    }
+    merged.set(canonical, bucket);
+  }
+
+  let widthMappingCount = 0;
+  for (const [canonicalValue, sourceValues] of Object.entries(
+    options.widthVariants
+  )) {
+    const canonical = requireSingleGrapheme(
+      canonicalValue,
+      `Width-variant key ${JSON.stringify(canonicalValue)}`,
+      normalization
+    );
+    const canonicalCodePoints = [...canonical];
+    if (
+      canonicalCodePoints.length !== 1 ||
+      canonicalCodePoints[0]!.codePointAt(0)! < 0x21 ||
+      canonicalCodePoints[0]!.codePointAt(0)! > 0x7e
+    ) {
+      throw new Error(
+        `Width-variant key ${JSON.stringify(canonicalValue)} must be one printable ASCII grapheme.`
+      );
+    }
+
+    const bucket = merged.get(canonical) ?? new Set<string>();
+    for (const sourceValue of sourceValues) {
+      const source = requireSingleGrapheme(
+        sourceValue,
+        `Width-variant value ${JSON.stringify(sourceValue)}`,
+        normalization
+      );
+      const folded = fullwidthAsciiFold(source);
+      if (folded !== canonical) {
+        throw new Error(
+          `Width-variant value ${JSON.stringify(sourceValue)} must be the fullwidth ASCII form of ${JSON.stringify(canonicalValue)}.`
+        );
+      }
+      if (substitutionSources.has(source)) {
+        throw new Error(
+          `Width-variant value ${JSON.stringify(sourceValue)} cannot also be configured as a substitution.`
+        );
+      }
+      widthSources.add(source);
+      bucket.add(source);
+      widthMappingCount += 1;
+    }
+    merged.set(canonical, bucket);
+  }
+
+  if (widthMappingCount === 0) {
+    throw new Error(
+      'censorRuleFromWidthObfuscatedTerms() needs at least one reviewed width variant.'
+    );
+  }
+
+  const maxWidthVariants = requireBudget(
+    'maxWidthVariants',
+    options.maxWidthVariants,
+    true
+  );
+  const substitutionsEnabled = substitutionSources.size > 0;
+  const maxSubstitutions = requireBudget(
+    'maxSubstitutions',
+    options.maxSubstitutions,
+    substitutionsEnabled
+  );
+  const ignored = new Set(
+    (options.ignored ?? []).map(value => normalize(value, normalization))
+  );
+  const otherTransformEnabled =
+    substitutionsEnabled || ignored.size > 0 || options.maxRepetitions > 0;
+
+  if (otherTransformEnabled && options.maxChanges === undefined) {
+    throw new Error(
+      'censorRuleFromWidthObfuscatedTerms() requires an explicit maxChanges when width variants are combined with substitutions, ignored graphemes, or repeated letters.'
+    );
+  }
+  const maxChanges = requireBudget(
+    'maxChanges',
+    options.maxChanges ?? maxWidthVariants,
+    true
+  );
+
+  return {
+    mergedSubstitutions: Object.fromEntries(
+      [...merged].map(([canonical, values]) => [canonical, [...values]])
+    ),
+    widthSources,
+    substitutionSources,
+    ignored,
+    maxWidthVariants,
+    maxSubstitutions,
+    maxChanges,
+  };
+}
+
+function candidateMappedClassCost(
+  text: string,
+  start: number,
+  end: number,
+  normalization: UnicodeNormalization,
+  config: CompiledWidthVariants
+) {
+  let widthVariants = 0;
+  let substitutions = 0;
+
+  const slice = text.slice(start, end);
+  for (const range of graphemeRanges(slice)) {
+    const source = normalize(slice.slice(range.start, range.end), normalization);
+    if (config.ignored.has(source)) continue;
+    if (config.widthSources.has(source)) {
+      widthVariants += 1;
+    } else if (config.substitutionSources.has(source)) {
+      substitutions += 1;
+    }
+  }
+
+  return { widthVariants, substitutions };
+}
+
+/**
+ * Match explicitly reviewed fullwidth ASCII variants with their own budget.
+ *
+ * This helper deliberately validates the U+FF01–U+FF5E fullwidth ASCII relation
+ * instead of enabling general NFKC compatibility folding. Circled letters,
+ * superscripts, ligatures, and arbitrary compatibility characters are outside
+ * this transform class.
+ */
+export function censorRuleFromWidthObfuscatedTerms(
+  id: string,
+  entries: readonly TargetedObfuscatedTerm[],
+  options: WidthObfuscatedTermOptions
+): CensorRule {
+  const normalization = options.normalization ?? 'NFC';
+  const config = compileWidthVariants(options, normalization);
+  const baseRule = censorRuleFromRepeatedObfuscatedTerms(id, entries, {
+    ...options,
+    substitutions: config.mergedSubstitutions,
+    maxSubstitutions: config.maxSubstitutions + config.maxWidthVariants,
+    maxChanges: config.maxChanges,
+  });
+  const baseMatcher: CensorMatcher | undefined = baseRule.matcher;
+  if (!baseMatcher) {
+    throw new Error('Width-obfuscated terms require a matcher-backed rule.');
+  }
+
+  return {
+    id,
+    profile: options.profile ?? 'obfuscated',
+    coverage: options.coverage,
+    matcher: {
+      *find(text) {
+        for (const match of baseMatcher.find(text)) {
+          const cost = candidateMappedClassCost(
+            text,
+            match.start,
+            match.end,
+            normalization,
+            config
+          );
+          if (cost.widthVariants > config.maxWidthVariants) continue;
+          if (cost.substitutions > config.maxSubstitutions) continue;
+          yield match;
+        }
+      },
+    },
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,9 @@
       "@scrawlix/core/repeated-obfuscated": [
         "packages/core/src/repeated-obfuscated.ts"
       ],
+      "@scrawlix/core/width-obfuscated": [
+        "packages/core/src/width-obfuscated.ts"
+      ],
       "@scrawlix/en": ["packages/en/src/index.ts"],
       "@scrawlix/en/corpus": ["packages/en/src/corpus.ts"],
       "@scrawlix/react": ["packages/react/src/index.tsx"],


### PR DESCRIPTION
## Summary
Add a dedicated, explicitly budgeted fullwidth-ASCII transform class as a focused core subpath.

- add `@scrawlix/core/width-obfuscated`
- add `censorRuleFromWidthObfuscatedTerms()`
- require caller-reviewed `widthVariants` mappings plus `maxWidthVariants`
- validate each mapping as the direct U+FF01–U+FF5E fullwidth ASCII form of one printable canonical ASCII grapheme
- reject circled letters, superscripts, ligatures, and arbitrary compatibility characters from this class
- keep width variants distinct from ordinary substitutions and reject source graphemes configured in both classes
- delegate exact source mapping, semantic targets, repetition semantics, boundaries, normalization, coverage, and profile metadata to the repeated/source-mapped matcher
- enforce width and ordinary-substitution budgets separately while `maxChanges` caps the total transform cost
- require an explicit total budget when width is combined with repetition, ordinary substitutions, or ignored graphemes
- add regressions for base matches, target variants inside/outside roots, separate class budgets, width+repetition totals, word-boundary negatives, strict compatibility validation, and mapping conflicts
- exercise the published subpath through installed-tarball runtime smoke

## Guardrail
This is intentionally narrower than NFKC compatibility folding. The helper recognizes only explicitly declared fullwidth ASCII source code points whose fixed Unicode offset maps to the declared canonical ASCII grapheme.

Progress on #38
Next: dogfood reviewed fullwidth variants in the opt-in English aggressive pack with corpus positives and clean combined-budget/boundary cases.