### PR TITLE
Serialize popup and Options settings mutations across contexts

### DIFF
--- a/apps/extension/src/options.ts
+++ b/apps/extension/src/options.ts
@@ -9,19 +9,21 @@ import {
   SYNC_SETTINGS_KEY,
   coverageSelector,
   maskFor,
-  normalizeCustomWords,
-  setSiteMode,
   type ExtensionAppearance,
   type ExtensionCoverage,
   type ExtensionReveal,
   type SyncSettings,
 } from './config';
 import {
+  applySettingsMutation,
+  commitSettingsMutation,
+  type SettingsMutation,
+} from './settings-mutations';
+import {
   loadCustomWords,
   loadExtensionState,
   loadSettings,
   saveCustomWords,
-  saveSettings,
 } from './storage';
 
 const PREVIEW_TERM = 'Mothbit';
@@ -69,6 +71,7 @@ const accessActionStatus = required<HTMLParagraphElement>('access-action-status'
 let settings: SyncSettings;
 let customWords: string[] = [];
 let settingsSaveQueue = Promise.resolve();
+let settingsSaveGeneration = 0;
 let stateGeneration = 0;
 
 function filterMatch(value: string, query: string) {
@@ -103,9 +106,6 @@ function renderPreview() {
   root.dataset.scrawlixReveal = settings.reveal;
   root.dataset.scrawlixRevealed = 'false';
   root.setAttribute('aria-hidden', 'true');
-
-  // The preview is one intentional control in the extension UI, so click reveal
-  // keeps an ordinary keyboard path here even though arbitrary-page fragments do not.
   if (settings.reveal === 'click') root.tabIndex = 0;
 
   for (const segment of engine.segment(PREVIEW_TERM)) {
@@ -204,9 +204,11 @@ function renderSites() {
     }
     select.value = mode;
     select.addEventListener('change', () => {
-      void persistSettings(
-        setSiteMode(settings, hostname, select.value === 'on' ? 'on' : 'off')
-      );
+      void persistSettings({
+        type: 'site-mode',
+        hostname,
+        mode: select.value === 'on' ? 'on' : 'off',
+      });
     });
 
     const remove = document.createElement('button');
@@ -214,7 +216,7 @@ function renderSites() {
     remove.className = 'quiet-button';
     remove.textContent = 'use default';
     remove.addEventListener('click', () => {
-      void persistSettings(setSiteMode(settings, hostname, 'inherit'));
+      void persistSettings({ type: 'site-mode', hostname, mode: 'inherit' });
     });
 
     row.append(text, select, remove);
@@ -302,8 +304,9 @@ async function renderAccess() {
   accessEmpty.hidden = entries.length > 0;
 }
 
-async function persistSettings(next: SyncSettings) {
-  settings = next;
+async function persistSettings(mutation: SettingsMutation) {
+  const generation = ++settingsSaveGeneration;
+  settings = applySettingsMutation(settings, mutation);
   renderGeneral();
   renderSites();
   settingsStatus.textContent = 'saving…';
@@ -312,10 +315,15 @@ async function persistSettings(next: SyncSettings) {
     .catch(() => undefined)
     .then(async () => {
       try {
-        await saveSettings(next);
-        if (settings === next) settingsStatus.textContent = 'saved';
+        const committed = await commitSettingsMutation(mutation);
+        if (generation === settingsSaveGeneration) {
+          settings = committed;
+          renderGeneral();
+          renderSites();
+          settingsStatus.textContent = 'saved';
+        }
       } catch {
-        if (settings === next) {
+        if (generation === settingsSaveGeneration) {
           settings = await loadSettings();
           renderGeneral();
           renderSites();
@@ -349,25 +357,36 @@ async function removeCustomTerm(term: string) {
 }
 
 async function addCustomTerms() {
-  const candidates = normalizeCustomWords(newTermsInput.value.split('\n'));
+  const candidates = newTermsInput.value
+    .split('\n')
+    .map(term => term.trim())
+    .filter(Boolean);
   const accepted = candidates.filter(
     term => Array.from(term).length <= MAX_CUSTOM_TERM_CODE_POINTS
   );
   const rejected = candidates.length - accepted.length;
-  const next = normalizeCustomWords([...customWords, ...accepted]);
-  const added = next.length - customWords.length;
+  const seen = new Set(customWords.map(term => term.toLocaleLowerCase()));
+  const additions = accepted.filter(term => {
+    const key = term.toLocaleLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  const next = [...customWords, ...additions];
 
   if (accepted.length === 0) {
-    customStatus.textContent = rejected > 0 ? 'Terms over the length limit were skipped.' : 'Enter a word or phrase first.';
+    customStatus.textContent = rejected > 0
+      ? 'Terms over the length limit were skipped.'
+      : 'Enter a word or phrase first.';
     return;
   }
 
   await persistCustomWords(
     next,
     rejected > 0
-      ? `Added ${added}; skipped ${rejected} over the length limit`
-      : added > 0
-        ? `Added ${added} ${added === 1 ? 'term' : 'terms'}`
+      ? `Added ${additions.length}; skipped ${rejected} over the length limit`
+      : additions.length > 0
+        ? `Added ${additions.length} ${additions.length === 1 ? 'term' : 'terms'}`
         : 'Those terms are already in your list'
   );
   newTermsInput.value = '';
@@ -387,31 +406,31 @@ async function reloadState() {
 }
 
 activeInput.addEventListener('change', () => {
-  void persistSettings({ ...settings, paused: !activeInput.checked });
+  void persistSettings({ type: 'paused', value: !activeInput.checked });
 });
 
 defaultEnabledSelect.addEventListener('change', () => {
-  void persistSettings({ ...settings, enabled: defaultEnabledSelect.value === 'on' });
+  void persistSettings({ type: 'enabled', value: defaultEnabledSelect.value === 'on' });
 });
 
 appearanceSelect.addEventListener('change', () => {
   void persistSettings({
-    ...settings,
-    appearance: appearanceSelect.value as ExtensionAppearance,
+    type: 'appearance',
+    value: appearanceSelect.value as ExtensionAppearance,
   });
 });
 
 coverageSelect.addEventListener('change', () => {
   void persistSettings({
-    ...settings,
-    coverage: coverageSelect.value as ExtensionCoverage,
+    type: 'coverage',
+    value: coverageSelect.value as ExtensionCoverage,
   });
 });
 
 revealSelect.addEventListener('change', () => {
   void persistSettings({
-    ...settings,
-    reveal: revealSelect.value as ExtensionReveal,
+    type: 'reveal',
+    value: revealSelect.value as ExtensionReveal,
   });
 });
 

--- a/apps/extension/src/settings-mutations.test.ts
+++ b/apps/extension/src/settings-mutations.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_SETTINGS,
+  SITE_OVERRIDES_KEY,
+  SYNC_SETTINGS_KEY,
+} from './config';
+import {
+  applySettingsMutation,
+  commitSettingsMutation,
+} from './settings-mutations';
+
+type Store = Record<string, unknown>;
+
+function storageArea(store: Store) {
+  return {
+    get: vi.fn(async (key: string) =>
+      Object.prototype.hasOwnProperty.call(store, key) ? { [key]: store[key] } : {}
+    ),
+    set: vi.fn(async (value: Store) => {
+      await Promise.resolve();
+      Object.assign(store, value);
+    }),
+  };
+}
+
+function serialLocks() {
+  let queue = Promise.resolve<unknown>(undefined);
+  return {
+    request: vi.fn(<T>(_name: string, callback: () => Promise<T> | T) => {
+      const result = queue.then(callback);
+      queue = result.catch(() => undefined);
+      return result;
+    }),
+  };
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('settings mutations', () => {
+  it('applies one field intent without rewriting unrelated settings', () => {
+    const next = applySettingsMutation(DEFAULT_SETTINGS, {
+      type: 'appearance',
+      value: 'blur',
+    });
+    expect(next).toEqual({ ...DEFAULT_SETTINGS, appearance: 'blur' });
+  });
+
+  it('serializes concurrent extension-page edits and preserves both fields', async () => {
+    const syncStore: Store = {
+      [SYNC_SETTINGS_KEY]: {
+        paused: false,
+        enabled: true,
+        appearance: 'scrawl',
+        coverage: 'middle',
+        reveal: 'hover',
+      },
+    };
+    const localStore: Store = { [SITE_OVERRIDES_KEY]: {} };
+    vi.stubGlobal('chrome', {
+      storage: {
+        sync: storageArea(syncStore),
+        local: storageArea(localStore),
+      },
+    });
+    const locks = serialLocks();
+    vi.stubGlobal('navigator', { locks });
+
+    await Promise.all([
+      commitSettingsMutation({ type: 'appearance', value: 'blur' }),
+      commitSettingsMutation({ type: 'coverage', value: 'full' }),
+    ]);
+
+    expect(syncStore[SYNC_SETTINGS_KEY]).toEqual({
+      paused: false,
+      enabled: true,
+      appearance: 'blur',
+      coverage: 'full',
+      reveal: 'hover',
+    });
+    expect(locks.request).toHaveBeenCalledTimes(2);
+  });
+
+  it('serializes pause and reveal edits without resurrecting stale state', async () => {
+    const syncStore: Store = {
+      [SYNC_SETTINGS_KEY]: {
+        paused: false,
+        enabled: true,
+        appearance: 'scrawl',
+        coverage: 'middle',
+        reveal: 'hover',
+      },
+    };
+    const localStore: Store = { [SITE_OVERRIDES_KEY]: {} };
+    vi.stubGlobal('chrome', {
+      storage: {
+        sync: storageArea(syncStore),
+        local: storageArea(localStore),
+      },
+    });
+    vi.stubGlobal('navigator', { locks: serialLocks() });
+
+    await Promise.all([
+      commitSettingsMutation({ type: 'paused', value: true }),
+      commitSettingsMutation({ type: 'reveal', value: 'never' }),
+    ]);
+
+    expect(syncStore[SYNC_SETTINGS_KEY]).toEqual({
+      paused: true,
+      enabled: true,
+      appearance: 'scrawl',
+      coverage: 'middle',
+      reveal: 'never',
+    });
+  });
+
+  it('keeps a site-mode mutation local while preserving compact preferences', async () => {
+    const syncStore: Store = {
+      [SYNC_SETTINGS_KEY]: {
+        paused: false,
+        enabled: false,
+        appearance: 'bar',
+        coverage: 'full',
+        reveal: 'never',
+      },
+    };
+    const localStore: Store = { [SITE_OVERRIDES_KEY]: {} };
+    vi.stubGlobal('chrome', {
+      storage: {
+        sync: storageArea(syncStore),
+        local: storageArea(localStore),
+      },
+    });
+    vi.stubGlobal('navigator', { locks: serialLocks() });
+
+    const committed = await commitSettingsMutation({
+      type: 'site-mode',
+      hostname: 'Example.COM',
+      mode: 'on',
+    });
+
+    expect(committed.siteOverrides).toEqual({ 'example.com': 'on' });
+    expect(localStore[SITE_OVERRIDES_KEY]).toEqual({ 'example.com': 'on' });
+    expect(syncStore[SYNC_SETTINGS_KEY]).toEqual({
+      paused: false,
+      enabled: false,
+      appearance: 'bar',
+      coverage: 'full',
+      reveal: 'never',
+    });
+  });
+});

--- a/apps/extension/src/settings-mutations.ts
+++ b/apps/extension/src/settings-mutations.ts
@@ -1,0 +1,53 @@
+import {
+  setSiteMode,
+  type ExtensionAppearance,
+  type ExtensionCoverage,
+  type ExtensionReveal,
+  type SiteMode,
+  type SyncSettings,
+} from './config';
+import { loadSettings, saveSettings } from './storage';
+
+export type SettingsMutation =
+  | { type: 'paused'; value: boolean }
+  | { type: 'enabled'; value: boolean }
+  | { type: 'appearance'; value: ExtensionAppearance }
+  | { type: 'coverage'; value: ExtensionCoverage }
+  | { type: 'reveal'; value: ExtensionReveal }
+  | { type: 'site-mode'; hostname: string; mode: SiteMode };
+
+const SETTINGS_WRITE_LOCK = 'scrawlix-settings-write';
+
+export function applySettingsMutation(
+  settings: SyncSettings,
+  mutation: SettingsMutation
+): SyncSettings {
+  switch (mutation.type) {
+    case 'paused':
+      return { ...settings, paused: mutation.value };
+    case 'enabled':
+      return { ...settings, enabled: mutation.value };
+    case 'appearance':
+      return { ...settings, appearance: mutation.value };
+    case 'coverage':
+      return { ...settings, coverage: mutation.value };
+    case 'reveal':
+      return { ...settings, reveal: mutation.value };
+    case 'site-mode':
+      return setSiteMode(settings, mutation.hostname, mutation.mode);
+  }
+}
+
+async function commitUnlocked(mutation: SettingsMutation) {
+  const current = await loadSettings();
+  const next = applySettingsMutation(current, mutation);
+  await saveSettings(next);
+  return next;
+}
+
+export async function commitSettingsMutation(mutation: SettingsMutation) {
+  const locks = navigator.locks;
+  if (!locks) return commitUnlocked(mutation);
+
+  return locks.request(SETTINGS_WRITE_LOCK, () => commitUnlocked(mutation));
+}


### PR DESCRIPTION
## What changed

- add a shared field-intent settings mutation API for pause, default behavior, appearance, coverage, reveal, and per-host site mode
- serialize popup/Options commits with the Web Locks API on the shared `chrome-extension://` origin
- for every commit, read the latest normalized extension state inside the lock, apply exactly one mutation intent, then persist the merged result
- keep each UI's existing local save queue so rapid edits from one page retain user order while the cross-context lock handles popup-vs-Options overlap
- preserve optimistic rendering and replace it with the committed normalized state after the lock-protected write
- add a per-page save generation so an Options `storage.onChanged` reload cannot leave the UI stuck on `saving…` after its own successful write
- preserve visible save-failure recovery by reloading the latest stored settings on error
- keep site-mode mutations local through the existing storage split; hostname policy cannot rewrite compact sync preferences from a stale snapshot
- add concurrency regressions for simultaneous appearance + coverage edits, pause + reveal edits, and site-policy writes preserving compact preferences
- add no new manifest permission or service-worker RPC path

## Why

Popup and Options previously serialized only their own page-local queues while writing complete settings objects. Two open extension pages could therefore hold different snapshots and let the later writer resurrect an older value for an unrelated field.

The mutation path preserves field intent: each write acquires the extension-origin lock, reads the latest state, applies one change, and commits the merged result.

A simple unlocked fallback remains for browsers without Web Locks; the first-store Chrome compatibility floor is tracked separately in #146.

## Stack

This PR is intentionally based on `copper/coverage-contract` / #125 so the cross-context settings fix can be reviewed independently.

Closes #144 and progresses #48, #51, and #23.