### PR TITLE
Add reviewed fullwidth variants to the English aggressive pack

### DIFF
--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
         replacement: workspaceFile('../../packages/en/src/index.ts'),
       },
       {
+        find: '@scrawlix/core/width-obfuscated',
+        replacement: workspaceFile('../../packages/core/src/width-obfuscated.ts'),
+      },
+      {
         find: '@scrawlix/core/repeated-obfuscated',
         replacement: workspaceFile(
           '../../packages/core/src/repeated-obfuscated.ts'

--- a/fixtures/consumer/runtime.mjs
+++ b/fixtures/consumer/runtime.mjs
@@ -67,6 +67,17 @@ assert.ok(
   )
 );
 
+const englishWidth = obfuscatedEngine.find('motherｆucker')[0];
+assert.equal(englishWidth?.text, 'motherｆucker');
+assert.equal(englishWidth?.targetText, 'ｆuck');
+assert.equal(englishWidth?.targetStart, 6);
+assert.equal(englishWidth?.targetEnd, 10);
+assert.ok(
+  englishObfuscatedProfanityCorpus.some(
+    testCase => testCase.id === 'obfuscated-width-fuck-mother-f'
+  )
+);
+
 const targetedEngine = createScrawlix({
   rules: [
     censorRuleFromTargetedObfuscatedTerms(

--- a/packages/en/README.md
+++ b/packages/en/README.md
@@ -43,7 +43,7 @@ The package also exports a separate aggressive pack:
 - `englishObfuscatedStrongProfanityRules`
 - `englishObfuscatedStrongProfanityPack`
 
-It catches a small reviewed set of one-change evasions across the same inflection and compound families declared by the canonical pack for `fuck`, `shit`, `bitch`, `asshole`, and `cunt`. Each candidate may use one reviewed symbol/digit substitution, one internal `.`, `-`, or zero-width-space insertion, **or** one excess repeated letter. The total budget stays one transform.
+It catches a small reviewed set of one-change evasions across the same inflection and compound families declared by the canonical pack for `fuck`, `shit`, `bitch`, `asshole`, and `cunt`. Each candidate may use one reviewed symbol/digit substitution, one internal `.`, `-`, or zero-width-space insertion, one excess repeated letter, **or** one reviewed fullwidth ASCII grapheme. The total budget stays one transform.
 
 ```ts
 import { createScrawlix, rulesFromPacks } from '@scrawlix/core';
@@ -60,13 +60,17 @@ const scrawlix = createScrawlix({
 });
 ```
 
-Examples include substitutions such as `f*ck` and `sh1t`, inserted separators such as `mother-fucker`, and bounded repetitions such as `fuuck`, `fuckking`, `motherfuucker`, `shittting`, `bittches`, `assshole`, and `cunnt`. Matches from this pack expose `profile: 'obfuscated'` and `packId: 'en-strong-profanity-obfuscated'` when composed through `rulesFromPacks()`.
+Examples include substitutions such as `f*ck` and `sh1t`, inserted separators such as `mother-fucker`, bounded repetitions such as `fuuck`, `fuckking`, `motherfuucker`, `shittting`, `bittches`, `assshole`, and `cunnt`, and reviewed fullwidth forms such as `ｆuck`, `fuckｉng`, `motherｆucker`, `bullshｉt`, `ｂitches`, `asshｏles`, and `cｕnts`.
 
-Full obfuscated forms preserve the canonical semantic root. For example, `f*cking` reports target text `f*ck`; `mother-fucker` targets `fuck`; `motherfuucker` targets `fuuck`; and `shittting` still targets `shit` because the excess `t` belongs to the final canonical `t` in the `shitting` run, outside the root boundary. Coverage therefore follows the same semantic profanity root as the canonical regex pack.
+Full obfuscated forms preserve the canonical semantic root. For example, `f*cking` targets `f*ck`; `mother-fucker` targets `fuck`; `motherfuucker` targets `fuuck`; `shittting` targets `shit`; `motherｆucker` targets `ｆuck`; and a fullwidth letter in a suffix such as `fuckｉng` stays outside the `fuck` target. Coverage therefore follows the same semantic profanity root as the canonical regex pack.
 
-Canonical repeated runs remain meaningful. The declared `ss` in `asshole` is the minimum accepted run; `assshole` consumes one repetition budget while `ashole` stays clean. Two excess letters, or a repetition combined with another transform, exceed this pack's one-change policy.
+Canonical repeated runs remain meaningful. The declared `ss` in `asshole` is the minimum accepted run; `assshole` consumes one repetition budget while `ashole` stays clean. Fullwidth mappings use a separate reviewed class limited to true U+FF01–U+FF5E forms. Circled and superscript compatibility characters stay outside this pack's width table.
 
-The reviewed tables and form families live in ordinary package code, and positive plus false-positive/over-budget cases live in JSON corpora. New aggressive behavior arrives with explicit corpus examples and ordinary-word/boundary negatives.
+The one-change ceiling applies across every aggressive class. Two fullwidth letters, a fullwidth letter plus a substitution, a fullwidth letter plus a repeat, or a fullwidth letter plus an inserted separator all exceed the pack policy.
+
+Matches from this pack expose `profile: 'obfuscated'` and `packId: 'en-strong-profanity-obfuscated'` when composed through `rulesFromPacks()`.
+
+The reviewed tables and form families live in ordinary package code, and positive plus false-positive/over-budget cases live in JSON corpora. Width cases live in their own corpus files so reviewers can inspect that behavior independently.
 
 ## Regression data
 

--- a/packages/en/src/corpus-data/obfuscated-width-clean.json
+++ b/packages/en/src/corpus-data/obfuscated-width-clean.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "obfuscated-width-clean-two-widths",
+    "text": "ｆｕck",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "width-variant", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-width-clean-width-plus-substitution",
+    "text": "ｆ*ck",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "width-variant", "substitution", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-width-clean-width-plus-repeat",
+    "text": "ｆuuck",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "width-variant", "repetition", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-width-clean-width-plus-separator",
+    "text": "ｆu-ck",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "width-variant", "punctuation-insertion", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-width-clean-fuckery-boundary",
+    "text": "ｆuckery",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "width-variant", "word-boundary"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-width-clean-country",
+    "text": "cｕntry",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "width-variant", "word-boundary", "ordinary-word"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-width-clean-asshole-under-run",
+    "text": "aｓhole",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "width-variant", "canonical-double"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-width-clean-circled-f",
+    "text": "ⓕuck",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "compatibility-character"],
+    "note": "General NFKC compatibility characters stay outside the reviewed fullwidth ASCII class.",
+    "matches": []
+  }
+]

--- a/packages/en/src/corpus-data/obfuscated-width.json
+++ b/packages/en/src/corpus-data/obfuscated-width.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "obfuscated-width-fuck-f",
+    "text": "ｆuck",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "width-variant"],
+    "matches": [
+      {
+        "ruleId": "fuck-obfuscated",
+        "text": "ｆuck",
+        "start": 0,
+        "end": 4,
+        "targetText": "ｆuck",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-width-fuck-suffix-i",
+    "text": "fuckｉng",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "width-variant", "inflection", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "fuck-obfuscated",
+        "text": "fuckｉng",
+        "start": 0,
+        "end": 7,
+        "targetText": "fuck",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-width-fuck-mother-f",
+    "text": "motherｆucker",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "width-variant", "compound", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "fuck-obfuscated",
+        "text": "motherｆucker",
+        "start": 0,
+        "end": 12,
+        "targetText": "ｆuck",
+        "targetStart": 6,
+        "targetEnd": 10
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-width-shit-i",
+    "text": "shｉt",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "width-variant"],
+    "matches": [
+      {
+        "ruleId": "shit-obfuscated",
+        "text": "shｉt",
+        "start": 0,
+        "end": 4,
+        "targetText": "shｉt",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-width-shit-bull-i",
+    "text": "bullshｉt",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "width-variant", "compound", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "shit-obfuscated",
+        "text": "bullshｉt",
+        "start": 0,
+        "end": 8,
+        "targetText": "shｉt",
+        "targetStart": 4,
+        "targetEnd": 8
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-width-bitch-plural-b",
+    "text": "ｂitches",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "width-variant", "plural", "inflection", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "bitch-obfuscated",
+        "text": "ｂitches",
+        "start": 0,
+        "end": 7,
+        "targetText": "ｂitch",
+        "targetStart": 0,
+        "targetEnd": 5
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-width-asshole-plural-o",
+    "text": "asshｏles",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "width-variant", "plural", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "asshole-obfuscated",
+        "text": "asshｏles",
+        "start": 0,
+        "end": 8,
+        "targetText": "asshｏle",
+        "targetStart": 0,
+        "targetEnd": 7
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-width-cunt-plural-u",
+    "text": "cｕnts",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "width-variant", "plural", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "cunt-obfuscated",
+        "text": "cｕnts",
+        "start": 0,
+        "end": 5,
+        "targetText": "cｕnt",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  }
+]

--- a/packages/en/src/corpus.ts
+++ b/packages/en/src/corpus.ts
@@ -1,5 +1,7 @@
 import cleanCorpus from './corpus-data/clean.json' with { type: 'json' };
 import obfuscatedCleanCorpus from './corpus-data/obfuscated-clean.json' with { type: 'json' };
+import obfuscatedWidthCleanCorpus from './corpus-data/obfuscated-width-clean.json' with { type: 'json' };
+import obfuscatedWidthCorpus from './corpus-data/obfuscated-width.json' with { type: 'json' };
 import obfuscatedCorpus from './corpus-data/obfuscated.json' with { type: 'json' };
 import profanityCorpus from './corpus-data/profanity.json' with { type: 'json' };
 
@@ -33,10 +35,14 @@ export const englishProfanityCorpus: readonly EnglishCorpusCase[] =
 /** Cases that contain suspicious substrings or boundaries but should stay clean. */
 export const englishCleanCorpus: readonly EnglishCorpusCase[] = cleanCorpus;
 
-/** Positive cases for the opt-in bounded English obfuscated base-form pack. */
-export const englishObfuscatedProfanityCorpus: readonly EnglishCorpusCase[] =
-  obfuscatedCorpus;
+/** Positive cases for the opt-in bounded English obfuscated pack. */
+export const englishObfuscatedProfanityCorpus: readonly EnglishCorpusCase[] = [
+  ...obfuscatedCorpus,
+  ...obfuscatedWidthCorpus,
+];
 
 /** False-positive and over-budget cases for the opt-in obfuscated pack. */
-export const englishObfuscatedCleanCorpus: readonly EnglishCorpusCase[] =
-  obfuscatedCleanCorpus;
+export const englishObfuscatedCleanCorpus: readonly EnglishCorpusCase[] = [
+  ...obfuscatedCleanCorpus,
+  ...obfuscatedWidthCleanCorpus,
+];

--- a/packages/en/src/index.test.ts
+++ b/packages/en/src/index.test.ts
@@ -83,6 +83,9 @@ describe('@scrawlix/en', () => {
       '[fuckk]ing mother[fuuck]er'
     );
     expect(marked(obfuscatedEngine.segment('shittting'))).toBe('[shit]tting');
+    expect(marked(obfuscatedEngine.segment('fuckｉng motherｆucker'))).toBe(
+      '[fuck]ｉng mother[ｆuck]er'
+    );
   });
 
   it('exports composable canonical and opt-in obfuscated packs', () => {

--- a/packages/en/src/index.ts
+++ b/packages/en/src/index.ts
@@ -4,8 +4,8 @@ import {
   type CensorRulePack,
   type CoverageSelector,
 } from '@scrawlix/core';
-import { censorRuleFromRepeatedObfuscatedTerms } from '@scrawlix/core/repeated-obfuscated';
 import type { TargetedObfuscatedTerm } from '@scrawlix/core/targeted-obfuscated';
+import { censorRuleFromWidthObfuscatedTerms } from '@scrawlix/core/width-obfuscated';
 
 /**
  * Covers orthographic English vowels (a/e/i/o/u) inside the semantic target.
@@ -67,6 +67,28 @@ export const englishStrongProfanityPack: CensorRulePack = {
 
 const englishObfuscatedIgnored = ['.', '-', '\u200B'] as const;
 
+const englishObfuscatedWidthVariants = {
+  a: ['ａ'],
+  b: ['ｂ'],
+  c: ['ｃ'],
+  d: ['ｄ'],
+  e: ['ｅ'],
+  f: ['ｆ'],
+  g: ['ｇ'],
+  h: ['ｈ'],
+  i: ['ｉ'],
+  k: ['ｋ'],
+  l: ['ｌ'],
+  m: ['ｍ'],
+  n: ['ｎ'],
+  o: ['ｏ'],
+  r: ['ｒ'],
+  s: ['ｓ'],
+  t: ['ｔ'],
+  u: ['ｕ'],
+  y: ['ｙ'],
+} as const;
+
 function targetedForms(
   target: string,
   forms: readonly string[]
@@ -121,65 +143,76 @@ const englishCuntForms = targetedForms('cunt', ['cunt', 'cunts']);
  * Conservative opt-in evasions mirroring the canonical pack's declared forms.
  *
  * Each candidate may use one reviewed substitution, one reviewed internal
- * separator/zero-width insertion, or one excess repeated letter. The combined
- * budget remains one transform. Full inflections/compounds are matched while
- * coverage and target metadata stay attached to the canonical profanity root.
+ * separator/zero-width insertion, one excess repeated letter, or one reviewed
+ * fullwidth ASCII grapheme. The combined budget remains one transform. Full
+ * inflections/compounds are matched while coverage and target metadata stay
+ * attached to the canonical profanity root.
  */
 export const englishObfuscatedStrongProfanityRules: readonly CensorRule[] = [
-  censorRuleFromRepeatedObfuscatedTerms('fuck-obfuscated', englishFuckForms, {
+  censorRuleFromWidthObfuscatedTerms('fuck-obfuscated', englishFuckForms, {
     substitutions: {
       u: ['*'],
       c: ['('],
     },
+    widthVariants: englishObfuscatedWidthVariants,
     ignored: englishObfuscatedIgnored,
     maxSubstitutions: 1,
     maxIgnored: 1,
     maxRepetitions: 1,
+    maxWidthVariants: 1,
     maxChanges: 1,
   }),
-  censorRuleFromRepeatedObfuscatedTerms('shit-obfuscated', englishShitForms, {
+  censorRuleFromWidthObfuscatedTerms('shit-obfuscated', englishShitForms, {
     substitutions: {
       s: ['$', '5'],
       i: ['1', '!', '*'],
       t: ['7'],
     },
+    widthVariants: englishObfuscatedWidthVariants,
     ignored: englishObfuscatedIgnored,
     maxSubstitutions: 1,
     maxIgnored: 1,
     maxRepetitions: 1,
+    maxWidthVariants: 1,
     maxChanges: 1,
   }),
-  censorRuleFromRepeatedObfuscatedTerms('bitch-obfuscated', englishBitchForms, {
+  censorRuleFromWidthObfuscatedTerms('bitch-obfuscated', englishBitchForms, {
     substitutions: {
       i: ['1', '!', '*'],
       t: ['7'],
     },
+    widthVariants: englishObfuscatedWidthVariants,
     ignored: englishObfuscatedIgnored,
     maxSubstitutions: 1,
     maxIgnored: 1,
     maxRepetitions: 1,
+    maxWidthVariants: 1,
     maxChanges: 1,
   }),
-  censorRuleFromRepeatedObfuscatedTerms('asshole-obfuscated', englishAssholeForms, {
+  censorRuleFromWidthObfuscatedTerms('asshole-obfuscated', englishAssholeForms, {
     substitutions: {
       a: ['@'],
       s: ['$', '5'],
       o: ['0'],
     },
+    widthVariants: englishObfuscatedWidthVariants,
     ignored: englishObfuscatedIgnored,
     maxSubstitutions: 1,
     maxIgnored: 1,
     maxRepetitions: 1,
+    maxWidthVariants: 1,
     maxChanges: 1,
   }),
-  censorRuleFromRepeatedObfuscatedTerms('cunt-obfuscated', englishCuntForms, {
+  censorRuleFromWidthObfuscatedTerms('cunt-obfuscated', englishCuntForms, {
     substitutions: {
       u: ['*'],
     },
+    widthVariants: englishObfuscatedWidthVariants,
     ignored: englishObfuscatedIgnored,
     maxSubstitutions: 1,
     maxIgnored: 1,
     maxRepetitions: 1,
+    maxWidthVariants: 1,
     maxChanges: 1,
   }),
 ] as const;


### PR DESCRIPTION
## Summary
Dogfood the reviewed fullwidth-ASCII helper in the opt-in English aggressive pack while keeping the global one-change policy.

- switch English aggressive rules to `censorRuleFromWidthObfuscatedTerms()`
- add an explicit fullwidth map only for ASCII letters that occur in the pack's declared forms
- add `maxWidthVariants: 1` while keeping `maxChanges: 1`, so each candidate may use one width variant OR one substitution OR one separator OR one excess repeat
- preserve all existing substitution/insertion/repetition behavior and semantic-root metadata
- keep width compatibility narrow: only reviewed U+FF01–U+FF5E forms are configured
- add a separate width corpus with 8 positive cases across bases, suffixes, compounds, plurals, and roots
- add a separate width-clean corpus with 8 regressions for two width variants, mixed transform budgets, word boundaries, canonical-double under-runs, ordinary `cｕntry`, and circled `ⓕuck`
- aggregate the new width corpus into the existing public aggressive corpus exports
- assert root-only coverage for width variants inside and outside semantic roots
- wire the demo source alias for `@scrawlix/core/width-obfuscated`
- exercise English fullwidth target metadata through installed-tarball runtime smoke

## Review expectation
`corpus:diff` should report exactly 16 new cases: 8 newly matching + 8 added clean regressions. Existing aggressive corpus cases should remain behaviorally unchanged.

## Guardrail
This pack reviews true fullwidth ASCII forms only. General NFKC compatibility characters remain outside the width table and are represented by explicit clean regressions.

Depends on merged #120.
Progress on #38