### PR TITLE
Release-gate the Node 18 package runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,16 @@ jobs:
       - run: pnpm typecheck
       - run: pnpm test
       - run: pnpm build
+      - name: Use Node 18 for published-runtime smoke
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Published runtime smoke — Node 18
+        run: node scripts/smoke-node18-runtime.mjs
+      - name: Restore Node 22 toolchain
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - name: Core benchmark harness smoke
         run: pnpm bench:core:smoke >/dev/null
       - name: Install Chromium

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,20 @@ jobs:
           pnpm typecheck
           pnpm test
           pnpm build
-          pnpm smoke:packages
+
+      - name: Use Node 18 for published-runtime smoke
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Published runtime smoke — Node 18
+        run: node scripts/smoke-node18-runtime.mjs
+      - name: Restore Node 24 publication toolchain
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Verify packed packages
+        run: pnpm smoke:packages
 
       - name: Verify synchronized release version
         run: node scripts/check-release-version.mjs "${{ inputs.version }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Scrawlix is in pre-release development. Until the first package version is chose
 - Added a framework-neutral renderer recipe with plain-DOM, Vue, Svelte, and Solid sketches plus a threshold for when a dedicated adapter package is worth maintaining.
 - Added explicit runtime compatibility and pre-1.0 versioning/public-contract policies.
 - Declared Node 18+ in every public package manifest and Node 22+ in the private workspace manifest so package-manager metadata matches the documented runtime/tooling baselines.
+- Release-gate already-built public package entrypoints under Node 18 in both CI and the permanent publication workflow while keeping build/browser tooling on Node 22/24.
 - Publish curated implementation sources alongside JS/declaration maps and verify every local map target against packed tarball contents while excluding source tests.
 - Added explicit privacy/output vocabulary for visual covers, presentation/screenshot guarantees, assistive-tech concealment, and sanitized export.
 - Aligned `README.md`, `AGENTS.md`, `llms.txt`, demo, extension, tests, and smoke consumers on the canonical pre-release public names and conservative defaults.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -15,6 +15,8 @@ Scrawlix publishes ESM and TypeScript declarations targeting modern JavaScript. 
 
 For published-package execution in Node, **Node 18 and newer** is the supported baseline for core/rehype and SSR contexts that execute package code directly. Every public `@scrawlix/*` manifest declares `engines.node: ">=18"` so package managers can surface that requirement before install.
 
+CI turns that promise into an execution gate: packages are installed and built with the repository's Node 22 toolchain, the workflow switches to Node 18 and runs already-built public entrypoints plus representative canonical/obfuscated/rehype behavior, then restores Node 22 before benchmark, browser, and packed-package work. The permanent npm publication workflow runs the same Node 18 package-runtime smoke before restoring its Node 24 publication toolchain.
+
 Repository CI and ordinary development verification use **Node 22**. The private root workspace declares `engines.node: ">=22"`. The OIDC npm publication job uses **Node 24** so its release runner comfortably satisfies npm trusted-publishing runtime requirements. The workspace includes current build/test tools with their own Node requirements, so contributors should follow the CI/toolchain baseline instead of treating the package-runtime minimum as the repository-development minimum.
 
 For browsers, support is capability-based during pre-1.0: the consuming browser must support the features above. Scrawlix's browser CI exercises current Chromium. Add explicit Firefox/Safari version claims only alongside CI or targeted compatibility tests that enforce them.

--- a/scripts/smoke-node18-runtime.mjs
+++ b/scripts/smoke-node18-runtime.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import { createScrawlix } from '../packages/core/dist/index.js';
+import { censorRuleFromRepeatedObfuscatedTerms } from '../packages/core/dist/repeated-obfuscated.js';
+import { censorRuleFromTargetedObfuscatedTerms } from '../packages/core/dist/targeted-obfuscated.js';
+import { censorRuleFromWidthObfuscatedTerms } from '../packages/core/dist/width-obfuscated.js';
+import { createDomScrawlix } from '../packages/dom/dist/index.js';
+import {
+  englishObfuscatedStrongProfanityRules,
+  englishStrongProfanityRules,
+} from '../packages/en/dist/index.js';
+import {
+  englishObfuscatedProfanityCorpus,
+  englishProfanityCorpus,
+} from '../packages/en/dist/corpus.js';
+import { transformHast } from '../packages/rehype/dist/index.js';
+import { CensoredText } from '../packages/react/dist/index.js';
+
+const nodeMajor = Number.parseInt(process.versions.node.split('.')[0] ?? '', 10);
+assert.equal(
+  nodeMajor,
+  18,
+  `Node 18 runtime smoke must execute under Node 18; received ${process.versions.node}`
+);
+
+assert.equal(typeof Intl.Segmenter, 'function');
+assert.equal(typeof ''.replaceAll, 'function');
+assert.equal(typeof [].at, 'function');
+
+const indexed = /(?<core>fuck)/d.exec('fuck');
+assert.deepEqual(indexed?.indices?.groups?.core, [0, 4]);
+assert.equal(/(?<=\p{L})\p{L}/u.test('ab'), true);
+
+const engine = createScrawlix({
+  rules: englishStrongProfanityRules,
+  coverage: 'middle',
+});
+const matches = engine.find('well, fuck');
+assert.equal(matches.length, 1);
+assert.equal(matches[0]?.targetText.toLowerCase(), 'fuck');
+assert.equal(matches[0]?.profile, 'canonical');
+assert.ok(englishProfanityCorpus.some(testCase => testCase.id === 'fuck-base'));
+
+const obfuscatedEngine = createScrawlix({
+  rules: englishObfuscatedStrongProfanityRules,
+});
+assert.equal(obfuscatedEngine.find('sh1t')[0]?.profile, 'obfuscated');
+assert.equal(obfuscatedEngine.find('motherfuucker')[0]?.targetText, 'fuuck');
+assert.equal(obfuscatedEngine.find('motherｆucker')[0]?.targetText, 'ｆuck');
+assert.ok(
+  englishObfuscatedProfanityCorpus.some(
+    testCase => testCase.id === 'obfuscated-shit-digit'
+  )
+);
+
+const targetedEngine = createScrawlix({
+  rules: [
+    censorRuleFromTargetedObfuscatedTerms(
+      'targeted-node18',
+      [{ term: 'fucking', target: 'fuck' }],
+      {
+        substitutions: { u: ['*'] },
+        maxSubstitutions: 1,
+      }
+    ),
+  ],
+});
+assert.equal(targetedEngine.find('f*cking')[0]?.targetText, 'f*ck');
+
+const repeatedEngine = createScrawlix({
+  rules: [
+    censorRuleFromRepeatedObfuscatedTerms(
+      'repeated-node18',
+      [{ term: 'motherfucker', target: 'fuck' }],
+      { maxRepetitions: 1 }
+    ),
+  ],
+});
+assert.equal(repeatedEngine.find('motherfuucker')[0]?.targetText, 'fuuck');
+
+const widthEngine = createScrawlix({
+  rules: [
+    censorRuleFromWidthObfuscatedTerms(
+      'width-node18',
+      [{ term: 'motherfucker', target: 'fuck' }],
+      {
+        widthVariants: { f: ['ｆ'] },
+        maxWidthVariants: 1,
+        maxRepetitions: 0,
+      }
+    ),
+  ],
+});
+assert.equal(widthEngine.find('motherｆucker')[0]?.targetText, 'ｆuck');
+
+const tree = {
+  type: 'root',
+  children: [
+    {
+      type: 'element',
+      tagName: 'p',
+      properties: {},
+      children: [{ type: 'text', value: 'well, fuck' }],
+    },
+  ],
+};
+transformHast(tree, {
+  rules: englishStrongProfanityRules,
+  coverage: 'middle',
+});
+assert.ok(
+  tree.children[0]?.children.some(
+    child =>
+      child.type === 'element' &&
+      Object.prototype.hasOwnProperty.call(
+        child.properties ?? {},
+        'data-scrawlix-cover'
+      )
+  )
+);
+
+assert.equal(typeof CensoredText, 'function');
+assert.equal(typeof createDomScrawlix, 'function');
+
+console.log(`Scrawlix Node ${process.versions.node} runtime smoke passed.`);


### PR DESCRIPTION
## Summary

Turns the public `engines.node >=18` promise into an executable release gate.

### Runtime smoke
Adds `scripts/smoke-node18-runtime.mjs`, which runs only under Node 18 and checks:
- `Intl.Segmenter`, RegExp match indices/lookbehind/property escapes, `replaceAll`, and `Array.at`
- canonical English matching/corpus exports
- aggressive English substitution, repetition, and fullwidth behavior
- targeted/repeated/width/confusable core subpath entrypoints
- rehype transformation
- React and DOM public module loading/exports

### CI/toolchain split
- install/typecheck/test/build stay on Node 22
- CI switches to Node 18 after build and runs the public-runtime smoke
- CI restores Node 22 before benchmark/browser/tarball tooling

### Publication path
- `publish.yml` runs the same Node 18 package-runtime smoke after build
- it restores Node 24 before packed-package verification, registry preflight, and OIDC publication
- no change to the private workspace's Node 22+ tooling requirement

### Moving public surface
The branch merges current `main`, including the reviewed `@scrawlix/core/confusable-obfuscated` helper, and the Node 18 smoke now executes that subpath too. The runtime floor therefore follows every current advanced core entrypoint.

### Docs
- document that the Node 18 floor is execution-tested rather than metadata-only
- record the gate in the changelog

Closes #131.