### PR TITLE
Add offline false-positive lexicon mining

### DIFF
--- a/docs/false-positive-mining.md
+++ b/docs/false-positive-mining.md
@@ -1,0 +1,109 @@
+# Offline false-positive mining
+
+Scrawlix can scan a frequency-ranked ordinary-language lexicon through a real pack profile and surface entries that the matcher catches for human review.
+
+The miner is offline repository tooling. It does not ship a dictionary, frequency dataset, or mining code in runtime packages.
+
+## English convenience command
+
+Build the packages and scan an external lexicon through the bundled English adapter:
+
+```sh
+pnpm corpus:mine:en -- \
+  --profile obfuscated \
+  --lexicon /path/to/frequency-ranked-words.txt
+```
+
+Use `canonical` to inspect the conservative English profile instead.
+
+For a machine-readable review artifact:
+
+```sh
+pnpm corpus:mine:en -- \
+  --profile obfuscated \
+  --lexicon /path/to/frequency-ranked-words.txt \
+  --json \
+  --output tmp/en-obfuscated-mining.json
+```
+
+`--limit 100` stops after the first 100 matching lexicon entries.
+
+## Lexicon format
+
+The input is UTF-8 text with one token or phrase per line in descending frequency order. The parsed line order becomes `rank`.
+
+An optional second tab-separated field can contain a numeric frequency:
+
+```text
+commonword	152340
+anotherword	98112
+phrase without frequency
+```
+
+Blank lines and lines whose trimmed content begins with `#` are ignored.
+
+The repository contains only a tiny synthetic smoke fixture. Bring real dictionaries/frequency datasets from an appropriately licensed local source. External lexicons stay outside published runtime bundles and should stay outside the repository unless their license and inclusion have been reviewed explicitly.
+
+## Generic adapters
+
+`pnpm corpus:mine` accepts any ESM adapter module:
+
+```sh
+pnpm corpus:mine -- \
+  --adapter scripts/mining-profiles/en.mjs \
+  --profile canonical \
+  --lexicon /path/to/list.txt
+```
+
+An adapter exports `miningAdapter` (or a default object) with this shape:
+
+```js
+export const miningAdapter = {
+  id: 'my-pack',
+  profiles: {
+    canonical: canonicalEngine,
+    obfuscated: aggressiveEngine,
+  },
+};
+```
+
+The adapter owns language/profile selection. The generic miner only iterates ranked entries and snapshots actual Scrawlix match metadata.
+
+Adapters that import workspace `dist/` packages need `pnpm build:packages` first. The `corpus:mine:en` convenience command performs that build automatically.
+
+## Review artifact
+
+Every mined hit is emitted with:
+
+- lexicon rank and source text;
+- optional source frequency;
+- selected match profile;
+- `reviewStatus: "unreviewed"`;
+- exact rule/pack/profile and full/target source ranges for every match.
+
+The report itself includes `reviewRequired: true`.
+
+Mining output never becomes a shipped clean corpus automatically. The CLI rejects `--output` paths under `packages/*/src/corpus-data/`.
+
+## Human-review workflow
+
+For each candidate:
+
+1. confirm the source lexicon entry and its language/context;
+2. inspect why the selected Scrawlix profile matched it;
+3. decide whether the behavior is a genuine false positive, an expected profane/evasive form, or lexicon noise;
+4. for a genuine false positive, add an ordinary hand-reviewed clean corpus case with a stable id, tags, and a note/provenance when useful;
+5. adjust matcher policy only when the evidence supports it;
+6. run the shared corpus tests and `pnpm corpus:diff -- main` before merge.
+
+The manual corpus edit is the promotion step. There is intentionally no `--promote` command.
+
+## Why rank is retained
+
+Frequency rank helps reviewers start with potentially high-impact collisions first. The miner does not assign truth or severity from rank: it only carries the lexicon ordering into the review queue.
+
+## CI and reproducibility
+
+`pnpm test` runs a synthetic English miner smoke after package builds. It verifies the adapter and real aggressive matcher path without bringing a third-party dictionary into CI.
+
+Large external mining runs remain an offline maintainer/contributor task because dataset provenance, licensing, size, and update cadence vary independently of Scrawlix releases.

--- a/fixtures/mining/english-ranked.txt
+++ b/fixtures/mining/english-ranked.txt
@@ -1,0 +1,6 @@
+# Synthetic ranked entries for the offline miner smoke test.
+shirt	1000
+sh1t	900
+country	800
+fuсk	700
+assorted	600

--- a/scripts/false-positive-miner-lib.mjs
+++ b/scripts/false-positive-miner-lib.mjs
@@ -1,0 +1,129 @@
+import path from 'node:path';
+
+export function parseRankedLexicon(value) {
+  const entries = [];
+
+  for (const rawLine of value.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    const [textField, frequencyField, ...extra] = rawLine.split('\t');
+    const text = textField?.trim();
+    if (!text) continue;
+    if (extra.length > 0) {
+      throw new Error(
+        `Lexicon line ${JSON.stringify(rawLine)} has more than two tab-separated fields.`
+      );
+    }
+
+    let frequency;
+    if (frequencyField !== undefined && frequencyField.trim() !== '') {
+      frequency = Number(frequencyField.trim());
+      if (!Number.isFinite(frequency) || frequency < 0) {
+        throw new Error(
+          `Lexicon frequency must be a non-negative number: ${JSON.stringify(rawLine)}`
+        );
+      }
+    }
+
+    entries.push({
+      rank: entries.length + 1,
+      text,
+      ...(frequency === undefined ? {} : { frequency }),
+    });
+  }
+
+  return entries;
+}
+
+function matchSnapshot(match) {
+  return {
+    ruleId: match.ruleId,
+    ...(match.packId ? { packId: match.packId } : {}),
+    ...(match.profile ? { profile: match.profile } : {}),
+    text: match.text,
+    start: match.start,
+    end: match.end,
+    targetText: match.targetText,
+    targetStart: match.targetStart,
+    targetEnd: match.targetEnd,
+  };
+}
+
+export function mineFalsePositiveCandidates(
+  entries,
+  engine,
+  { profile, limit = Number.POSITIVE_INFINITY } = {}
+) {
+  if (!profile) throw new Error('A mining profile name is required.');
+  if (!(Number.isInteger(limit) && limit >= 1) && limit !== Number.POSITIVE_INFINITY) {
+    throw new Error('Mining limit must be a positive integer.');
+  }
+
+  const candidates = [];
+
+  for (const entry of entries) {
+    const matches = engine.find(entry.text);
+    if (matches.length === 0) continue;
+
+    candidates.push({
+      rank: entry.rank,
+      text: entry.text,
+      ...(entry.frequency === undefined ? {} : { frequency: entry.frequency }),
+      profile,
+      reviewStatus: 'unreviewed',
+      matches: matches.map(matchSnapshot),
+    });
+
+    if (candidates.length >= limit) break;
+  }
+
+  return candidates;
+}
+
+export function miningReport({ adapterId, profile, lexicon, candidates }) {
+  return {
+    schemaVersion: 1,
+    generatedBy: 'scrawlix corpus:mine',
+    adapterId,
+    profile,
+    lexicon,
+    candidateCount: candidates.length,
+    reviewRequired: true,
+    candidates,
+  };
+}
+
+export function isCorpusDataPath(root, outputPath) {
+  const relative = path
+    .relative(root, path.resolve(root, outputPath))
+    .replaceAll('\\', '/');
+  return /(^|\/)packages\/[^/]+\/src\/corpus-data(?:\/|$)/u.test(relative);
+}
+
+export function formatMiningReport(report) {
+  const lines = [
+    `False-positive mining: ${report.adapterId}/${report.profile}`,
+    `Lexicon: ${report.lexicon}`,
+    `${report.candidateCount} candidate${report.candidateCount === 1 ? '' : 's'} require human review.`,
+  ];
+
+  for (const candidate of report.candidates) {
+    const frequency =
+      candidate.frequency === undefined ? '' : ` frequency=${candidate.frequency}`;
+    lines.push(`- #${candidate.rank} ${JSON.stringify(candidate.text)}${frequency}`);
+    for (const match of candidate.matches) {
+      lines.push(
+        `  ${match.ruleId} ${JSON.stringify(match.text)} -> ${JSON.stringify(match.targetText)} [${match.start},${match.end})/[${match.targetStart},${match.targetEnd})`
+      );
+    }
+  }
+
+  if (report.candidateCount > 0) {
+    lines.push(
+      'Review candidates manually before adding any clean regression case. Mining output is never promoted automatically.'
+    );
+  }
+
+  return lines.join('\n');
+}

--- a/scripts/false-positive-miner-lib.test.mjs
+++ b/scripts/false-positive-miner-lib.test.mjs
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import path from 'node:path';
+import {
+  formatMiningReport,
+  isCorpusDataPath,
+  mineFalsePositiveCandidates,
+  miningReport,
+  parseRankedLexicon,
+} from './false-positive-miner-lib.mjs';
+
+test('parses ranked lexicon lines and optional frequencies', () => {
+  assert.deepEqual(
+    parseRankedLexicon('# comment\nalpha\t100\n\nbeta\n gamma \t 2.5 \n'),
+    [
+      { rank: 1, text: 'alpha', frequency: 100 },
+      { rank: 2, text: 'beta' },
+      { rank: 3, text: 'gamma', frequency: 2.5 },
+    ]
+  );
+});
+
+test('rejects malformed lexicon frequencies and extra fields', () => {
+  assert.throws(
+    () => parseRankedLexicon('alpha\tnope'),
+    /frequency must be a non-negative number/
+  );
+  assert.throws(
+    () => parseRankedLexicon('alpha\t1\textra'),
+    /more than two tab-separated fields/
+  );
+});
+
+test('mines matching lexicon entries in rank order with review status', () => {
+  const engine = {
+    find(text) {
+      if (!text.includes('x')) return [];
+      const start = text.indexOf('x');
+      return [
+        {
+          ruleId: 'x-rule',
+          profile: 'obfuscated',
+          text: 'x',
+          start,
+          end: start + 1,
+          targetText: 'x',
+          targetStart: start,
+          targetEnd: start + 1,
+        },
+      ];
+    },
+  };
+  const entries = parseRankedLexicon('alpha\nbox\t50\nxray\t25\nnext\t10\n');
+
+  assert.deepEqual(
+    mineFalsePositiveCandidates(entries, engine, {
+      profile: 'obfuscated',
+      limit: 2,
+    }),
+    [
+      {
+        rank: 2,
+        text: 'box',
+        frequency: 50,
+        profile: 'obfuscated',
+        reviewStatus: 'unreviewed',
+        matches: [
+          {
+            ruleId: 'x-rule',
+            profile: 'obfuscated',
+            text: 'x',
+            start: 2,
+            end: 3,
+            targetText: 'x',
+            targetStart: 2,
+            targetEnd: 3,
+          },
+        ],
+      },
+      {
+        rank: 3,
+        text: 'xray',
+        frequency: 25,
+        profile: 'obfuscated',
+        reviewStatus: 'unreviewed',
+        matches: [
+          {
+            ruleId: 'x-rule',
+            profile: 'obfuscated',
+            text: 'x',
+            start: 0,
+            end: 1,
+            targetText: 'x',
+            targetStart: 0,
+            targetEnd: 1,
+          },
+        ],
+      },
+    ]
+  );
+});
+
+test('formats a review-oriented report', () => {
+  const report = miningReport({
+    adapterId: 'example',
+    profile: 'canonical',
+    lexicon: 'words.txt',
+    candidates: [
+      {
+        rank: 4,
+        text: 'word',
+        profile: 'canonical',
+        reviewStatus: 'unreviewed',
+        matches: [
+          {
+            ruleId: 'rule',
+            profile: 'canonical',
+            text: 'or',
+            start: 1,
+            end: 3,
+            targetText: 'or',
+            targetStart: 1,
+            targetEnd: 3,
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(report.reviewRequired, true);
+  assert.equal(report.candidates[0].reviewStatus, 'unreviewed');
+  assert.match(formatMiningReport(report), /require human review/);
+  assert.match(formatMiningReport(report), /never promoted automatically/);
+});
+
+test('blocks mining output under shipped corpus-data directories', () => {
+  const root = path.resolve('/repo');
+  assert.equal(
+    isCorpusDataPath(root, 'packages/en/src/corpus-data/mined.json'),
+    true
+  );
+  assert.equal(isCorpusDataPath(root, 'tmp/mined.json'), false);
+  assert.equal(isCorpusDataPath(root, 'fixtures/mining/report.json'), false);
+});
+
+test('requires a profile and validates candidate limits', () => {
+  const engine = { find: () => [] };
+  assert.throws(
+    () => mineFalsePositiveCandidates([], engine),
+    /profile name is required/
+  );
+  assert.throws(
+    () => mineFalsePositiveCandidates([], engine, { profile: 'x', limit: 0 }),
+    /positive integer/
+  );
+});

--- a/scripts/mine-false-positives.mjs
+++ b/scripts/mine-false-positives.mjs
@@ -1,0 +1,139 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
+import {
+  formatMiningReport,
+  isCorpusDataPath,
+  mineFalsePositiveCandidates,
+  miningReport,
+  parseRankedLexicon,
+} from './false-positive-miner-lib.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const usage = `Usage:
+  pnpm corpus:mine -- --adapter <module.mjs> --profile <name> --lexicon <file> [options]
+
+Options:
+  --output <file>   Write the unreviewed JSON report outside packages/*/src/corpus-data/.
+  --limit <n>       Stop after n matching lexicon entries.
+  --json            Print the JSON report instead of the text summary.
+  --help            Show this message.
+
+Lexicon format:
+  One token/phrase per line in descending frequency order.
+  An optional second tab-separated field may contain a numeric frequency.
+`;
+
+function parseArguments(argv) {
+  const args = argv.filter(argument => argument !== '--');
+  const options = {
+    json: false,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--json') {
+      options.json = true;
+      continue;
+    }
+    if (argument === '--help') {
+      options.help = true;
+      continue;
+    }
+    if (
+      argument === '--adapter' ||
+      argument === '--profile' ||
+      argument === '--lexicon' ||
+      argument === '--output' ||
+      argument === '--limit'
+    ) {
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`${argument} requires a value.\n\n${usage}`);
+      }
+      const key = argument.slice(2);
+      options[key] = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument ${JSON.stringify(argument)}.\n\n${usage}`);
+  }
+
+  if (options.help) return options;
+  for (const required of ['adapter', 'profile', 'lexicon']) {
+    if (!options[required]) {
+      throw new Error(`--${required} is required.\n\n${usage}`);
+    }
+  }
+
+  if (options.limit !== undefined) {
+    const limit = Number(options.limit);
+    if (!Number.isInteger(limit) || limit < 1) {
+      throw new Error('--limit must be a positive integer.');
+    }
+    options.limit = limit;
+  }
+
+  return options;
+}
+
+async function loadMiningAdapter(adapterPath) {
+  const absolute = path.resolve(root, adapterPath);
+  const module = await import(pathToFileURL(absolute).href);
+  const adapter = module.miningAdapter ?? module.default;
+  if (!adapter || typeof adapter !== 'object') {
+    throw new Error(
+      `Mining adapter ${JSON.stringify(adapterPath)} must export miningAdapter or a default adapter object.`
+    );
+  }
+  if (typeof adapter.id !== 'string' || !adapter.id) {
+    throw new Error(`Mining adapter ${JSON.stringify(adapterPath)} needs a non-empty id.`);
+  }
+  if (!adapter.profiles || typeof adapter.profiles !== 'object') {
+    throw new Error(`Mining adapter ${JSON.stringify(adapterPath)} needs a profiles object.`);
+  }
+  return adapter;
+}
+
+const options = parseArguments(process.argv.slice(2));
+if (options.help) {
+  console.log(usage);
+  process.exit(0);
+}
+
+const adapter = await loadMiningAdapter(options.adapter);
+const engine = adapter.profiles[options.profile];
+if (!engine || typeof engine.find !== 'function') {
+  const profiles = Object.keys(adapter.profiles).sort();
+  throw new Error(
+    `Mining adapter ${JSON.stringify(adapter.id)} has no engine for profile ${JSON.stringify(options.profile)}. Available profiles: ${profiles.join(', ') || '(none)'}.`
+  );
+}
+
+const lexiconAbsolute = path.resolve(root, options.lexicon);
+const entries = parseRankedLexicon(await fs.readFile(lexiconAbsolute, 'utf8'));
+const candidates = mineFalsePositiveCandidates(entries, engine, {
+  profile: options.profile,
+  ...(options.limit === undefined ? {} : { limit: options.limit }),
+});
+const report = miningReport({
+  adapterId: adapter.id,
+  profile: options.profile,
+  lexicon: path.relative(root, lexiconAbsolute).replaceAll('\\', '/'),
+  candidates,
+});
+
+if (options.output) {
+  if (isCorpusDataPath(root, options.output)) {
+    throw new Error(
+      'Mining output cannot be written under packages/*/src/corpus-data/. Review candidates manually and promote selected clean cases with an ordinary corpus JSON edit.'
+    );
+  }
+  const outputAbsolute = path.resolve(root, options.output);
+  await fs.mkdir(path.dirname(outputAbsolute), { recursive: true });
+  await fs.writeFile(outputAbsolute, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+}
+
+console.log(options.json ? JSON.stringify(report, null, 2) : formatMiningReport(report));

--- a/scripts/mining-profiles/en.mjs
+++ b/scripts/mining-profiles/en.mjs
@@ -1,0 +1,13 @@
+import { createScrawlix } from '../../packages/core/dist/index.js';
+import {
+  englishObfuscatedStrongProfanityRules,
+  englishStrongProfanityRules,
+} from '../../packages/en/dist/index.js';
+
+export const miningAdapter = {
+  id: 'en-strong-profanity',
+  profiles: {
+    canonical: createScrawlix({ rules: englishStrongProfanityRules }),
+    obfuscated: createScrawlix({ rules: englishObfuscatedStrongProfanityRules }),
+  },
+};

--- a/scripts/smoke-false-positive-miner.mjs
+++ b/scripts/smoke-false-positive-miner.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  mineFalsePositiveCandidates,
+  parseRankedLexicon,
+} from './false-positive-miner-lib.mjs';
+import { miningAdapter } from './mining-profiles/en.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const lexicon = await fs.readFile(
+  path.join(root, 'fixtures', 'mining', 'english-ranked.txt'),
+  'utf8'
+);
+const entries = parseRankedLexicon(lexicon);
+const candidates = mineFalsePositiveCandidates(
+  entries,
+  miningAdapter.profiles.obfuscated,
+  { profile: 'obfuscated' }
+);
+
+assert.deepEqual(
+  candidates.map(candidate => [candidate.rank, candidate.text]),
+  [
+    [2, 'sh1t'],
+    [4, 'fuсk'],
+  ]
+);
+assert.ok(candidates.every(candidate => candidate.reviewStatus === 'unreviewed'));
+assert.ok(
+  candidates.every(candidate =>
+    candidate.matches.every(match => match.profile === 'obfuscated')
+  )
+);
+
+console.log('Scrawlix false-positive miner smoke passed.');


### PR DESCRIPTION
Superseded by the corrected save-generation review branch. The original field-intent/Web-Locks design remains, but the replacement also prevents Options' own `storage.onChanged` reload from leaving the UI stuck on `saving…` after a successful commit.