### PR TITLE
Bound custom-term matching cost and explain list limits

### DIFF
--- a/apps/extension/src/actions.ts
+++ b/apps/extension/src/actions.ts
@@ -1,7 +1,8 @@
+import { MAX_CUSTOM_TERM_CODE_POINTS } from './config';
+
 export const ADD_SELECTION_MENU_ID = 'scrawlix-add-selection';
 export const TEMPORARY_REVEAL_COMMAND = 'temporary-reveal';
 export const TEMPORARY_REVEAL_MS = 10_000;
-export const MAX_CUSTOM_TERM_CODE_POINTS = 200;
 
 export function customTermFromSelection(value: unknown): string | null {
   if (typeof value !== 'string') return null;

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -32,9 +32,20 @@ export type ExtensionStateSnapshot = {
 
 export type SessionAction = 'none' | 'start' | 'stop' | 'restart' | 'decorate';
 
+export type CustomWordMergeResult = {
+  words: string[];
+  added: number;
+  duplicates: number;
+  overLength: number;
+  overCapacity: number;
+};
+
 export const SYNC_SETTINGS_KEY = 'scrawlixSettings';
 export const SITE_OVERRIDES_KEY = 'scrawlixSiteOverrides';
 export const CUSTOM_WORDS_KEY = 'scrawlixCustomWords';
+export const MAX_CUSTOM_TERM_CODE_POINTS = 200;
+export const MAX_CUSTOM_TERMS = 500;
+export const MAX_CUSTOM_TOTAL_CODE_POINTS = 20_000;
 
 export const DEFAULT_SETTINGS: SyncSettings = {
   paused: false,
@@ -106,23 +117,88 @@ export function normalizeSettings(value: unknown): SyncSettings {
   };
 }
 
-export function normalizeCustomWords(value: unknown): string[] {
-  if (!Array.isArray(value)) return [];
+function codePointLength(value: string) {
+  return Array.from(value).length;
+}
 
-  const seen = new Set<string>();
-  const words: string[] = [];
+function appendCustomWord(
+  state: {
+    words: string[];
+    seen: Set<string>;
+    totalCodePoints: number;
+  },
+  item: unknown
+): 'added' | 'empty' | 'duplicate' | 'overLength' | 'overCapacity' {
+  if (typeof item !== 'string') return 'empty';
+  const word = item.trim();
+  if (!word) return 'empty';
 
-  for (const item of value) {
-    if (typeof item !== 'string') continue;
-    const word = item.trim();
-    if (!word) continue;
-    const key = word.toLocaleLowerCase();
-    if (seen.has(key)) continue;
-    seen.add(key);
-    words.push(word);
+  const length = codePointLength(word);
+  if (length > MAX_CUSTOM_TERM_CODE_POINTS) return 'overLength';
+
+  const key = word.toLocaleLowerCase();
+  if (state.seen.has(key)) return 'duplicate';
+
+  if (
+    state.words.length >= MAX_CUSTOM_TERMS ||
+    state.totalCodePoints + length > MAX_CUSTOM_TOTAL_CODE_POINTS
+  ) {
+    return 'overCapacity';
   }
 
-  return words;
+  state.seen.add(key);
+  state.words.push(word);
+  state.totalCodePoints += length;
+  return 'added';
+}
+
+export function mergeCustomWords(
+  existing: readonly string[],
+  incoming: unknown
+): CustomWordMergeResult {
+  const state = {
+    words: [] as string[],
+    seen: new Set<string>(),
+    totalCodePoints: 0,
+  };
+
+  for (const item of existing) appendCustomWord(state, item);
+
+  const result: CustomWordMergeResult = {
+    words: state.words,
+    added: 0,
+    duplicates: 0,
+    overLength: 0,
+    overCapacity: 0,
+  };
+
+  if (!Array.isArray(incoming)) return result;
+
+  for (const item of incoming) {
+    switch (appendCustomWord(state, item)) {
+      case 'added':
+        result.added += 1;
+        break;
+      case 'duplicate':
+        result.duplicates += 1;
+        break;
+      case 'overLength':
+        result.overLength += 1;
+        break;
+      case 'overCapacity':
+        result.overCapacity += 1;
+        break;
+      case 'empty':
+        break;
+    }
+  }
+
+  return result;
+}
+
+export function normalizeCustomWords(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return mergeCustomWords([], value).words;
 }
 
 export function siteModeFor(settings: SyncSettings, hostname: string): SiteMode {

--- a/apps/extension/src/options.ts
+++ b/apps/extension/src/options.ts
@@ -2,14 +2,16 @@ import { censorRuleFromWords, createScrawlix } from '@scrawlix/core';
 import './content.css';
 import './options.css';
 import { removeHostAccess } from './access';
-import { MAX_CUSTOM_TERM_CODE_POINTS } from './actions';
 import {
   CUSTOM_WORDS_KEY,
+  MAX_CUSTOM_TERM_CODE_POINTS,
+  MAX_CUSTOM_TERMS,
+  MAX_CUSTOM_TOTAL_CODE_POINTS,
   SITE_OVERRIDES_KEY,
   SYNC_SETTINGS_KEY,
   coverageSelector,
   maskFor,
-  normalizeCustomWords,
+  mergeCustomWords,
   setSiteMode,
   type ExtensionAppearance,
   type ExtensionCoverage,
@@ -142,11 +144,16 @@ function renderGeneral() {
   renderPreview();
 }
 
+function customCodePointUsage() {
+  return customWords.reduce((total, term) => total + Array.from(term).length, 0);
+}
+
 function renderTerms() {
   const query = termFilter.value;
   const filtered = customWords.filter(term => filterMatch(term, query));
+  const usedCodePoints = customCodePointUsage();
 
-  customCount.textContent = `${customWords.length} ${customWords.length === 1 ? 'term' : 'terms'}`;
+  customCount.textContent = `${customWords.length}/${MAX_CUSTOM_TERMS} terms · ${usedCodePoints.toLocaleString()}/${MAX_CUSTOM_TOTAL_CODE_POINTS.toLocaleString()} chars`;
   termList.replaceChildren();
 
   for (const term of filtered) {
@@ -348,28 +355,33 @@ async function removeCustomTerm(term: string) {
   await persistCustomWords(next, `Removed ${term}`);
 }
 
-async function addCustomTerms() {
-  const candidates = normalizeCustomWords(newTermsInput.value.split('\n'));
-  const accepted = candidates.filter(
-    term => Array.from(term).length <= MAX_CUSTOM_TERM_CODE_POINTS
-  );
-  const rejected = candidates.length - accepted.length;
-  const next = normalizeCustomWords([...customWords, ...accepted]);
-  const added = next.length - customWords.length;
+function customMergeMessage(result: ReturnType<typeof mergeCustomWords>) {
+  const skipped: string[] = [];
+  if (result.duplicates > 0) skipped.push(`${result.duplicates} duplicate`);
+  if (result.overLength > 0) skipped.push(`${result.overLength} too long`);
+  if (result.overCapacity > 0) skipped.push(`${result.overCapacity} over list budget`);
 
-  if (accepted.length === 0) {
-    customStatus.textContent = rejected > 0 ? 'Terms over the length limit were skipped.' : 'Enter a word or phrase first.';
+  if (result.added > 0) {
+    const added = `Added ${result.added} ${result.added === 1 ? 'term' : 'terms'}`;
+    return skipped.length > 0 ? `${added}; skipped ${skipped.join(', ')}` : added;
+  }
+
+  if (result.overCapacity > 0) return 'Custom-term list is at its matching budget.';
+  if (result.overLength > 0) {
+    return `Terms can be up to ${MAX_CUSTOM_TERM_CODE_POINTS} characters each.`;
+  }
+  if (result.duplicates > 0) return 'Those terms are already in your list.';
+  return 'Enter a word or phrase first.';
+}
+
+async function addCustomTerms() {
+  const result = mergeCustomWords(customWords, newTermsInput.value.split('\n'));
+  if (result.added === 0) {
+    customStatus.textContent = customMergeMessage(result);
     return;
   }
 
-  await persistCustomWords(
-    next,
-    rejected > 0
-      ? `Added ${added}; skipped ${rejected} over the length limit`
-      : added > 0
-        ? `Added ${added} ${added === 1 ? 'term' : 'terms'}`
-        : 'Those terms are already in your list'
-  );
+  await persistCustomWords(result.words, customMergeMessage(result));
   newTermsInput.value = '';
   newTermsInput.focus();
 }

--- a/apps/extension/src/storage.test.ts
+++ b/apps/extension/src/storage.test.ts
@@ -1,6 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { DEFAULT_SETTINGS, SITE_OVERRIDES_KEY, SYNC_SETTINGS_KEY } from './config';
-import { loadSettings, migrateSiteOverridesToLocal, saveSettings } from './storage';
+import {
+  CUSTOM_WORDS_KEY,
+  DEFAULT_SETTINGS,
+  MAX_CUSTOM_TERM_CODE_POINTS,
+  MAX_CUSTOM_TERMS,
+  SITE_OVERRIDES_KEY,
+  SYNC_SETTINGS_KEY,
+} from './config';
+import {
+  loadSettings,
+  migrateSiteOverridesToLocal,
+  saveCustomWords,
+  saveSettings,
+} from './storage';
 
 type Store = Record<string, unknown>;
 
@@ -95,14 +107,9 @@ describe('extension storage split', () => {
     });
   });
 
-  it('preserves an intentionally empty local override map during migration', async () => {
-    const syncStore: Store = {
-      [SYNC_SETTINGS_KEY]: {
-        ...DEFAULT_SETTINGS,
-        siteOverrides: { 'legacy.example': 'on' },
-      },
-    };
-    const localStore: Store = { [SITE_OVERRIDES_KEY]: {} };
+  it('persists only the bounded normalized custom-term list', async () => {
+    const syncStore: Store = {};
+    const localStore: Store = {};
     vi.stubGlobal('chrome', {
       storage: {
         sync: storageArea(syncStore),
@@ -110,15 +117,14 @@ describe('extension storage split', () => {
       },
     });
 
-    await migrateSiteOverridesToLocal();
+    const terms = [
+      ...Array.from({ length: MAX_CUSTOM_TERMS + 10 }, (_, index) => `term-${index}`),
+      'x'.repeat(MAX_CUSTOM_TERM_CODE_POINTS + 1),
+    ];
+    await saveCustomWords(terms);
 
-    expect(localStore[SITE_OVERRIDES_KEY]).toEqual({});
-    expect(syncStore[SYNC_SETTINGS_KEY]).toEqual({
-      paused: false,
-      enabled: true,
-      appearance: 'scrawl',
-      coverage: 'middle',
-      reveal: 'hover',
-    });
+    const stored = localStore[CUSTOM_WORDS_KEY] as string[];
+    expect(stored).toHaveLength(MAX_CUSTOM_TERMS);
+    expect(stored).not.toContain('x'.repeat(MAX_CUSTOM_TERM_CODE_POINTS + 1));
   });
 });


### PR DESCRIPTION
## What changed

- enforce one shared custom-term matching budget beneath every extension UI/storage path:
  - 200 Unicode code points per term
  - 500 terms maximum
  - 20,000 Unicode code points across the active list
- add `mergeCustomWords()` so incoming terms report duplicate, over-length, and over-capacity outcomes while preserving the bounded normalized list
- keep case-insensitive deduplication
- allow a later shorter incoming term to use remaining total budget after an earlier longer term does not fit
- make the selection context-menu use the same per-term limit constant
- make `saveCustomWords()` persist only the bounded normalized list
- update Options paste/add feedback to distinguish duplicates, long terms, and exhausted matcher budget
- surface the limits beside the custom-term form and expose current usage in the count label tooltip
- add unit regressions for Unicode length, term-count cap, total budget, duplicate reporting, and direct storage persistence

## Why

`chrome.storage.local` can hold far more data than Scrawlix should compile into one alternation RegExp and run against every eligible text node on modern pages. These limits are a browser-performance contract, not a storage-quota workaround.

## Stack

This PR is intentionally based on `copper/coverage-contract` / #125 so the matcher-budget change can be reviewed independently.

Closes #135 and progresses #23.