### PR TITLE
Add reviewed confusables to the English aggressive pack

### DIFF
--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -21,6 +21,12 @@ export default defineConfig({
         replacement: workspaceFile('../../packages/en/src/index.ts'),
       },
       {
+        find: '@scrawlix/core/confusable-obfuscated',
+        replacement: workspaceFile(
+          '../../packages/core/src/confusable-obfuscated.ts'
+        ),
+      },
+      {
         find: '@scrawlix/core/width-obfuscated',
         replacement: workspaceFile('../../packages/core/src/width-obfuscated.ts'),
       },

--- a/fixtures/consumer/runtime.mjs
+++ b/fixtures/consumer/runtime.mjs
@@ -79,6 +79,17 @@ assert.ok(
   )
 );
 
+const englishConfusable = obfuscatedEngine.find('motherfuсker')[0];
+assert.equal(englishConfusable?.text, 'motherfuсker');
+assert.equal(englishConfusable?.targetText, 'fuсk');
+assert.equal(englishConfusable?.targetStart, 6);
+assert.equal(englishConfusable?.targetEnd, 10);
+assert.ok(
+  englishObfuscatedProfanityCorpus.some(
+    testCase => testCase.id === 'obfuscated-confusable-fuck-mother-c'
+  )
+);
+
 const targetedEngine = createScrawlix({
   rules: [
     censorRuleFromTargetedObfuscatedTerms(

--- a/packages/en/README.md
+++ b/packages/en/README.md
@@ -43,7 +43,7 @@ The package also exports a separate aggressive pack:
 - `englishObfuscatedStrongProfanityRules`
 - `englishObfuscatedStrongProfanityPack`
 
-It catches a small reviewed set of one-change evasions across the same inflection and compound families declared by the canonical pack for `fuck`, `shit`, `bitch`, `asshole`, and `cunt`. Each candidate may use one reviewed symbol/digit substitution, one internal `.`, `-`, or zero-width-space insertion, one excess repeated letter, **or** one reviewed fullwidth ASCII grapheme. The total budget stays one transform.
+It catches a small reviewed set of one-change evasions across the same inflection and compound families declared by the canonical pack for `fuck`, `shit`, `bitch`, `asshole`, and `cunt`. Each candidate may use one reviewed symbol/digit substitution, one internal `.`, `-`, or zero-width-space insertion, one excess repeated letter, one reviewed fullwidth ASCII grapheme, **or** one reviewed Unicode confusable. The total budget stays one transform.
 
 ```ts
 import { createScrawlix, rulesFromPacks } from '@scrawlix/core';
@@ -60,17 +60,30 @@ const scrawlix = createScrawlix({
 });
 ```
 
-Examples include substitutions such as `f*ck` and `sh1t`, inserted separators such as `mother-fucker`, bounded repetitions such as `fuuck`, `fuckking`, `motherfuucker`, `shittting`, `bittches`, `assshole`, and `cunnt`, and reviewed fullwidth forms such as `ｆuck`, `fuckｉng`, `motherｆucker`, `bullshｉt`, `ｂitches`, `asshｏles`, and `cｕnts`.
+Examples include substitutions such as `f*ck` and `sh1t`, inserted separators such as `mother-fucker`, bounded repetitions such as `fuuck` and `shittting`, fullwidth forms such as `ｆuck` and `motherｆucker`, and reviewed cross-script forms such as `fuсk`, `fuckіng`, `motherfuсker`, `ѕhit`, `bullshіt`, `bіtches`, `аsshole`, `asshоles`, and `сunts`.
 
-Full obfuscated forms preserve the canonical semantic root. For example, `f*cking` targets `f*ck`; `mother-fucker` targets `fuck`; `motherfuucker` targets `fuuck`; `shittting` targets `shit`; `motherｆucker` targets `ｆuck`; and a fullwidth letter in a suffix such as `fuckｉng` stays outside the `fuck` target. Coverage therefore follows the same semantic profanity root as the canonical regex pack.
+Full obfuscated forms preserve the canonical semantic root. For example, `motherfuсker` targets `fuсk`, `fuckіng` targets `fuck`, and `asshоles` targets `asshоle`. Coverage follows the same semantic profanity root as the canonical regex pack.
 
-Canonical repeated runs remain meaningful. The declared `ss` in `asshole` is the minimum accepted run; `assshole` consumes one repetition budget while `ashole` stays clean. Fullwidth mappings use a separate reviewed class limited to true U+FF01–U+FF5E forms. Circled and superscript compatibility characters stay outside this pack's width table.
+### Reviewed confusable set
 
-The one-change ceiling applies across every aggressive class. Two fullwidth letters, a fullwidth letter plus a substitution, a fullwidth letter plus a repeat, or a fullwidth letter plus an inserted separator all exceed the pack policy.
+The current English pack reviews only this small set of source lookalikes:
+
+- Latin `a` ← Cyrillic `а` (U+0430)
+- Latin `c` ← Cyrillic `с` (U+0441)
+- Latin `e` ← Cyrillic `е` (U+0435)
+- Latin `i` ← Ukrainian Cyrillic `і` (U+0456)
+- Latin `o` ← Cyrillic `о` (U+043E)
+- Latin `s` ← Cyrillic `ѕ` (U+0455)
+
+Other lookalikes stay clean until they receive their own corpus evidence and explicit review. The clean corpus includes Greek omicron `ο` and Greek lunate sigma `ϲ` examples to pin that boundary. Fullwidth forms stay in the width class, and compatibility forms such as circled letters stay outside the confusable table.
+
+Canonical repeated runs remain meaningful. The declared `ss` in `asshole` is the minimum accepted run; `assshole` consumes one repetition budget while `ashole` stays clean. Fullwidth mappings use a separate reviewed class limited to true U+FF01–U+FF5E forms.
+
+The one-change ceiling applies across every aggressive class. Two confusables, or a confusable combined with a substitution, width variant, repeat, or inserted separator, exceed the pack policy.
 
 Matches from this pack expose `profile: 'obfuscated'` and `packId: 'en-strong-profanity-obfuscated'` when composed through `rulesFromPacks()`.
 
-The reviewed tables and form families live in ordinary package code, and positive plus false-positive/over-budget cases live in JSON corpora. Width cases live in their own corpus files so reviewers can inspect that behavior independently.
+The reviewed tables and form families live in ordinary package code, and positive plus false-positive/over-budget cases live in JSON corpora. Width and confusable cases live in separate corpus files so reviewers can inspect those behaviors independently.
 
 ## Regression data
 
@@ -87,4 +100,4 @@ import {
 
 The current package is intentionally narrow strong-profanity coverage. It is a reviewable set of English rules and aggressive examples, with explicit corpus evidence for the scope it claims.
 
-See the [language-pack guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/language-packs.md) for authoring, composition, boundary, Unicode, and obfuscation guidance. For edge/boundary or no-match diagnostics, use the [troubleshooting guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/troubleshooting.md).
+See the [language-pack guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/language-packs.md) for authoring, composition, boundary, Unicode, and obfuscation guidance. Use the [confusable-matching guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/confusable-matching.md) for reviewed lookalike policy, and the [troubleshooting guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/troubleshooting.md) for edge/boundary or no-match diagnostics.

--- a/packages/en/src/corpus-data/obfuscated-confusable-clean.json
+++ b/packages/en/src/corpus-data/obfuscated-confusable-clean.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "obfuscated-confusable-clean-plus-width",
+    "text": "fuсｋ",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "confusable", "width-variant", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-confusable-clean-plus-substitution",
+    "text": "ѕh1t",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "confusable", "substitution", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-confusable-clean-plus-repeat",
+    "text": "ѕhhit",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "confusable", "repetition", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-confusable-clean-plus-separator",
+    "text": "ѕh-it",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "confusable", "punctuation-insertion", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-confusable-clean-two-confusables",
+    "text": "аsshоle",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "obfuscation", "confusable", "budget"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-confusable-clean-fuckery-boundary",
+    "text": "fuсkery",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "confusable", "word-boundary"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-confusable-clean-country",
+    "text": "сountry",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "confusable", "ordinary-word", "cyrillic"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-confusable-clean-shirt",
+    "text": "ѕhirt",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "confusable", "ordinary-word", "cyrillic"],
+    "matches": []
+  },
+  {
+    "id": "obfuscated-confusable-clean-greek-omicron",
+    "text": "asshοle",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "confusable", "unreviewed-lookalike", "greek"],
+    "note": "Greek omicron remains clean because only reviewed Cyrillic o is enabled for canonical o.",
+    "matches": []
+  },
+  {
+    "id": "obfuscated-confusable-clean-greek-lunate-sigma",
+    "text": "fuϲk",
+    "profile": "obfuscated",
+    "tags": ["false-positive", "confusable", "unreviewed-lookalike", "greek"],
+    "note": "A visually similar unreviewed Greek character does not inherit the reviewed Cyrillic-c mapping.",
+    "matches": []
+  }
+]

--- a/packages/en/src/corpus-data/obfuscated-confusable.json
+++ b/packages/en/src/corpus-data/obfuscated-confusable.json
@@ -1,0 +1,172 @@
+[
+  {
+    "id": "obfuscated-confusable-fuck-c",
+    "text": "fuсk",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "confusable", "cyrillic"],
+    "matches": [
+      {
+        "ruleId": "fuck-obfuscated",
+        "text": "fuсk",
+        "start": 0,
+        "end": 4,
+        "targetText": "fuсk",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-confusable-fuck-suffix-i",
+    "text": "fuckіng",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "confusable", "cyrillic", "inflection", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "fuck-obfuscated",
+        "text": "fuckіng",
+        "start": 0,
+        "end": 7,
+        "targetText": "fuck",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-confusable-fuck-mother-c",
+    "text": "motherfuсker",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "confusable", "cyrillic", "compound", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "fuck-obfuscated",
+        "text": "motherfuсker",
+        "start": 0,
+        "end": 12,
+        "targetText": "fuсk",
+        "targetStart": 6,
+        "targetEnd": 10
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-confusable-shit-s",
+    "text": "ѕhit",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "confusable", "cyrillic"],
+    "matches": [
+      {
+        "ruleId": "shit-obfuscated",
+        "text": "ѕhit",
+        "start": 0,
+        "end": 4,
+        "targetText": "ѕhit",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-confusable-shit-i",
+    "text": "shіt",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "confusable", "cyrillic"],
+    "matches": [
+      {
+        "ruleId": "shit-obfuscated",
+        "text": "shіt",
+        "start": 0,
+        "end": 4,
+        "targetText": "shіt",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-confusable-shit-bull-i",
+    "text": "bullshіt",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "confusable", "cyrillic", "compound", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "shit-obfuscated",
+        "text": "bullshіt",
+        "start": 0,
+        "end": 8,
+        "targetText": "shіt",
+        "targetStart": 4,
+        "targetEnd": 8
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-confusable-bitch-plural-i",
+    "text": "bіtches",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "confusable", "cyrillic", "plural", "inflection", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "bitch-obfuscated",
+        "text": "bіtches",
+        "start": 0,
+        "end": 7,
+        "targetText": "bіtch",
+        "targetStart": 0,
+        "targetEnd": 5
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-confusable-asshole-a",
+    "text": "аsshole",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "confusable", "cyrillic"],
+    "matches": [
+      {
+        "ruleId": "asshole-obfuscated",
+        "text": "аsshole",
+        "start": 0,
+        "end": 7,
+        "targetText": "аsshole",
+        "targetStart": 0,
+        "targetEnd": 7
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-confusable-asshole-plural-o",
+    "text": "asshоles",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "confusable", "cyrillic", "plural", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "asshole-obfuscated",
+        "text": "asshоles",
+        "start": 0,
+        "end": 8,
+        "targetText": "asshоle",
+        "targetStart": 0,
+        "targetEnd": 7
+      }
+    ]
+  },
+  {
+    "id": "obfuscated-confusable-cunt-plural-c",
+    "text": "сunts",
+    "profile": "obfuscated",
+    "tags": ["obfuscation", "confusable", "cyrillic", "plural", "semantic-target"],
+    "matches": [
+      {
+        "ruleId": "cunt-obfuscated",
+        "text": "сunts",
+        "start": 0,
+        "end": 5,
+        "targetText": "сunt",
+        "targetStart": 0,
+        "targetEnd": 4
+      }
+    ]
+  }
+]

--- a/packages/en/src/corpus.ts
+++ b/packages/en/src/corpus.ts
@@ -1,5 +1,7 @@
 import cleanCorpus from './corpus-data/clean.json' with { type: 'json' };
 import obfuscatedCleanCorpus from './corpus-data/obfuscated-clean.json' with { type: 'json' };
+import obfuscatedConfusableCleanCorpus from './corpus-data/obfuscated-confusable-clean.json' with { type: 'json' };
+import obfuscatedConfusableCorpus from './corpus-data/obfuscated-confusable.json' with { type: 'json' };
 import obfuscatedWidthCleanCorpus from './corpus-data/obfuscated-width-clean.json' with { type: 'json' };
 import obfuscatedWidthCorpus from './corpus-data/obfuscated-width.json' with { type: 'json' };
 import obfuscatedCorpus from './corpus-data/obfuscated.json' with { type: 'json' };
@@ -39,10 +41,12 @@ export const englishCleanCorpus: readonly EnglishCorpusCase[] = cleanCorpus;
 export const englishObfuscatedProfanityCorpus: readonly EnglishCorpusCase[] = [
   ...obfuscatedCorpus,
   ...obfuscatedWidthCorpus,
+  ...obfuscatedConfusableCorpus,
 ];
 
 /** False-positive and over-budget cases for the opt-in obfuscated pack. */
 export const englishObfuscatedCleanCorpus: readonly EnglishCorpusCase[] = [
   ...obfuscatedCleanCorpus,
   ...obfuscatedWidthCleanCorpus,
+  ...obfuscatedConfusableCleanCorpus,
 ];

--- a/packages/en/src/index.test.ts
+++ b/packages/en/src/index.test.ts
@@ -86,6 +86,10 @@ describe('@scrawlix/en', () => {
     expect(marked(obfuscatedEngine.segment('fuckｉng motherｆucker'))).toBe(
       '[fuck]ｉng mother[ｆuck]er'
     );
+    expect(marked(obfuscatedEngine.segment('fuckіng motherfuсker'))).toBe(
+      '[fuck]іng mother[fuсk]er'
+    );
+    expect(marked(obfuscatedEngine.segment('asshоles'))).toBe('[asshоle]s');
   });
 
   it('exports composable canonical and opt-in obfuscated packs', () => {

--- a/packages/en/src/index.ts
+++ b/packages/en/src/index.ts
@@ -4,8 +4,8 @@ import {
   type CensorRulePack,
   type CoverageSelector,
 } from '@scrawlix/core';
+import { censorRuleFromConfusableObfuscatedTerms } from '@scrawlix/core/confusable-obfuscated';
 import type { TargetedObfuscatedTerm } from '@scrawlix/core/targeted-obfuscated';
-import { censorRuleFromWidthObfuscatedTerms } from '@scrawlix/core/width-obfuscated';
 
 /**
  * Covers orthographic English vowels (a/e/i/o/u) inside the semantic target.
@@ -89,6 +89,20 @@ const englishObfuscatedWidthVariants = {
   y: ['ｙ'],
 } as const;
 
+/**
+ * Reviewed cross-script lookalikes observed in English-style evasions.
+ * This list is deliberately small; other Greek/Cyrillic/math lookalikes remain
+ * clean until they receive corpus evidence and explicit review.
+ */
+const englishObfuscatedConfusables = {
+  a: ['а'], // Cyrillic small a U+0430
+  c: ['с'], // Cyrillic small es U+0441
+  e: ['е'], // Cyrillic small ie U+0435
+  i: ['і'], // Cyrillic small Ukrainian i U+0456
+  o: ['о'], // Cyrillic small o U+043E
+  s: ['ѕ'], // Cyrillic small dze U+0455
+} as const;
+
 function targetedForms(
   target: string,
   forms: readonly string[]
@@ -143,76 +157,86 @@ const englishCuntForms = targetedForms('cunt', ['cunt', 'cunts']);
  * Conservative opt-in evasions mirroring the canonical pack's declared forms.
  *
  * Each candidate may use one reviewed substitution, one reviewed internal
- * separator/zero-width insertion, one excess repeated letter, or one reviewed
- * fullwidth ASCII grapheme. The combined budget remains one transform. Full
- * inflections/compounds are matched while coverage and target metadata stay
- * attached to the canonical profanity root.
+ * separator/zero-width insertion, one excess repeated letter, one reviewed
+ * fullwidth ASCII grapheme, or one reviewed Unicode confusable. The combined
+ * budget remains one transform. Full inflections/compounds are matched while
+ * coverage and target metadata stay attached to the canonical profanity root.
  */
 export const englishObfuscatedStrongProfanityRules: readonly CensorRule[] = [
-  censorRuleFromWidthObfuscatedTerms('fuck-obfuscated', englishFuckForms, {
+  censorRuleFromConfusableObfuscatedTerms('fuck-obfuscated', englishFuckForms, {
     substitutions: {
       u: ['*'],
       c: ['('],
     },
     widthVariants: englishObfuscatedWidthVariants,
+    confusables: englishObfuscatedConfusables,
     ignored: englishObfuscatedIgnored,
     maxSubstitutions: 1,
     maxIgnored: 1,
     maxRepetitions: 1,
     maxWidthVariants: 1,
+    maxConfusables: 1,
     maxChanges: 1,
   }),
-  censorRuleFromWidthObfuscatedTerms('shit-obfuscated', englishShitForms, {
+  censorRuleFromConfusableObfuscatedTerms('shit-obfuscated', englishShitForms, {
     substitutions: {
       s: ['$', '5'],
       i: ['1', '!', '*'],
       t: ['7'],
     },
     widthVariants: englishObfuscatedWidthVariants,
+    confusables: englishObfuscatedConfusables,
     ignored: englishObfuscatedIgnored,
     maxSubstitutions: 1,
     maxIgnored: 1,
     maxRepetitions: 1,
     maxWidthVariants: 1,
+    maxConfusables: 1,
     maxChanges: 1,
   }),
-  censorRuleFromWidthObfuscatedTerms('bitch-obfuscated', englishBitchForms, {
+  censorRuleFromConfusableObfuscatedTerms('bitch-obfuscated', englishBitchForms, {
     substitutions: {
       i: ['1', '!', '*'],
       t: ['7'],
     },
     widthVariants: englishObfuscatedWidthVariants,
+    confusables: englishObfuscatedConfusables,
     ignored: englishObfuscatedIgnored,
     maxSubstitutions: 1,
     maxIgnored: 1,
     maxRepetitions: 1,
     maxWidthVariants: 1,
+    maxConfusables: 1,
     maxChanges: 1,
   }),
-  censorRuleFromWidthObfuscatedTerms('asshole-obfuscated', englishAssholeForms, {
+  censorRuleFromConfusableObfuscatedTerms('asshole-obfuscated', englishAssholeForms, {
     substitutions: {
       a: ['@'],
       s: ['$', '5'],
       o: ['0'],
     },
     widthVariants: englishObfuscatedWidthVariants,
+    confusables: englishObfuscatedConfusables,
     ignored: englishObfuscatedIgnored,
     maxSubstitutions: 1,
     maxIgnored: 1,
     maxRepetitions: 1,
     maxWidthVariants: 1,
+    maxConfusables: 1,
     maxChanges: 1,
   }),
-  censorRuleFromWidthObfuscatedTerms('cunt-obfuscated', englishCuntForms, {
+  censorRuleFromConfusableObfuscatedTerms('cunt-obfuscated', englishCuntForms, {
     substitutions: {
       u: ['*'],
     },
     widthVariants: englishObfuscatedWidthVariants,
+    confusables: englishObfuscatedConfusables,
     ignored: englishObfuscatedIgnored,
     maxSubstitutions: 1,
     maxIgnored: 1,
     maxRepetitions: 1,
     maxWidthVariants: 1,
+    maxConfusables: 1,
     maxChanges: 1,
   }),
 ] as const;


### PR DESCRIPTION
## Summary
Dogfood the explicit confusable core helper in the opt-in English aggressive pack while preserving the global one-change policy.

- switch English aggressive rules to `censorRuleFromConfusableObfuscatedTerms()`
- add a deliberately small reviewed confusable table: Cyrillic `а`, `с`, `е`, Ukrainian `і`, Cyrillic `о`, and Cyrillic `ѕ`
- add `maxConfusables: 1` while keeping `maxChanges: 1`, so each candidate may use one confusable OR one width variant OR one substitution OR one separator OR one excess repeat
- preserve all existing morphology, semantic-root, substitution, separator, repetition, and width behavior
- add a separate confusable corpus with 10 positive cases across roots, suffixes, compounds, and plurals
- add a separate confusable-clean corpus with 10 regressions covering mixed transform budgets, two-confusable attempts, word-boundary traps, ordinary words, and unreviewed Greek lookalikes
- aggregate the confusable corpus into the existing public aggressive corpus exports
- assert root-only coverage for confusables inside and outside semantic roots
- wire the demo source alias for `@scrawlix/core/confusable-obfuscated`
- document the exact six-character reviewed set and the unreviewed-lookalike policy
- exercise English confusable target metadata through installed-tarball runtime smoke

## Review expectation
`corpus:diff` should report exactly 20 new cases: 10 newly matching + 10 added clean regressions. Existing aggressive corpus cases should remain behaviorally unchanged.

## Guardrail
Reviewing a Cyrillic lookalike does not enable Greek or other-script lookalikes automatically. Fullwidth and compatibility forms stay in their own classes. The pack continues to cap every candidate at one total aggressive transform.

Depends on merged #129.
Completes the transform-class work in #38.