### PR TITLE
Add explicitly reviewed Unicode confusables

### DIFF
--- a/docs/confusable-matching.md
+++ b/docs/confusable-matching.md
@@ -1,0 +1,62 @@
+# Reviewed Unicode confusable matching
+
+Scrawlix treats Unicode confusable matching as an explicit pack-owned policy, not as a universal text normalization step.
+
+Use the focused core subpath when a pack has reviewed specific single-grapheme lookalikes:
+
+```ts
+import { createScrawlix } from '@scrawlix/core';
+import { censorRuleFromConfusableObfuscatedTerms } from '@scrawlix/core/confusable-obfuscated';
+
+const rule = censorRuleFromConfusableObfuscatedTerms(
+  'example-confusable',
+  [{ term: 'motherfucker', target: 'fuck' }],
+  {
+    confusables: {
+      c: ['с'], // Cyrillic small es, U+0441
+    },
+    maxConfusables: 1,
+    maxRepetitions: 0,
+  }
+);
+
+const engine = createScrawlix({ rules: [rule] });
+engine.find('motherfuсker')[0]?.targetText; // "fuсk"
+```
+
+## Contract
+
+`confusables` reads as canonical grapheme → explicitly reviewed source graphemes. Every key and value must be exactly one extended grapheme. A match keeps exact UTF-16 ranges into the original caller-owned source string and preserves semantic targets, boundary policy, coverage, normalization, and `profile: 'obfuscated'`.
+
+`maxConfusables` is always explicit. Confusables can be combined with the existing substitution, ignored-grapheme, repeated-letter, and reviewed fullwidth classes. Each class keeps its own budget, and `maxChanges` is required whenever confusables are combined with another transform class.
+
+## Compatibility forms stay separate
+
+This helper deliberately avoids Unicode confusable skeleton generation and blanket compatibility folding.
+
+Direct fullwidth ASCII forms belong in `widthVariants`. Compatibility-equivalent characters such as circled letters, superscripts, and ligatures are rejected from the confusable class when NFKC collapses them to the declared canonical grapheme. This keeps compatibility policy independently reviewable instead of hiding it inside a broad lookalike transform.
+
+For example:
+
+- `c: ['с']` can be a reviewed confusable mapping when a pack chooses it.
+- `f: ['ｆ']` belongs in `widthVariants`.
+- `f: ['ⓕ']` is compatibility-equivalent and stays outside the confusable class unless a future reviewed compatibility policy explicitly owns it.
+
+## Unreviewed lookalikes stay clean
+
+The helper only applies mappings present in the pack. Reviewing Cyrillic `о` for canonical `o` does not implicitly enable Greek `ο`, mathematical alphabets, or other characters that resemble the same Latin letter.
+
+This narrow rule is intentional. Confusable matching has a large false-positive surface across languages and scripts, so packs should add each mapping alongside positive corpus evidence and ordinary-text negatives relevant to their audience.
+
+## Review checklist
+
+Before adding a confusable mapping:
+
+1. identify the exact source code point/grapheme and canonical target;
+2. verify the form is genuinely observed in the pack's evasion corpus;
+3. add a positive case that proves the intended match and exact source/target ranges;
+4. add clean neighboring words or multilingual text that could be caught accidentally;
+5. keep the class budget small and explicit;
+6. inspect `pnpm corpus:diff -- <base-ref>` before merge.
+
+Scrawlix core supplies source-safe execution. Language packs remain responsible for deciding which lookalikes are appropriate for their locale, register, and moderation policy.

--- a/fixtures/consumer/runtime.mjs
+++ b/fixtures/consumer/runtime.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { createScrawlix } from '@scrawlix/core';
+import { censorRuleFromConfusableObfuscatedTerms } from '@scrawlix/core/confusable-obfuscated';
 import { censorRuleFromRepeatedObfuscatedTerms } from '@scrawlix/core/repeated-obfuscated';
 import { censorRuleFromTargetedObfuscatedTerms } from '@scrawlix/core/targeted-obfuscated';
 import { censorRuleFromWidthObfuscatedTerms } from '@scrawlix/core/width-obfuscated';
@@ -126,6 +127,24 @@ const widthMatch = widthEngine.find('motherｆucker')[0];
 assert.equal(widthMatch?.text, 'motherｆucker');
 assert.equal(widthMatch?.targetText, 'ｆuck');
 assert.equal(widthMatch?.profile, 'obfuscated');
+
+const confusableEngine = createScrawlix({
+  rules: [
+    censorRuleFromConfusableObfuscatedTerms(
+      'confusable-smoke',
+      [{ term: 'motherfucker', target: 'fuck' }],
+      {
+        confusables: { c: ['с'] },
+        maxConfusables: 1,
+        maxRepetitions: 0,
+      }
+    ),
+  ],
+});
+const confusableMatch = confusableEngine.find('motherfuсker')[0];
+assert.equal(confusableMatch?.text, 'motherfuсker');
+assert.equal(confusableMatch?.targetText, 'fuсk');
+assert.equal(confusableMatch?.profile, 'obfuscated');
 
 const tree = {
   type: 'root',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,11 @@
       "types": "./dist/width-obfuscated.d.ts",
       "import": "./dist/width-obfuscated.js",
       "default": "./dist/width-obfuscated.js"
+    },
+    "./confusable-obfuscated": {
+      "types": "./dist/confusable-obfuscated.d.ts",
+      "import": "./dist/confusable-obfuscated.js",
+      "default": "./dist/confusable-obfuscated.js"
     }
   },
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,14 @@
     "node": ">=18"
   },
   "sideEffects": false,
-  "files": ["dist"],
+  "files": [
+    "dist",
+    "src/index.ts",
+    "src/targeted-obfuscated.ts",
+    "src/repeated-obfuscated.ts",
+    "src/width-obfuscated.ts",
+    "src/confusable-obfuscated.ts"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/core/src/confusable-obfuscated.test.ts
+++ b/packages/core/src/confusable-obfuscated.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+import { createScrawlix } from './index';
+import { censorRuleFromConfusableObfuscatedTerms } from './confusable-obfuscated';
+
+describe('confusable obfuscated terms', () => {
+  it('matches one explicitly reviewed cross-script confusable', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromConfusableObfuscatedTerms('fuck-confusable', ['fuck'], {
+          confusables: { c: ['с'] },
+          maxConfusables: 1,
+          maxRepetitions: 0,
+        }),
+      ],
+    });
+
+    expect(engine.find('fuсk')).toEqual([
+      {
+        ruleId: 'fuck-confusable',
+        profile: 'obfuscated',
+        text: 'fuсk',
+        start: 0,
+        end: 4,
+        targetText: 'fuсk',
+        targetStart: 0,
+        targetEnd: 4,
+      },
+    ]);
+    expect(engine.find('fuck')).toEqual([]);
+  });
+
+  it('preserves semantic roots for confusables inside and outside the target', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromConfusableObfuscatedTerms(
+          'fuck-confusable',
+          [
+            { term: 'motherfucker', target: 'fuck' },
+            { term: 'fucking', target: 'fuck' },
+          ],
+          {
+            confusables: { c: ['с'], i: ['і'] },
+            maxConfusables: 1,
+            maxRepetitions: 0,
+          }
+        ),
+      ],
+      coverage: 'full',
+    });
+
+    expect(engine.find('motherfuсker')[0]).toMatchObject({
+      text: 'motherfuсker',
+      targetText: 'fuсk',
+      targetStart: 6,
+      targetEnd: 10,
+    });
+    expect(engine.find('fuckіng')[0]).toMatchObject({
+      text: 'fuckіng',
+      targetText: 'fuck',
+      targetStart: 0,
+      targetEnd: 4,
+    });
+    expect(engine.segment('motherfuсker')).toEqual([
+      { text: 'mother', covered: false, ruleIds: [] },
+      { text: 'fuсk', covered: true, ruleIds: ['fuck-confusable'] },
+      { text: 'er', covered: false, ruleIds: [] },
+    ]);
+  });
+
+  it('keeps confusables and ordinary substitutions on separate budgets', () => {
+    const combined = createScrawlix({
+      rules: [
+        censorRuleFromConfusableObfuscatedTerms('shit-confusable', ['shit'], {
+          confusables: { s: ['ѕ'] },
+          substitutions: { i: ['1'] },
+          maxConfusables: 1,
+          maxSubstitutions: 1,
+          maxRepetitions: 0,
+          maxChanges: 2,
+        }),
+      ],
+    });
+    const tight = createScrawlix({
+      rules: [
+        censorRuleFromConfusableObfuscatedTerms('shit-confusable', ['shit'], {
+          confusables: { s: ['ѕ'] },
+          substitutions: { i: ['1'] },
+          maxConfusables: 1,
+          maxSubstitutions: 1,
+          maxRepetitions: 0,
+          maxChanges: 1,
+        }),
+      ],
+    });
+
+    expect(combined.find('ѕh1t')[0]).toMatchObject({ text: 'ѕh1t' });
+    expect(tight.find('ѕh1t')).toEqual([]);
+  });
+
+  it('keeps confusable and width budgets separate', () => {
+    const combined = createScrawlix({
+      rules: [
+        censorRuleFromConfusableObfuscatedTerms('fuck-confusable', ['fuck'], {
+          confusables: { c: ['с'] },
+          widthVariants: { k: ['ｋ'] },
+          maxConfusables: 1,
+          maxWidthVariants: 1,
+          maxRepetitions: 0,
+          maxChanges: 2,
+        }),
+      ],
+    });
+    const tight = createScrawlix({
+      rules: [
+        censorRuleFromConfusableObfuscatedTerms('fuck-confusable', ['fuck'], {
+          confusables: { c: ['с'] },
+          widthVariants: { k: ['ｋ'] },
+          maxConfusables: 1,
+          maxWidthVariants: 1,
+          maxRepetitions: 0,
+          maxChanges: 1,
+        }),
+      ],
+    });
+
+    expect(combined.find('fuсｋ')[0]).toMatchObject({ text: 'fuсｋ' });
+    expect(tight.find('fuсｋ')).toEqual([]);
+  });
+
+  it('composes one confusable with one repeated letter under the total budget', () => {
+    const combined = createScrawlix({
+      rules: [
+        censorRuleFromConfusableObfuscatedTerms('shit-confusable', ['shit'], {
+          confusables: { s: ['ѕ'] },
+          maxConfusables: 1,
+          maxRepetitions: 1,
+          maxChanges: 2,
+        }),
+      ],
+    });
+    const tight = createScrawlix({
+      rules: [
+        censorRuleFromConfusableObfuscatedTerms('shit-confusable', ['shit'], {
+          confusables: { s: ['ѕ'] },
+          maxConfusables: 1,
+          maxRepetitions: 1,
+          maxChanges: 1,
+        }),
+      ],
+    });
+
+    expect(combined.find('ѕhhit')[0]).toMatchObject({ text: 'ѕhhit' });
+    expect(tight.find('ѕhhit')).toEqual([]);
+  });
+
+  it('preserves word boundaries after explicit confusable mapping', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromConfusableObfuscatedTerms('fuck-confusable', ['fuck'], {
+          confusables: { c: ['с'] },
+          maxConfusables: 1,
+          maxRepetitions: 0,
+        }),
+      ],
+    });
+
+    expect(engine.find('fuсk')).toHaveLength(1);
+    expect(engine.find('fuсkery')).toEqual([]);
+  });
+
+  it('does not apply unreviewed Unicode lookalikes', () => {
+    const engine = createScrawlix({
+      rules: [
+        censorRuleFromConfusableObfuscatedTerms('asshole-confusable', ['asshole'], {
+          confusables: { o: ['о'] },
+          maxConfusables: 1,
+          maxRepetitions: 0,
+        }),
+      ],
+    });
+
+    expect(engine.find('asshоle')).toHaveLength(1);
+    expect(engine.find('asshοle')).toEqual([]);
+  });
+
+  it('keeps width and compatibility-equivalent forms out of the confusable class', () => {
+    expect(() =>
+      censorRuleFromConfusableObfuscatedTerms('bad', ['fuck'], {
+        confusables: { f: ['ｆ'] },
+        maxConfusables: 1,
+        maxRepetitions: 0,
+      })
+    ).toThrow('belongs in widthVariants');
+
+    expect(() =>
+      censorRuleFromConfusableObfuscatedTerms('bad', ['fuck'], {
+        confusables: { f: ['ⓕ'] },
+        maxConfusables: 1,
+        maxRepetitions: 0,
+      })
+    ).toThrow('compatibility-equivalent');
+  });
+
+  it('rejects source graphemes assigned to multiple transform classes', () => {
+    expect(() =>
+      censorRuleFromConfusableObfuscatedTerms('bad', ['fuck'], {
+        confusables: { c: ['с'] },
+        substitutions: { c: ['с'] },
+        maxConfusables: 1,
+        maxSubstitutions: 1,
+        maxRepetitions: 0,
+        maxChanges: 1,
+      })
+    ).toThrow('cannot also be configured as a substitution');
+  });
+
+  it('requires a total budget when confusables are combined with another class', () => {
+    expect(() =>
+      censorRuleFromConfusableObfuscatedTerms('bad', ['shit'], {
+        confusables: { s: ['ѕ'] },
+        maxConfusables: 1,
+        maxRepetitions: 1,
+      })
+    ).toThrow('requires an explicit maxChanges');
+  });
+});

--- a/packages/core/src/confusable-obfuscated.ts
+++ b/packages/core/src/confusable-obfuscated.ts
@@ -1,0 +1,338 @@
+import {
+  graphemeRanges,
+  type CensorMatcher,
+  type CensorRule,
+  type ObfuscatedTermSubstitutions,
+  type UnicodeNormalization,
+} from './index.js';
+import {
+  censorRuleFromRepeatedObfuscatedTerms,
+  type RepeatedObfuscatedTermOptions,
+} from './repeated-obfuscated.js';
+import type { TargetedObfuscatedTerm } from './targeted-obfuscated.js';
+
+export type ConfusableObfuscatedTermOptions = RepeatedObfuscatedTermOptions & {
+  /** Canonical grapheme -> explicitly reviewed Unicode lookalike source graphemes. */
+  confusables: ObfuscatedTermSubstitutions;
+  /** Maximum reviewed confusable source graphemes in one accepted candidate. */
+  maxConfusables: number;
+  /** Optional reviewed fullwidth ASCII class kept separate from confusables. */
+  widthVariants?: ObfuscatedTermSubstitutions;
+  maxWidthVariants?: number;
+};
+
+type CompiledMappedClasses = {
+  mergedSubstitutions: ObfuscatedTermSubstitutions;
+  confusableSources: ReadonlySet<string>;
+  widthSources: ReadonlySet<string>;
+  substitutionSources: ReadonlySet<string>;
+  ignored: ReadonlySet<string>;
+  maxConfusables: number;
+  maxWidthVariants: number;
+  maxSubstitutions: number;
+  maxChanges: number;
+};
+
+function normalize(value: string, normalization: UnicodeNormalization) {
+  return normalization === 'none' ? value : value.normalize(normalization);
+}
+
+function requireSingleGrapheme(
+  value: string,
+  label: string,
+  normalization: UnicodeNormalization
+) {
+  const normalized = normalize(value, normalization);
+  const ranges = graphemeRanges(normalized);
+  if (
+    normalized.length === 0 ||
+    ranges.length !== 1 ||
+    ranges[0]!.start !== 0 ||
+    ranges[0]!.end !== normalized.length
+  ) {
+    throw new Error(`${label} must be exactly one extended grapheme.`);
+  }
+  return normalized;
+}
+
+function requireBudget(name: string, value: number | undefined, enabled: boolean) {
+  if (enabled && value === undefined) {
+    throw new Error(
+      `censorRuleFromConfusableObfuscatedTerms() requires an explicit ${name} when that transform class is configured.`
+    );
+  }
+  const resolved = value ?? 0;
+  if (!Number.isInteger(resolved) || resolved < 0) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  return resolved;
+}
+
+function fullwidthAsciiFold(value: string) {
+  const codePoints = [...value];
+  if (codePoints.length !== 1) return null;
+  const codePoint = codePoints[0]!.codePointAt(0)!;
+  if (codePoint < 0xff01 || codePoint > 0xff5e) return null;
+  return String.fromCodePoint(codePoint - 0xfee0);
+}
+
+function appendMapping(
+  merged: Map<string, Set<string>>,
+  canonical: string,
+  source: string
+) {
+  const bucket = merged.get(canonical) ?? new Set<string>();
+  bucket.add(source);
+  merged.set(canonical, bucket);
+}
+
+function compileMappedClasses(
+  options: ConfusableObfuscatedTermOptions,
+  normalization: UnicodeNormalization
+): CompiledMappedClasses {
+  const merged = new Map<string, Set<string>>();
+  const substitutionSources = new Set<string>();
+  const widthSources = new Set<string>();
+  const confusableSources = new Set<string>();
+
+  for (const [canonicalValue, sourceValues] of Object.entries(
+    options.substitutions ?? {}
+  )) {
+    const canonical = requireSingleGrapheme(
+      canonicalValue,
+      `Substitution key ${JSON.stringify(canonicalValue)}`,
+      normalization
+    );
+    for (const sourceValue of sourceValues) {
+      const source = requireSingleGrapheme(
+        sourceValue,
+        `Substitution value ${JSON.stringify(sourceValue)}`,
+        normalization
+      );
+      substitutionSources.add(source);
+      appendMapping(merged, canonical, source);
+    }
+  }
+
+  let widthMappingCount = 0;
+  for (const [canonicalValue, sourceValues] of Object.entries(
+    options.widthVariants ?? {}
+  )) {
+    const canonical = requireSingleGrapheme(
+      canonicalValue,
+      `Width-variant key ${JSON.stringify(canonicalValue)}`,
+      normalization
+    );
+    const canonicalCodePoints = [...canonical];
+    if (
+      canonicalCodePoints.length !== 1 ||
+      canonicalCodePoints[0]!.codePointAt(0)! < 0x21 ||
+      canonicalCodePoints[0]!.codePointAt(0)! > 0x7e
+    ) {
+      throw new Error(
+        `Width-variant key ${JSON.stringify(canonicalValue)} must be one printable ASCII grapheme.`
+      );
+    }
+
+    for (const sourceValue of sourceValues) {
+      const source = requireSingleGrapheme(
+        sourceValue,
+        `Width-variant value ${JSON.stringify(sourceValue)}`,
+        normalization
+      );
+      if (fullwidthAsciiFold(source) !== canonical) {
+        throw new Error(
+          `Width-variant value ${JSON.stringify(sourceValue)} must be the fullwidth ASCII form of ${JSON.stringify(canonicalValue)}.`
+        );
+      }
+      if (substitutionSources.has(source)) {
+        throw new Error(
+          `Width-variant value ${JSON.stringify(sourceValue)} cannot also be configured as a substitution.`
+        );
+      }
+      widthSources.add(source);
+      appendMapping(merged, canonical, source);
+      widthMappingCount += 1;
+    }
+  }
+
+  let confusableMappingCount = 0;
+  for (const [canonicalValue, sourceValues] of Object.entries(
+    options.confusables
+  )) {
+    const canonical = requireSingleGrapheme(
+      canonicalValue,
+      `Confusable key ${JSON.stringify(canonicalValue)}`,
+      normalization
+    );
+    for (const sourceValue of sourceValues) {
+      const source = requireSingleGrapheme(
+        sourceValue,
+        `Confusable value ${JSON.stringify(sourceValue)}`,
+        normalization
+      );
+      if (source === canonical) {
+        throw new Error(
+          `Confusable value ${JSON.stringify(sourceValue)} maps to itself; remove it from the reviewed table.`
+        );
+      }
+      if (fullwidthAsciiFold(source) !== null) {
+        throw new Error(
+          `Confusable value ${JSON.stringify(sourceValue)} is a fullwidth ASCII variant and belongs in widthVariants.`
+        );
+      }
+      if (source.normalize('NFKC') === canonical.normalize('NFKC')) {
+        throw new Error(
+          `Confusable value ${JSON.stringify(sourceValue)} is compatibility-equivalent to ${JSON.stringify(canonicalValue)} and belongs in a reviewed compatibility class instead.`
+        );
+      }
+      if (substitutionSources.has(source)) {
+        throw new Error(
+          `Confusable value ${JSON.stringify(sourceValue)} cannot also be configured as a substitution.`
+        );
+      }
+      if (widthSources.has(source)) {
+        throw new Error(
+          `Confusable value ${JSON.stringify(sourceValue)} cannot also be configured as a width variant.`
+        );
+      }
+      confusableSources.add(source);
+      appendMapping(merged, canonical, source);
+      confusableMappingCount += 1;
+    }
+  }
+
+  if (confusableMappingCount === 0) {
+    throw new Error(
+      'censorRuleFromConfusableObfuscatedTerms() needs at least one reviewed confusable mapping.'
+    );
+  }
+
+  const maxConfusables = requireBudget(
+    'maxConfusables',
+    options.maxConfusables,
+    true
+  );
+  const maxWidthVariants = requireBudget(
+    'maxWidthVariants',
+    options.maxWidthVariants,
+    widthMappingCount > 0
+  );
+  const maxSubstitutions = requireBudget(
+    'maxSubstitutions',
+    options.maxSubstitutions,
+    substitutionSources.size > 0
+  );
+  const ignored = new Set(
+    (options.ignored ?? []).map(value => normalize(value, normalization))
+  );
+  const otherTransformEnabled =
+    substitutionSources.size > 0 ||
+    widthMappingCount > 0 ||
+    ignored.size > 0 ||
+    options.maxRepetitions > 0;
+
+  if (otherTransformEnabled && options.maxChanges === undefined) {
+    throw new Error(
+      'censorRuleFromConfusableObfuscatedTerms() requires an explicit maxChanges when confusables are combined with width variants, substitutions, ignored graphemes, or repeated letters.'
+    );
+  }
+  const maxChanges = requireBudget(
+    'maxChanges',
+    options.maxChanges ?? maxConfusables,
+    true
+  );
+
+  return {
+    mergedSubstitutions: Object.fromEntries(
+      [...merged].map(([canonical, values]) => [canonical, [...values]])
+    ),
+    confusableSources,
+    widthSources,
+    substitutionSources,
+    ignored,
+    maxConfusables,
+    maxWidthVariants,
+    maxSubstitutions,
+    maxChanges,
+  };
+}
+
+function candidateMappedClassCost(
+  text: string,
+  start: number,
+  end: number,
+  normalization: UnicodeNormalization,
+  config: CompiledMappedClasses
+) {
+  let confusables = 0;
+  let widthVariants = 0;
+  let substitutions = 0;
+
+  const slice = text.slice(start, end);
+  for (const range of graphemeRanges(slice)) {
+    const source = normalize(slice.slice(range.start, range.end), normalization);
+    if (config.ignored.has(source)) continue;
+    if (config.confusableSources.has(source)) {
+      confusables += 1;
+    } else if (config.widthSources.has(source)) {
+      widthVariants += 1;
+    } else if (config.substitutionSources.has(source)) {
+      substitutions += 1;
+    }
+  }
+
+  return { confusables, widthVariants, substitutions };
+}
+
+/**
+ * Match only caller-reviewed Unicode confusables with an explicit class budget.
+ *
+ * No confusable skeleton is generated. Compatibility-equivalent forms and direct
+ * fullwidth ASCII variants are rejected from this class so packs can keep those
+ * policies separately reviewable.
+ */
+export function censorRuleFromConfusableObfuscatedTerms(
+  id: string,
+  entries: readonly TargetedObfuscatedTerm[],
+  options: ConfusableObfuscatedTermOptions
+): CensorRule {
+  const normalization = options.normalization ?? 'NFC';
+  const config = compileMappedClasses(options, normalization);
+  const baseRule = censorRuleFromRepeatedObfuscatedTerms(id, entries, {
+    ...options,
+    substitutions: config.mergedSubstitutions,
+    maxSubstitutions:
+      config.maxSubstitutions +
+      config.maxWidthVariants +
+      config.maxConfusables,
+    maxChanges: config.maxChanges,
+  });
+  const baseMatcher: CensorMatcher | undefined = baseRule.matcher;
+  if (!baseMatcher) {
+    throw new Error('Confusable-obfuscated terms require a matcher-backed rule.');
+  }
+
+  return {
+    id,
+    profile: options.profile ?? 'obfuscated',
+    coverage: options.coverage,
+    matcher: {
+      *find(text) {
+        for (const match of baseMatcher.find(text)) {
+          const cost = candidateMappedClassCost(
+            text,
+            match.start,
+            match.end,
+            normalization,
+            config
+          );
+          if (cost.confusables > config.maxConfusables) continue;
+          if (cost.widthVariants > config.maxWidthVariants) continue;
+          if (cost.substitutions > config.maxSubstitutions) continue;
+          yield match;
+        }
+      },
+    },
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,9 @@
       "@scrawlix/core/width-obfuscated": [
         "packages/core/src/width-obfuscated.ts"
       ],
+      "@scrawlix/core/confusable-obfuscated": [
+        "packages/core/src/confusable-obfuscated.ts"
+      ],
       "@scrawlix/en": ["packages/en/src/index.ts"],
       "@scrawlix/en/corpus": ["packages/en/src/corpus.ts"],
       "@scrawlix/react": ["packages/react/src/index.tsx"],


### PR DESCRIPTION
## Summary
Add a dedicated caller-reviewed Unicode confusable class as a focused core subpath.

- add `@scrawlix/core/confusable-obfuscated`
- add `censorRuleFromConfusableObfuscatedTerms()`
- require explicit single-grapheme `confusables` mappings plus `maxConfusables`
- generate no Unicode skeleton and apply no blanket cross-script equivalence
- preserve exact original-source ranges, semantic targets, repetition semantics, boundaries, normalization, coverage, and `profile: 'obfuscated'`
- keep confusable, fullwidth, ordinary substitution, ignored-grapheme, and repeated-letter costs separately budgeted
- require `maxChanges` whenever confusables are combined with another transform class
- reject direct fullwidth ASCII forms from the confusable class
- reject compatibility-equivalent forms whose NFKC value already equals the declared canonical grapheme, keeping compatibility policy separate
- reject source graphemes assigned to multiple transform classes
- add regressions for reviewed Cyrillic lookalikes, semantic roots, separate class budgets, confusable+width, confusable+repeat, word boundaries, unreviewed Greek lookalikes, compatibility/fullwidth separation, and constructor validation
- add a dedicated authoring/guardrail document
- exercise the public package subpath through installed-tarball runtime smoke

## Guardrail
This helper applies only mappings a pack explicitly declares. Reviewing Cyrillic `о` for Latin `o` does not enable Greek `ο`, mathematical alphabets, compatibility forms, or any other lookalike. Core supplies source-safe execution; packs own the linguistic and false-positive policy.

Progress on #38
Next: dogfood a very small reviewed confusable set in the opt-in English aggressive pack, with its own positive/clean JSON corpus lane.