### PR TITLE
Add a cold-adopter troubleshooting path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added compiled ESM/declaration artifacts for public packages.
 - Added external tarball consumer smoke tests as a CI release gate, with strict declaration checking, React 18/19 production builds, and a Next.js 16 App Router production build using the documented client-wrapper boundary.
 - Added package-local READMEs for every public package, exact install commands, a top-level integration chooser, a docs index, React CSS troubleshooting, Next.js client-boundary guidance, and clearer source/accessibility notes.
+- Added a symptom-first troubleshooting guide covering matching, CSS, App Router boundaries, DOM observation/exclusions, grapheme-expanded coverage, public subpaths, and packed-package diagnosis.
 - Added a framework-neutral renderer recipe with plain-DOM, Vue, Svelte, and Solid sketches plus a threshold for when a dedicated adapter package is worth maintaining.
 - Added explicit runtime compatibility and pre-1.0 versioning/public-contract policies.
 - Declared Node 18+ in every public package manifest and Node 22+ in the private workspace manifest so package-manager metadata matches the documented runtime/tooling baselines.

--- a/apps/demo/public/llms.txt
+++ b/apps/demo/public/llms.txt
@@ -78,6 +78,13 @@ Framework-neutral renderer rule:
 - A dedicated adapter package is justified when it owns reusable framework-specific interaction, accessibility, lifecycle/restoration, SSR/client-boundary behavior, plugin integration, or a tested DOM/CSS contract. A simple segment loop belongs in application code/docs.
 - Custom renderers preserve source text unless they explicitly implement separate sanitized-output semantics; do not market a CSS cover as destructive redaction.
 
+Troubleshooting rule:
+- When output surprises you, inspect `engine.find(text)` before changing rendering code. Empty match output points toward rule selection/boundary/profile issues; correct matches with bad presentation point toward the adapter/CSS/lifecycle layer.
+- Duplicated or visibly uncovered React source usually means `@scrawlix/react/styles.css` is missing.
+- Next.js serialization errors mean rule selection crossed the Server-to-Client boundary; keep RegExp/function-based rules inside a Client Component.
+- DOM `observe()` requires `MutationObserver`; one-time transforms can use `apply()`.
+- Use `docs/troubleshooting.md` for the full symptom-first guide.
+
 Custom terms and phrases:
 
 ```ts
@@ -126,6 +133,7 @@ The browser extension keeps browser state outside reusable packages. Global trea
 
 Use only documented public package exports. Maintainer guidance: https://github.com/teamleaderleo/scrawlix/blob/main/AGENTS.md
 Docs index: https://github.com/teamleaderleo/scrawlix/blob/main/docs/README.md
+Troubleshooting: https://github.com/teamleaderleo/scrawlix/blob/main/docs/troubleshooting.md
 Custom renderers: https://github.com/teamleaderleo/scrawlix/blob/main/docs/custom-renderers.md
 Compatibility: https://github.com/teamleaderleo/scrawlix/blob/main/docs/compatibility.md
 Versioning: https://github.com/teamleaderleo/scrawlix/blob/main/docs/versioning.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ Start with the repository README for installation and the shortest path for your
 
 ## Recipes and design notes
 
+- [`troubleshooting.md`](./troubleshooting.md) — symptom-first diagnostics for matching, React CSS, Next.js boundaries, DOM observation/exclusions, coverage ranges, and package imports
 - [`compatibility.md`](./compatibility.md) — JavaScript/browser capabilities, Node baseline, React majors, grapheme fallback, DOM/CSS/TypeScript expectations
 - [`versioning.md`](./versioning.md) — synchronized release train, 0.x semver policy, public data/CSS contracts, and deprecation rules
 - [`privacy-and-output.md`](./privacy-and-output.md) — visual covers, presentation/screenshot guarantees, accessibility policy, and sanitized export semantics

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,181 @@
+# Troubleshooting Scrawlix
+
+Start here when an integration compiles but the result looks wrong, nothing matches, or a framework/runtime rejects the setup.
+
+## React text is duplicated or visibly uncovered
+
+The built-in React renderer requires its stylesheet:
+
+```ts
+import '@scrawlix/react/styles.css';
+```
+
+That file owns both the built-in appearances and the visually-hidden accessibility source copy. Import it once from the application's global CSS/entry path.
+
+For Next.js App Router, import the stylesheet from the root layout or another allowed global CSS entry.
+
+## Nothing matches
+
+Scrawlix selects rules explicitly. `createScrawlix()` with zero rules is a no-op.
+
+Check matching before debugging rendering:
+
+```ts
+const engine = createScrawlix({ rules });
+console.log(engine.find(text));
+```
+
+If `find()` returns no matches:
+
+1. confirm the intended rule collection is actually passed to the engine/adapter
+2. inspect the exact input string
+3. check the rule's boundary, normalization, and matching profile
+4. for a language pack, compare the input with its documented corpus/scope
+
+For packaged English strong profanity:
+
+```ts
+import { englishStrongProfanityRules } from '@scrawlix/en';
+
+const engine = createScrawlix({
+  rules: englishStrongProfanityRules,
+});
+```
+
+## A custom term matches or misses at an edge
+
+`censorRuleFromTerms()` uses Unicode-aware word context and NFC canonical equivalence by default.
+
+```ts
+const rule = censorRuleFromTerms('private', ['Project Velvet']);
+```
+
+Useful boundary choices include:
+
+- default / `unicode-word` — keep a candidate separate from surrounding Unicode word context
+- `substring` — allow direct adjacency deliberately
+- `locale-word` — use pack-selected locale segmentation where lexical boundaries require it
+
+If exact canonical form should matter, use the helper's explicit normalization option instead of relying on the NFC default.
+
+For aggressive spellings, keep canonical and obfuscated rules explicit. Inspect `match.profile` from `find()` when you need to know which matching path fired.
+
+## Coverage looks wider than the callback requested
+
+Scrawlix guarantees that exposed covered ranges stay on extended-grapheme boundaries. A custom coverage callback may return UTF-16 offsets inside a grapheme; core expands those edges to the surrounding grapheme boundary before segmentation.
+
+Use `graphemeRanges()` from core when authoring character-sensitive coverage logic:
+
+```ts
+import { graphemeRanges } from '@scrawlix/core';
+```
+
+For the simplest cross-runtime behavior, `coverage: 'full'` covers the complete semantic target.
+
+## Next.js says props are not serializable
+
+Scrawlix rules contain `RegExp` values, and coverage selectors can be functions. Keep rule selection inside an application-owned Client Component.
+
+```tsx
+// app/ScrawlixText.tsx
+'use client';
+
+import { englishStrongProfanityRules } from '@scrawlix/en';
+import { CensoredText } from '@scrawlix/react';
+
+export function ScrawlixText({ text }: { text: string }) {
+  return <CensoredText text={text} rules={englishStrongProfanityRules} />;
+}
+```
+
+A Server Component can pass serializable values such as `text` to that wrapper. The packed-package release gate production-builds this pattern.
+
+## `createDomScrawlix().observe()` throws about `MutationObserver`
+
+`observe()` requires a browser-like DOM whose root document exposes `defaultView.MutationObserver`.
+
+If you only need a one-time transformation, use:
+
+```ts
+const controller = createDomScrawlix({ rules });
+controller.apply(root);
+```
+
+Use `observe()` for live page mutations. Call the observation handle's `restore()` when disabling an active observed session so observation stops before source text returns.
+
+## DOM or rehype leaves some content untouched
+
+Both adapters have safe default exclusions.
+
+The rehype adapter skips code/pre/script/style/textarea-like prose regions by default. The DOM adapter also skips form/editable/code-like regions, non-HTML namespaces, and generated Scrawlix output.
+
+Application-owned escape hatch:
+
+```html
+<div data-scrawlix-ignore>...</div>
+```
+
+Both adapters also expose explicit exclusion/custom-skip options. Check those before treating a skipped subtree as a matcher failure.
+
+## A DOM page was transformed twice or restoration touched the wrong node
+
+Use one controller/session for the lifecycle you own. `@scrawlix/dom` marks generated roots and tracks ownership so repeated application by the same controller remains idempotent and restoration only replaces roots that controller created.
+
+For active observation, prefer:
+
+```ts
+const observation = controller.observe(document.body);
+// later
+observation.restore();
+```
+
+That operation disconnects, clears queued work, and restores owned source text as one lifecycle action.
+
+## An import or subpath fails
+
+Use documented package exports rather than reaching into `dist` or source paths.
+
+Canonical public imports include:
+
+```ts
+import { createScrawlix } from '@scrawlix/core';
+import { englishStrongProfanityRules } from '@scrawlix/en';
+import { englishProfanityCorpus } from '@scrawlix/en/corpus';
+import { CensoredText } from '@scrawlix/react';
+import '@scrawlix/react/styles.css';
+import { rehypeScrawlix } from '@scrawlix/rehype';
+import { createDomScrawlix } from '@scrawlix/dom';
+```
+
+Core also exposes focused documented subpaths for advanced matching helpers. Check the current core package README before inventing a deep import.
+
+## The package works in the workspace but fails after packing
+
+Run the same release gate used by CI:
+
+```sh
+pnpm smoke:packages
+```
+
+It packs all public packages, validates map/source targets inside each tarball, installs packed artifacts into external React 18/19 consumers, executes runtime checks, typechecks declarations, production-builds both React majors, and production-builds the Next.js App Router fixture.
+
+A workspace-only import can pass ordinary repository typechecking while failing this gate. Treat the packed-package result as the public-package truth.
+
+## The visible cover is being treated as secure redaction
+
+Scrawlix's ordinary React/DOM/rehype rendering preserves caller-owned source text by design. Visual covers are reversible presentation.
+
+Read [`privacy-and-output.md`](./privacy-and-output.md) when the use case involves screenshots, assistive technology, copied/serialized output, or sanitized export. Choose an output guarantee explicitly instead of inferring one from appearance.
+
+## Still stuck
+
+When opening an issue, include:
+
+- package(s) and versions
+- runtime/framework and version
+- a minimal source string
+- the exact rules/options involved
+- `engine.find(text)` output when the problem concerns matching
+- whether the failure reproduces with packed/registry packages
+
+Small reproducible inputs are especially useful for matcher and corpus bugs.

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -33,4 +33,4 @@ The adapter transforms only matching eligible text nodes. It skips form/editable
 
 This package emits semantic wrappers and `data-scrawlix-cover` / `data-scrawlix-rules` attributes. Presentation belongs to the consuming application.
 
-See `docs/dom.md` in the repository for lifecycle, exclusion, and restoration details.
+See the [DOM lifecycle guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/dom.md) for observation, exclusions, and restoration details. For `MutationObserver`, skipped-subtree, or lifecycle diagnostics, use the [troubleshooting guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/troubleshooting.md).

--- a/packages/en/README.md
+++ b/packages/en/README.md
@@ -83,4 +83,4 @@ import {
 
 The current package is intentionally narrow strong-profanity coverage. It is a reviewable set of English rules and aggressive examples, with explicit corpus evidence for the scope it claims.
 
-See `docs/language-packs.md` in the repository for authoring, composition, boundary, Unicode, and obfuscation guidance.
+See the [language-pack guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/language-packs.md) for authoring, composition, boundary, Unicode, and obfuscation guidance. For edge/boundary or no-match diagnostics, use the [troubleshooting guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/troubleshooting.md).

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -91,4 +91,6 @@ import '@scrawlix/react/styles.css';
 
 The repository's packed-package smoke suite installs a real Next.js App Router fixture and production-builds this client-wrapper path, so the documented boundary is release-gated.
 
+For first-use failures such as duplicated text, no matches, or App Router serialization errors, see the [Scrawlix troubleshooting guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/troubleshooting.md).
+
 See the repository README for core, rehype, and arbitrary-DOM paths.

--- a/packages/rehype/README.md
+++ b/packages/rehype/README.md
@@ -32,4 +32,4 @@ Covered fragments become spans carrying `data-scrawlix-cover` and `data-scrawlix
 
 For direct HAST use, import `transformHast`.
 
-See the root README for the adapter chooser and `docs/language-packs.md` for rule-pack authoring.
+See the repository README for the adapter chooser and the [language-pack guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/language-packs.md) for rule-pack authoring. For skipped-subtree or no-match diagnostics, use the [troubleshooting guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/troubleshooting.md).


### PR DESCRIPTION
## Summary

Turns the most common first-integration failures into one symptom-first guide.

### Diagnostics covered
- duplicated/uncovered React output → required stylesheet
- no matches → inspect `engine.find(text)` before renderer code
- custom-term edge surprises → boundary / normalization / profile choices
- custom coverage widening → extended-grapheme boundary guarantee
- Next.js serialization errors → keep rule packs inside the Client Component boundary
- DOM `observe()` / `MutationObserver` failures → choose `apply()` vs live observation
- DOM/rehype skipped content → default exclusions and `data-scrawlix-ignore`
- public import/subpath failures → documented exports only
- workspace success but package failure → run `pnpm smoke:packages`
- visual cover vs sanitized-output expectations → explicit privacy/output guidance

### Discovery
- link from the docs index
- add an agent troubleshooting rule + canonical URL to `llms.txt`
- link React, DOM, rehype, and English npm-facing READMEs to the guide
- replace monorepo-relative README links in those package pages with registry-safe GitHub links

No runtime/API changes.

Closes #113.