### PR TITLE
Prove extension policy and treatment survive browser restart

### DIFF
--- a/tests/browser/browser.spec.ts
+++ b/tests/browser/browser.spec.ts
@@ -27,6 +27,25 @@ async function launchExtensionContext(profilePath: string, unpackedPath: string)
   });
 }
 
+async function waitForPageRegistration(worker: import('@playwright/test').Worker) {
+  await expect
+    .poll(async () =>
+      worker.evaluate(async () => {
+        const scripts = await chrome.scripting.getRegisteredContentScripts({
+          ids: ['scrawlix-page'],
+        });
+        return {
+          matches: scripts[0]?.matches?.sort() ?? [],
+          runAt: scripts[0]?.runAt ?? null,
+        };
+      })
+    )
+    .toEqual({
+      matches: ['http://*/*', 'https://*/*'],
+      runAt: 'document_start',
+    });
+}
+
 test('demo controls drive real rendered coverage and reveal state', async ({ page }) => {
   await page.goto('http://127.0.0.1:4173');
 
@@ -68,22 +87,7 @@ test('built extension registers granted hosts and handles page interaction in Ch
 
   try {
     const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
-    await expect
-      .poll(async () =>
-        worker.evaluate(async () => {
-          const scripts = await chrome.scripting.getRegisteredContentScripts({
-            ids: ['scrawlix-page'],
-          });
-          return {
-            matches: scripts[0]?.matches?.sort() ?? [],
-            runAt: scripts[0]?.runAt ?? null,
-          };
-        })
-      )
-      .toEqual({
-        matches: ['http://*/*', 'https://*/*'],
-        runAt: 'document_start',
-      });
+    await waitForPageRegistration(worker);
 
     const page = context.pages()[0] ?? (await context.newPage());
     await page.goto('http://127.0.0.1:4174/fixture.html');
@@ -237,6 +241,11 @@ test('built extension persists forced-host policy and treatment across browser r
     const worker =
       firstContext.serviceWorkers()[0] ??
       (await firstContext.waitForEvent('serviceworker'));
+    // This synthetic fresh profile starts with broad host access promoted into the test
+    // manifest. Wait for the worker to mirror those pre-granted patterns into the same
+    // dynamic registration production creates immediately after a runtime grant.
+    await waitForPageRegistration(worker);
+
     const page = firstContext.pages()[0] ?? (await firstContext.newPage());
     await page.goto('http://127.0.0.1:4174/fixture.html');
 
@@ -311,13 +320,16 @@ test('built extension persists forced-host policy and treatment across browser r
     await firstContext.close();
   }
 
-  // Relaunch Chromium against the exact same persistent profile: sync/local settings and
-  // dynamic registration must reconstruct the same effective page behavior.
+  // Relaunch Chromium against the exact same persistent profile. The persisted dynamic
+  // registration must be available before navigation, and sync/local state must restore
+  // the same effective page behavior.
   const secondContext = await launchExtensionContext(profilePath, testExtensionPath);
   try {
     const worker =
       secondContext.serviceWorkers()[0] ??
       (await secondContext.waitForEvent('serviceworker'));
+    await waitForPageRegistration(worker);
+
     const page = secondContext.pages()[0] ?? (await secondContext.newPage());
     await page.goto('http://127.0.0.1:4174/fixture.html');
 

--- a/tests/browser/browser.spec.ts
+++ b/tests/browser/browser.spec.ts
@@ -16,6 +16,17 @@ function extensionWithPregrantedHosts(outputPath: string) {
   return outputPath;
 }
 
+async function launchExtensionContext(profilePath: string, unpackedPath: string) {
+  return chromium.launchPersistentContext(profilePath, {
+    channel: 'chromium',
+    headless: true,
+    args: [
+      `--disable-extensions-except=${unpackedPath}`,
+      `--load-extension=${unpackedPath}`,
+    ],
+  });
+}
+
 test('demo controls drive real rendered coverage and reveal state', async ({ page }) => {
   await page.goto('http://127.0.0.1:4173');
 
@@ -50,16 +61,9 @@ test('built extension registers granted hosts and handles page interaction in Ch
   const testExtensionPath = extensionWithPregrantedHosts(
     testInfo.outputPath('extension-under-test')
   );
-  const context = await chromium.launchPersistentContext(
+  const context = await launchExtensionContext(
     testInfo.outputPath('extension-profile'),
-    {
-      channel: 'chromium',
-      headless: true,
-      args: [
-        `--disable-extensions-except=${testExtensionPath}`,
-        `--load-extension=${testExtensionPath}`,
-      ],
-    }
+    testExtensionPath
   );
 
   try {
@@ -219,5 +223,126 @@ test('built extension registers granted hosts and handles page interaction in Ch
     await expect(page.locator('#clicked')).toHaveText('native link worked');
   } finally {
     await context.close();
+  }
+});
+
+test('built extension persists forced-host policy and treatment across browser restart', async ({}, testInfo) => {
+  const testExtensionPath = extensionWithPregrantedHosts(
+    testInfo.outputPath('state-extension-under-test')
+  );
+  const profilePath = testInfo.outputPath('state-extension-profile');
+
+  const firstContext = await launchExtensionContext(profilePath, testExtensionPath);
+  try {
+    const worker =
+      firstContext.serviceWorkers()[0] ??
+      (await firstContext.waitForEvent('serviceworker'));
+    const page = firstContext.pages()[0] ?? (await firstContext.newPage());
+    await page.goto('http://127.0.0.1:4174/fixture.html');
+
+    const root = page.locator('#initial [data-scrawlix-dom-root]');
+    await expect(root).toHaveCount(1);
+
+    // Default-off + forced-on is the allowlist configuration. Keep it active while
+    // changing treatment so global/default changes cannot accidentally tear it down.
+    await worker.evaluate(async () => {
+      await chrome.storage.sync.set({
+        scrawlixSettings: {
+          paused: false,
+          enabled: false,
+          appearance: 'bar',
+          coverage: 'full',
+          reveal: 'never',
+        },
+      });
+      await chrome.storage.local.set({
+        scrawlixSiteOverrides: { '127.0.0.1': 'on' },
+      });
+    });
+
+    await expect(root).toHaveAttribute('data-scrawlix-appearance', 'bar');
+    await expect(root).toHaveAttribute('data-scrawlix-reveal', 'never');
+    await expect(page.locator('#initial [data-scrawlix-cover]')).toHaveText('fuck');
+
+    await page.evaluate(() => {
+      (window as typeof window & { __scrawlixRoot?: Element | null }).__scrawlixRoot =
+        document.querySelector('#initial [data-scrawlix-dom-root]');
+    });
+
+    await worker.evaluate(async () => {
+      const stored = (await chrome.storage.sync.get('scrawlixSettings'))
+        .scrawlixSettings as Record<string, unknown>;
+      await chrome.storage.sync.set({
+        scrawlixSettings: { ...stored, appearance: 'blur' },
+      });
+    });
+
+    await expect(root).toHaveAttribute('data-scrawlix-appearance', 'blur');
+    expect(
+      await page.evaluate(() => {
+        const saved = (window as typeof window & { __scrawlixRoot?: Element | null })
+          .__scrawlixRoot;
+        return saved === document.querySelector('#initial [data-scrawlix-dom-root]');
+      })
+    ).toBe(true);
+
+    // Master pause wins even over an explicit forced-on hostname and restores exact source.
+    await worker.evaluate(async () => {
+      const stored = (await chrome.storage.sync.get('scrawlixSettings'))
+        .scrawlixSettings as Record<string, unknown>;
+      await chrome.storage.sync.set({
+        scrawlixSettings: { ...stored, paused: true },
+      });
+    });
+    await expect(root).toHaveCount(0);
+    await expect(page.locator('#initial')).toHaveText('well, fuck this');
+
+    await worker.evaluate(async () => {
+      const stored = (await chrome.storage.sync.get('scrawlixSettings'))
+        .scrawlixSettings as Record<string, unknown>;
+      await chrome.storage.sync.set({
+        scrawlixSettings: { ...stored, paused: false },
+      });
+    });
+    await expect(root).toHaveCount(1);
+    await expect(root).toHaveAttribute('data-scrawlix-appearance', 'blur');
+    await expect(page.locator('#initial [data-scrawlix-cover]')).toHaveText('fuck');
+  } finally {
+    await firstContext.close();
+  }
+
+  // Relaunch Chromium against the exact same persistent profile: sync/local settings and
+  // dynamic registration must reconstruct the same effective page behavior.
+  const secondContext = await launchExtensionContext(profilePath, testExtensionPath);
+  try {
+    const worker =
+      secondContext.serviceWorkers()[0] ??
+      (await secondContext.waitForEvent('serviceworker'));
+    const page = secondContext.pages()[0] ?? (await secondContext.newPage());
+    await page.goto('http://127.0.0.1:4174/fixture.html');
+
+    const root = page.locator('#initial [data-scrawlix-dom-root]');
+    await expect(root).toHaveCount(1);
+    await expect(root).toHaveAttribute('data-scrawlix-appearance', 'blur');
+    await expect(root).toHaveAttribute('data-scrawlix-reveal', 'never');
+    await expect(page.locator('#initial [data-scrawlix-cover]')).toHaveText('fuck');
+
+    const stored = await worker.evaluate(async () => {
+      const sync = (await chrome.storage.sync.get('scrawlixSettings')).scrawlixSettings;
+      const local = (await chrome.storage.local.get('scrawlixSiteOverrides'))
+        .scrawlixSiteOverrides;
+      return { sync, local };
+    });
+
+    expect(stored.sync).toEqual({
+      paused: false,
+      enabled: false,
+      appearance: 'blur',
+      coverage: 'full',
+      reveal: 'never',
+    });
+    expect(stored.local).toEqual({ '127.0.0.1': 'on' });
+  } finally {
+    await secondContext.close();
   }
 });


### PR DESCRIPTION
## What changed

Add a dedicated real-Chromium regression for the extension state edge case that originally motivated the browser-product review.

The test:

- launches Scrawlix with a persistent Chromium profile
- waits for the fresh-profile dynamic registration before navigation, mirroring the production post-grant path
- configures **default sites off** plus a forced-on `127.0.0.1` hostname override
- sets full coverage / bar treatment / hidden reveal
- changes appearance to blur while the forced-on host remains effective and proves the exact generated DOM root identity is preserved (presentation-only redecorate)
- turns on the true master pause and proves Scrawlix restores the exact source text
- unpauses and proves the forced-on host returns with the previous treatment
- closes Chromium completely
- relaunches against the exact same browser profile
- verifies dynamic registration before navigation
- proves the forced-on host, default-off policy, blur/full/hidden treatment, local hostname override, and hostname-free synced settings all survive restart

## Why

This gives the global/default-off + per-host override + appearance-change + browser-restart path a browser-level proof instead of relying only on pure reconciliation/storage unit tests.

## Validation

CI is green on the final head:

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Chromium demo smoke
- Chromium extension smoke, including the two-launch persistent-profile state regression
- `pnpm smoke:packages`

## Stack

This PR is intentionally based on `copper/coverage-contract` / #125 and changes only browser regression coverage.

Progresses #48 and #23.