### PR TITLE
Add a shared framework-neutral corpus runner

### DIFF
--- a/docs/corpus-runner.md
+++ b/docs/corpus-runner.md
@@ -1,0 +1,94 @@
+# Shared corpus runner
+
+Language packs can evaluate their JSON regression cases through the framework-neutral helpers exported from `@scrawlix/core/corpus`.
+
+The runner owns the common execution contract:
+
+- resolve the case's named `profile` to a registered Scrawlix engine;
+- compare full-match and semantic-target text plus exact UTF-16 source ranges;
+- require every actual match to report the same active profile as the corpus case;
+- compare optional `packId` provenance when the corpus declares it;
+- verify `segment()` reconstructs the exact original source string;
+- produce case-scoped diagnostic output when behavior differs.
+
+It does not choose language rules or infer which profile should be active. A pack registers those engines explicitly once.
+
+## Vitest or Jest-style per-case tests
+
+```ts
+import { createScrawlix } from '@scrawlix/core';
+import { createCorpusRunner } from '@scrawlix/core/corpus';
+import { it } from 'vitest';
+import { myCorpus } from './corpus';
+import { canonicalRules, aggressiveRules } from './index';
+
+const runCorpusCase = createCorpusRunner({
+  canonical: createScrawlix({ rules: canonicalRules }),
+  obfuscated: createScrawlix({ rules: aggressiveRules }),
+});
+
+it.each(myCorpus)('$id', corpusCase => {
+  runCorpusCase(corpusCase);
+});
+```
+
+After this wiring exists, adding another ordinary regression case requires only a JSON edit. The stable case id becomes the test name.
+
+## One-shot or CLI-style validation
+
+```ts
+import { assertCorpus } from '@scrawlix/core/corpus';
+
+const summary = assertCorpus(myCorpus, {
+  canonical: canonicalEngine,
+  obfuscated: aggressiveEngine,
+});
+
+console.log(summary.caseCount, summary.matchCount);
+```
+
+`assertCorpus()` collects every failed case and throws one aggregated error. `evaluateCorpus()` returns the failure objects instead when a tool wants to format or store them itself.
+
+For one case, use `evaluateCorpusCase()` or `assertCorpusCase()`.
+
+## Corpus types
+
+`@scrawlix/core/corpus` exports the shared types used by the runner:
+
+- `CorpusCase`
+- `CorpusExpectedMatch`
+- `CorpusProfileEngines`
+- `CorpusCaseResult`
+- `CorpusCaseFailure`
+
+A corpus case contains its stable id, exact source text, named profile, tags, optional note, and expected matches. Expected matches contain rule id, full/target text, and exact UTF-16 ranges. `packId` is optional: declare it only when the corpus intentionally verifies composed-pack provenance.
+
+The JSON Schema in `schemas/corpus.schema.json` accepts the same optional `packId` field.
+
+## Failure behavior
+
+The runner reports missing profile engines explicitly. Match metadata differences include expected and actual snapshots. Profile provenance failures are reported separately from range/text mismatches, which makes an accidental `canonical`/`obfuscated` routing change visible even when the same text still matches.
+
+Source reconstruction is also checked separately. A matcher can therefore have correct expected ranges and still fail the corpus runner if its engine segmentation loses or rewrites caller-owned source text.
+
+## Relation to corpus validation and diffing
+
+These tools serve different jobs:
+
+- `pnpm validate:corpora` validates JSON schema, stable ids, and declared source-range invariants without executing rules.
+- the shared corpus runner executes pack rules against those cases and compares actual behavior.
+- `pnpm corpus:diff -- <base-ref> [head-ref|WORKTREE]` shows the expected behavioral delta between two corpus revisions before merge.
+
+Pack CI should keep schema validation and executable corpus tests. Pull-request CI already prints the corpus diff against the exact base commit.
+
+## Author workflow
+
+For a normal matcher change:
+
+1. add the newly handled source form to a corpus JSON file;
+2. add plausible clean/near-neighbor cases alongside it;
+3. run the pack tests through the shared runner;
+4. run `pnpm corpus:diff -- main` to inspect the declared behavior change;
+5. review any newly matching ordinary text before merge.
+
+The next #52 tooling layer can build on the same case types/results for offline false-positive candidate mining without coupling mining logic to Vitest or one language package.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,8 @@
     "src/targeted-obfuscated.ts",
     "src/repeated-obfuscated.ts",
     "src/width-obfuscated.ts",
-    "src/confusable-obfuscated.ts"
+    "src/confusable-obfuscated.ts",
+    "src/corpus.ts"
   ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -42,6 +43,11 @@
       "types": "./dist/confusable-obfuscated.d.ts",
       "import": "./dist/confusable-obfuscated.js",
       "default": "./dist/confusable-obfuscated.js"
+    },
+    "./corpus": {
+      "types": "./dist/corpus.d.ts",
+      "import": "./dist/corpus.js",
+      "default": "./dist/corpus.js"
     }
   },
   "repository": {

--- a/packages/core/src/corpus.test.ts
+++ b/packages/core/src/corpus.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import {
+  censorRuleFromTerms,
+  createScrawlix,
+  rulesFromPacks,
+  type ScrawlixEngine,
+} from './index';
+import {
+  assertCorpus,
+  createCorpusRunner,
+  evaluateCorpus,
+  evaluateCorpusCase,
+  type CorpusCase,
+} from './corpus';
+
+const canonicalEngine = createScrawlix({
+  rules: [censorRuleFromTerms('bad', ['bad'])],
+  coverage: 'full',
+});
+
+const canonicalCases: readonly CorpusCase[] = [
+  {
+    id: 'bad-base',
+    text: 'bad',
+    profile: 'canonical',
+    tags: ['base'],
+    matches: [
+      {
+        ruleId: 'bad',
+        text: 'bad',
+        start: 0,
+        end: 3,
+        targetText: 'bad',
+        targetStart: 0,
+        targetEnd: 3,
+      },
+    ],
+  },
+  {
+    id: 'bad-clean-neighbor',
+    text: 'badly',
+    profile: 'canonical',
+    tags: ['false-positive'],
+    matches: [],
+  },
+];
+
+describe('shared corpus runner', () => {
+  it('evaluates positive and clean cases through a named profile engine', () => {
+    expect(
+      assertCorpus(canonicalCases, { canonical: canonicalEngine })
+    ).toEqual({
+      caseCount: 2,
+      matchCount: 1,
+    });
+    expect(
+      evaluateCorpus(canonicalCases, { canonical: canonicalEngine })
+    ).toEqual([]);
+  });
+
+  it('creates a reusable case runner for test-framework loops', () => {
+    const runCase = createCorpusRunner({ canonical: canonicalEngine });
+
+    expect(runCase(canonicalCases[0]!)).toEqual({
+      ok: true,
+      caseId: 'bad-base',
+      profile: 'canonical',
+      matchCount: 1,
+    });
+  });
+
+  it('reports exact metadata differences with the corpus case id', () => {
+    const wrong: CorpusCase = {
+      ...canonicalCases[0]!,
+      matches: [
+        {
+          ...canonicalCases[0]!.matches[0]!,
+          targetEnd: 2,
+          targetText: 'ba',
+        },
+      ],
+    };
+
+    const runCase = createCorpusRunner({ canonical: canonicalEngine });
+    expect(() => runCase(wrong)).toThrow('Corpus case "bad-base" (canonical) failed');
+    expect(() => runCase(wrong)).toThrow('Expected match metadata');
+  });
+
+  it('reports a missing profile engine explicitly', () => {
+    const result = evaluateCorpusCase(canonicalCases[0]!, {});
+
+    expect(result).toMatchObject({
+      ok: false,
+      caseId: 'bad-base',
+      profile: 'canonical',
+    });
+    if (!result.ok) {
+      expect(result.messages[0]).toContain('No corpus engine was registered');
+    }
+  });
+
+  it('checks active match-profile provenance', () => {
+    const wrongProfileEngine = createScrawlix({
+      rules: [
+        censorRuleFromTerms('bad', ['bad'], {
+          profile: 'obfuscated',
+        }),
+      ],
+    });
+
+    const result = evaluateCorpusCase(canonicalCases[0]!, {
+      canonical: wrongProfileEngine,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.messages.join('\n')).toContain(
+        'Match profile provenance differed from corpus profile'
+      );
+    }
+  });
+
+  it('checks pack provenance only when the corpus declares it', () => {
+    const packEngine = createScrawlix({
+      rules: rulesFromPacks({
+        id: 'example-pack',
+        rules: [censorRuleFromTerms('bad', ['bad'])],
+      }),
+    });
+    const withPack: CorpusCase = {
+      ...canonicalCases[0]!,
+      matches: [
+        {
+          ...canonicalCases[0]!.matches[0]!,
+          packId: 'example-pack',
+        },
+      ],
+    };
+
+    expect(evaluateCorpusCase(withPack, { canonical: packEngine }).ok).toBe(true);
+    expect(
+      evaluateCorpusCase(canonicalCases[0]!, { canonical: packEngine }).ok
+    ).toBe(true);
+  });
+
+  it('detects broken source reconstruction independently of match metadata', () => {
+    const broken: ScrawlixEngine = {
+      find: text => canonicalEngine.find(text),
+      segment: text => [
+        {
+          text: text.slice(0, -1),
+          covered: false,
+          ruleIds: [],
+        },
+      ],
+    };
+
+    const result = evaluateCorpusCase(canonicalCases[0]!, {
+      canonical: broken,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.messages.join('\n')).toContain(
+        'segment() failed exact source reconstruction'
+      );
+    }
+  });
+});

--- a/packages/core/src/corpus.ts
+++ b/packages/core/src/corpus.ts
@@ -1,0 +1,232 @@
+import type { ScrawlixEngine, ScrawlixMatch } from './index.js';
+
+export type CorpusExpectedMatch = {
+  ruleId: string;
+  /** Optional expected pack provenance when a corpus is run through composed packs. */
+  packId?: string;
+  text: string;
+  start: number;
+  end: number;
+  targetText: string;
+  targetStart: number;
+  targetEnd: number;
+};
+
+export type CorpusCase = {
+  id: string;
+  text: string;
+  /** Named engine/profile used to evaluate this case. */
+  profile: string;
+  tags: readonly string[];
+  note?: string;
+  matches: readonly CorpusExpectedMatch[];
+};
+
+export type CorpusProfileEngines = Readonly<Record<string, ScrawlixEngine>>;
+
+export type CorpusActualMatch = CorpusExpectedMatch & {
+  profile?: string;
+};
+
+export type CorpusCaseFailure = {
+  caseId: string;
+  profile: string;
+  messages: readonly string[];
+  expectedMatches: readonly CorpusExpectedMatch[];
+  actualMatches: readonly CorpusActualMatch[];
+};
+
+export type CorpusCaseResult =
+  | {
+      ok: true;
+      caseId: string;
+      profile: string;
+      matchCount: number;
+    }
+  | ({ ok: false } & CorpusCaseFailure);
+
+function actualMatchSnapshot(
+  match: ScrawlixMatch,
+  expected: CorpusExpectedMatch | undefined
+): CorpusActualMatch {
+  return {
+    ruleId: match.ruleId,
+    ...(expected?.packId !== undefined ? { packId: match.packId } : {}),
+    profile: match.profile,
+    text: match.text,
+    start: match.start,
+    end: match.end,
+    targetText: match.targetText,
+    targetStart: match.targetStart,
+    targetEnd: match.targetEnd,
+  };
+}
+
+function expectedMatchSnapshot(match: CorpusExpectedMatch) {
+  return {
+    ruleId: match.ruleId,
+    ...(match.packId !== undefined ? { packId: match.packId } : {}),
+    text: match.text,
+    start: match.start,
+    end: match.end,
+    targetText: match.targetText,
+    targetStart: match.targetStart,
+    targetEnd: match.targetEnd,
+  };
+}
+
+function comparableActualMatch(match: CorpusActualMatch) {
+  return {
+    ruleId: match.ruleId,
+    ...(match.packId !== undefined ? { packId: match.packId } : {}),
+    text: match.text,
+    start: match.start,
+    end: match.end,
+    targetText: match.targetText,
+    targetStart: match.targetStart,
+    targetEnd: match.targetEnd,
+  };
+}
+
+function jsonEqual(left: unknown, right: unknown) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function formatValue(value: unknown) {
+  return JSON.stringify(value, null, 2);
+}
+
+/** Evaluate one corpus case without depending on a test framework. */
+export function evaluateCorpusCase(
+  corpusCase: CorpusCase,
+  engines: CorpusProfileEngines
+): CorpusCaseResult {
+  const engine = engines[corpusCase.profile];
+  if (!engine) {
+    return {
+      ok: false,
+      caseId: corpusCase.id,
+      profile: corpusCase.profile,
+      messages: [
+        `No corpus engine was registered for profile ${JSON.stringify(corpusCase.profile)}.`,
+      ],
+      expectedMatches: corpusCase.matches,
+      actualMatches: [],
+    };
+  }
+
+  const found = engine.find(corpusCase.text);
+  const actualMatches = found.map((match, index) =>
+    actualMatchSnapshot(match, corpusCase.matches[index])
+  );
+  const messages: string[] = [];
+
+  const wrongProfiles = found
+    .filter(match => match.profile !== corpusCase.profile)
+    .map(match => ({
+      ruleId: match.ruleId,
+      expectedProfile: corpusCase.profile,
+      actualProfile: match.profile,
+      text: match.text,
+      start: match.start,
+      end: match.end,
+    }));
+  if (wrongProfiles.length > 0) {
+    messages.push(
+      `Match profile provenance differed from corpus profile:\n${formatValue(wrongProfiles)}`
+    );
+  }
+
+  const expectedMatches = corpusCase.matches.map(expectedMatchSnapshot);
+  const comparableActual = actualMatches.map(comparableActualMatch);
+  if (!jsonEqual(comparableActual, expectedMatches)) {
+    messages.push(
+      `Expected match metadata:\n${formatValue(expectedMatches)}\nActual match metadata:\n${formatValue(comparableActual)}`
+    );
+  }
+
+  const reconstructed = engine
+    .segment(corpusCase.text)
+    .map(segment => segment.text)
+    .join('');
+  if (reconstructed !== corpusCase.text) {
+    messages.push(
+      `segment() failed exact source reconstruction: expected ${JSON.stringify(corpusCase.text)}, received ${JSON.stringify(reconstructed)}.`
+    );
+  }
+
+  if (messages.length > 0) {
+    return {
+      ok: false,
+      caseId: corpusCase.id,
+      profile: corpusCase.profile,
+      messages,
+      expectedMatches: corpusCase.matches,
+      actualMatches,
+    };
+  }
+
+  return {
+    ok: true,
+    caseId: corpusCase.id,
+    profile: corpusCase.profile,
+    matchCount: found.length,
+  };
+}
+
+/** Format one failed corpus case as a readable test/CLI error. */
+export function formatCorpusCaseFailure(failure: CorpusCaseFailure) {
+  return [
+    `Corpus case ${JSON.stringify(failure.caseId)} (${failure.profile}) failed:`,
+    ...failure.messages.map(message => `- ${message.replaceAll('\n', '\n  ')}`),
+  ].join('\n');
+}
+
+/** Evaluate one case and throw a case-scoped error on mismatch. */
+export function assertCorpusCase(
+  corpusCase: CorpusCase,
+  engines: CorpusProfileEngines
+) {
+  const result = evaluateCorpusCase(corpusCase, engines);
+  if (!result.ok) {
+    throw new Error(formatCorpusCaseFailure(result));
+  }
+  return result;
+}
+
+/**
+ * Register profile engines once and obtain a reusable case runner suitable for
+ * Vitest/Jest `it.each`, Node test loops, or custom pack tooling.
+ */
+export function createCorpusRunner(engines: CorpusProfileEngines) {
+  return (corpusCase: CorpusCase) => assertCorpusCase(corpusCase, engines);
+}
+
+/** Evaluate an entire corpus and return every failure without throwing. */
+export function evaluateCorpus(
+  cases: readonly CorpusCase[],
+  engines: CorpusProfileEngines
+) {
+  return cases
+    .map(corpusCase => evaluateCorpusCase(corpusCase, engines))
+    .filter((result): result is CorpusCaseFailure & { ok: false } => !result.ok);
+}
+
+/** Evaluate an entire corpus and throw one aggregated error when any case fails. */
+export function assertCorpus(
+  cases: readonly CorpusCase[],
+  engines: CorpusProfileEngines
+) {
+  const failures = evaluateCorpus(cases, engines);
+  if (failures.length > 0) {
+    throw new Error(failures.map(formatCorpusCaseFailure).join('\n\n'));
+  }
+
+  return {
+    caseCount: cases.length,
+    matchCount: cases.reduce((total, corpusCase) => {
+      const engine = engines[corpusCase.profile];
+      return total + (engine ? engine.find(corpusCase.text).length : 0);
+    }, 0),
+  };
+}

--- a/packages/en/README.md
+++ b/packages/en/README.md
@@ -85,19 +85,43 @@ Matches from this pack expose `profile: 'obfuscated'` and `packId: 'en-strong-pr
 
 The reviewed tables and form families live in ordinary package code, and positive plus false-positive/over-budget cases live in JSON corpora. Width and confusable cases live in separate corpus files so reviewers can inspect those behaviors independently.
 
-## Regression data
+## Regression data and shared runner
 
 Regression data is available from the explicit subpath:
 
 ```ts
 import {
   englishCleanCorpus,
+  englishCorpus,
   englishObfuscatedCleanCorpus,
   englishObfuscatedProfanityCorpus,
   englishProfanityCorpus,
 } from '@scrawlix/en/corpus';
 ```
 
+`englishCorpus` aggregates every bundled canonical/aggressive positive and clean case. It can be run directly through the framework-neutral core corpus helper:
+
+```ts
+import { createScrawlix } from '@scrawlix/core';
+import { createCorpusRunner } from '@scrawlix/core/corpus';
+import {
+  englishObfuscatedStrongProfanityRules,
+  englishStrongProfanityRules,
+} from '@scrawlix/en';
+import { englishCorpus } from '@scrawlix/en/corpus';
+
+const runCorpusCase = createCorpusRunner({
+  canonical: createScrawlix({ rules: englishStrongProfanityRules }),
+  obfuscated: createScrawlix({ rules: englishObfuscatedStrongProfanityRules }),
+});
+
+for (const corpusCase of englishCorpus) {
+  runCorpusCase(corpusCase);
+}
+```
+
+The package's own Vitest suite uses this same runner, so ordinary future corpus-case additions stay data-only once profile engines are registered.
+
 The current package is intentionally narrow strong-profanity coverage. It is a reviewable set of English rules and aggressive examples, with explicit corpus evidence for the scope it claims.
 
-See the [language-pack guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/language-packs.md) for authoring, composition, boundary, Unicode, and obfuscation guidance. Use the [confusable-matching guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/confusable-matching.md) for reviewed lookalike policy, and the [troubleshooting guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/troubleshooting.md) for edge/boundary or no-match diagnostics.
+See the [language-pack guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/language-packs.md) for authoring, composition, boundary, Unicode, and obfuscation guidance. Use the [shared corpus-runner guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/corpus-runner.md) for executable corpus tests, the [confusable-matching guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/confusable-matching.md) for reviewed lookalike policy, and the [troubleshooting guide](https://github.com/teamleaderleo/scrawlix/blob/main/docs/troubleshooting.md) for edge/boundary or no-match diagnostics.

--- a/packages/en/src/corpus.ts
+++ b/packages/en/src/corpus.ts
@@ -1,3 +1,7 @@
+import type {
+  CorpusCase,
+  CorpusExpectedMatch,
+} from '@scrawlix/core/corpus';
 import cleanCorpus from './corpus-data/clean.json' with { type: 'json' };
 import obfuscatedCleanCorpus from './corpus-data/obfuscated-clean.json' with { type: 'json' };
 import obfuscatedConfusableCleanCorpus from './corpus-data/obfuscated-confusable-clean.json' with { type: 'json' };
@@ -7,24 +11,8 @@ import obfuscatedWidthCorpus from './corpus-data/obfuscated-width.json' with { t
 import obfuscatedCorpus from './corpus-data/obfuscated.json' with { type: 'json' };
 import profanityCorpus from './corpus-data/profanity.json' with { type: 'json' };
 
-export type EnglishCorpusMatch = {
-  ruleId: string;
-  text: string;
-  start: number;
-  end: number;
-  targetText: string;
-  targetStart: number;
-  targetEnd: number;
-};
-
-export type EnglishCorpusCase = {
-  id: string;
-  text: string;
-  profile: string;
-  tags: readonly string[];
-  note?: string;
-  matches: readonly EnglishCorpusMatch[];
-};
+export type EnglishCorpusMatch = CorpusExpectedMatch;
+export type EnglishCorpusCase = CorpusCase;
 
 /**
  * Reviewable regression data for the bundled English profanity rules.
@@ -49,4 +37,12 @@ export const englishObfuscatedCleanCorpus: readonly EnglishCorpusCase[] = [
   ...obfuscatedCleanCorpus,
   ...obfuscatedWidthCleanCorpus,
   ...obfuscatedConfusableCleanCorpus,
+];
+
+/** Complete bundled English regression corpus, ready for the shared runner. */
+export const englishCorpus: readonly EnglishCorpusCase[] = [
+  ...englishProfanityCorpus,
+  ...englishCleanCorpus,
+  ...englishObfuscatedProfanityCorpus,
+  ...englishObfuscatedCleanCorpus,
 ];

--- a/packages/en/src/index.test.ts
+++ b/packages/en/src/index.test.ts
@@ -3,13 +3,9 @@ import {
   rulesFromPacks,
   type ScrawlixSegment,
 } from '@scrawlix/core';
+import { createCorpusRunner } from '@scrawlix/core/corpus';
 import { describe, expect, it } from 'vitest';
-import {
-  englishCleanCorpus,
-  englishObfuscatedCleanCorpus,
-  englishObfuscatedProfanityCorpus,
-  englishProfanityCorpus,
-} from './corpus';
+import { englishCorpus } from './corpus';
 import {
   englishObfuscatedStrongProfanityPack,
   englishObfuscatedStrongProfanityRules,
@@ -24,24 +20,6 @@ function marked(segments: readonly ScrawlixSegment[]) {
     .join('');
 }
 
-function expectedMatches(
-  engine: ReturnType<typeof createScrawlix>,
-  text: string,
-  profile: string
-) {
-  const found = engine.find(text);
-  expect(found.every(match => match.profile === profile)).toBe(true);
-  return found.map(match => ({
-    ruleId: match.ruleId,
-    text: match.text,
-    start: match.start,
-    end: match.end,
-    targetText: match.targetText,
-    targetStart: match.targetStart,
-    targetEnd: match.targetEnd,
-  }));
-}
-
 describe('@scrawlix/en', () => {
   const engine = createScrawlix({
     rules: englishStrongProfanityRules,
@@ -51,25 +29,13 @@ describe('@scrawlix/en', () => {
     rules: englishObfuscatedStrongProfanityRules,
     coverage: 'full',
   });
-
-  it.each(englishProfanityCorpus)('$id', corpusCase => {
-    expect(
-      expectedMatches(engine, corpusCase.text, corpusCase.profile)
-    ).toEqual(corpusCase.matches);
+  const runCorpusCase = createCorpusRunner({
+    canonical: engine,
+    obfuscated: obfuscatedEngine,
   });
 
-  it.each(englishCleanCorpus)('$id stays clean', corpusCase => {
-    expect(engine.find(corpusCase.text)).toEqual([]);
-  });
-
-  it.each(englishObfuscatedProfanityCorpus)('$id', corpusCase => {
-    expect(
-      expectedMatches(obfuscatedEngine, corpusCase.text, corpusCase.profile)
-    ).toEqual(corpusCase.matches);
-  });
-
-  it.each(englishObfuscatedCleanCorpus)('$id stays clean', corpusCase => {
-    expect(obfuscatedEngine.find(corpusCase.text)).toEqual([]);
+  it.each(englishCorpus)('$id', corpusCase => {
+    runCorpusCase(corpusCase);
   });
 
   it('covers only the semantic root inside obfuscated inflections and compounds', () => {

--- a/schemas/corpus.schema.json
+++ b/schemas/corpus.schema.json
@@ -61,6 +61,10 @@
           "type": "string",
           "minLength": 1
         },
+        "packId": {
+          "type": "string",
+          "minLength": 1
+        },
         "text": {
           "type": "string",
           "minLength": 1

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
       "@scrawlix/core/confusable-obfuscated": [
         "packages/core/src/confusable-obfuscated.ts"
       ],
+      "@scrawlix/core/corpus": ["packages/core/src/corpus.ts"],
       "@scrawlix/en": ["packages/en/src/index.ts"],
       "@scrawlix/en/corpus": ["packages/en/src/corpus.ts"],
       "@scrawlix/react": ["packages/react/src/index.tsx"],


### PR DESCRIPTION
## Summary
Add the shared executable corpus runner from #52 and migrate the English pack to use it.

- add `@scrawlix/core/corpus`
- add shared `CorpusCase` / `CorpusExpectedMatch` types and profile-engine mapping types
- add `evaluateCorpusCase()`, `assertCorpusCase()`, `createCorpusRunner()`, `evaluateCorpus()`, and `assertCorpus()`
- compare exact full-match/semantic-target text and UTF-16 ranges
- require actual match-profile provenance to equal the corpus case profile
- verify `segment()` reconstructs caller-owned source text exactly
- support optional expected `packId` provenance without forcing pack ids into every corpus
- add optional `packId` to the JSON corpus schema
- add runner regressions for positive/clean cases, readable mismatch output, missing profile engines, wrong profile provenance, optional pack provenance, and source-reconstruction failures
- migrate `@scrawlix/en` from bespoke match-normalization loops to one shared profile registration plus `it.each(englishCorpus)`
- export aggregate `englishCorpus` alongside the existing category-specific arrays
- run the complete installed English corpus through `assertCorpus()` in packed-package runtime smoke
- package the runner source so declaration/source-map targets remain valid after publish
- add a dedicated authoring guide and update the English README

## Author workflow
A pack registers its named profile engines once. After that, ordinary regression additions are JSON-only: the stable case id becomes the per-case test name and the shared runner owns match/target/profile/source-reconstruction checks.

## Tooling roles
- `pnpm validate:corpora` validates corpus data/schema/range declarations
- the shared runner executes the rules against the cases
- `pnpm corpus:diff` shows the expected data delta before merge

Progress on #52
Next: use the shared result/types as the execution seam for offline false-positive candidate mining and human-review workflow.