### PR TITLE
Compress agent and repository context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-This file is the maintainer map for humans and coding agents working on Scrawlix.
+This is the maintainer map for humans and coding agents working on Scrawlix. Keep durable Scrawlix-specific contracts here; follow the linked owner docs for procedures and adoption recipes.
 
 ## Mission
 
@@ -13,34 +13,28 @@ Scrawlix is programmable censorship for text and the web. Keep four concerns ind
 
 A change in one layer should rarely require logic in another.
 
-## Work continuity
-
-Once the maintainer has given a clear objective or said to continue, prefer sustained implementation runs. Keep advancing through concrete, reviewable work while useful next actions remain; a green test, commit, or pull request is a checkpoint, not an automatic stopping point.
-
-Use CI results, review findings, release checklists, open issues, and newly exposed edge cases as prompts for the next focused slice. Keep long runs reviewable with narrow branches, tests, issues, and pull requests.
-
-Stop for a genuine human decision, unavailable credential/external action, safety or privacy boundary needing explicit approval, irreducible product ambiguity, or when further work would become speculative churn. Do not promise background or asynchronous work; this applies to sustained work during the active agent run.
-
-See `docs/agent-work-continuity.md` for the fuller guidance.
-
-## Workspace map
+## Owners and routing
 
 - `packages/core` — language-neutral matching, segmentation, generic coverage, custom-term helpers
-- `packages/en` — English strong-profanity rules, English-specific coverage helpers, English regression corpus
-- `packages/react` — React renderer and appearance/reveal behavior
-- `packages/rehype` — HAST/rehype transformer for syntax-tree prose
-- `packages/dom` — arbitrary-page text-node transformation, restoration, and mutation observation
-- `apps/demo` — public interactive proof sheet and integration consumer
-- `apps/extension` — Manifest V3 application: browser state, popup UI, and injected presentation
-- `fixtures/consumer` — external packed-package React 18/19 smoke consumer
-- `fixtures/next-consumer` — packed-package Next.js App Router smoke consumer
-- `docs` — design, adoption, compatibility, versioning, release, and extension guidance
+- `packages/en` — English rules, English-specific coverage, regression corpus
+- `packages/react` — React rendering plus appearance/reveal behavior
+- `packages/rehype` — HAST transformation
+- `packages/dom` — arbitrary-page transformation, restoration, mutation observation
+- `apps/demo` — public integration/demo application
+- `apps/extension` — Manifest V3 browser application and injected presentation
+- `fixtures/*` — packed-package consumer release gates
+- `docs/README.md` — documentation index and topic owners
+- `docs/dom.md` — DOM lifecycle, exclusions, and restoration details
+- `docs/agent-work-continuity.md` — sustained agent-work guidance
+- `docs/releasing.md` — release runbook, registry bootstrap, trusted publishing, and verification
+- `docs/compatibility.md` — runtime/framework compatibility
+- `docs/versioning.md` — public-contract and release-classification policy
 
-Scrapbook adoption remains tracked separately as a real-consumer integration.
+Keep package behavior in reusable packages and browser state/UI in `apps/extension`. Scrapbook adoption remains a separate consumer integration.
 
 ## Canonical public names and defaults
 
-Use these names in code, docs, examples, and agent-generated changes:
+Use these names in code, docs, examples, and generated changes:
 
 - `createScrawlix`
 - `censorRuleFromTerms`
@@ -53,17 +47,15 @@ Use these names in code, docs, examples, and agent-generated changes:
 - `transformHast`
 - `createDomScrawlix`
 
-Core defaults to `coverage: 'full'`. React defaults to `appearance="scrawl"` and `reveal="never"`. Partial coverage and reveal behavior are deliberate caller choices.
+Core defaults to `coverage: 'full'`. React defaults to `appearance="scrawl"` and `reveal="never"`. Partial coverage and reveal are caller choices.
 
-The reusable packages use named runtime exports as the canonical API. `@scrawlix/rehype` and `@scrawlix/dom` do not carry duplicate default exports.
+Reusable packages use named runtime exports. `@scrawlix/rehype` and `@scrawlix/dom` have no duplicate default export. Keep one canonical API: avoid convenience packages, automatic English selection, compatibility aliases, and alternate spellings.
 
-Do not invent convenience packages, automatic English selection, compatibility aliases, or alternate spellings for the public API.
+## Repository verification
 
-## Toolchain and commands
+The root `packageManager` field pins pnpm. Repository CI uses Node 22 and frozen installs. Use the pinned pnpm/Corepack version.
 
-The root `packageManager` field pins the exact pnpm release used by CI. Use that version through Corepack/pnpm tooling instead of silently changing package-manager versions.
-
-For a verification checkout whose dependency graph should already be committed:
+For a clean verification checkout:
 
 ```sh
 pnpm install --frozen-lockfile
@@ -73,132 +65,82 @@ pnpm build
 pnpm smoke:packages
 ```
 
-When intentionally changing dependencies, run the pinned pnpm install normally, review the resulting `pnpm-lock.yaml`, and commit manifest + lockfile changes together. Never hand-edit lockfile resolutions.
+Dependency changes use a normal pinned-pnpm install; review and commit manifest plus lockfile changes together. Never hand-edit lockfile resolutions.
 
-Repository CI uses Node 22 and frozen installs. The demo and extension builds are part of the workspace build. The packed-package smoke suite installs tarballs into consumers outside the workspace dependency graph, strictly typechecks Scrawlix declarations through React 18 and React 19, production-builds both majors, and production-builds the documented Next.js App Router client-wrapper path.
+`scripts/smoke-packages.mjs` is a release gate for the actual packed public packages: external consumers must receive usable JavaScript, declarations, CSS/exports, and every local source-map target without packed source tests. When adding or splitting a public entrypoint, keep each package `files` list aligned with emitted maps and extend the packed consumer coverage.
 
-Public package builds emit JavaScript and declaration source maps. Each package manifest deliberately includes only the implementation source files those maps target; source tests stay out of tarballs. When adding or splitting a public implementation entrypoint, update the package `files` list so every local `.js.map` / `.d.ts.map` source remains available after packing. `pnpm smoke:packages` parses the packed archives and fails on unresolved local map targets, path escapes, or packed `*.test.*` sources.
+Release procedure belongs in `docs/releasing.md`; runtime baselines belong in `docs/compatibility.md`.
 
-The npm publication workflow uses Node 24 so its OIDC runner comfortably satisfies trusted-publishing runtime requirements. Published runtime compatibility and workspace-tooling expectations live in `docs/compatibility.md`. Release classification and public-contract rules live in `docs/versioning.md`.
+## Product invariants
 
-## Invariants
+### Preserve exact source text
 
-### Preserve source text exactly
+`engine.segment(text).map(segment => segment.text).join('')` must equal the original JavaScript string exactly. Matching and rendering may derive alternate views; caller-owned source remains unchanged.
 
-`engine.segment(text).map(segment => segment.text).join('')` must always equal the original `text` byte-for-byte at the JavaScript string level. Rendering may obscure glyphs; matching must never rewrite the caller's source.
+### Keep core language-neutral and rules explicit
 
-### Keep core language-neutral
+`@scrawlix/core` owns language-neutral matching and generic coverage. Profanity vocabulary, locale morphology, and language-specific character policy belong in language/rule packs.
 
-Do not add profanity lists, locale-specific morphology, or language-specific character classification to `@scrawlix/core`. Put those in a language/rule pack.
+`createScrawlix()` with zero rules is a no-op. Adapters receive rules explicitly; avoid hidden language detection or bundled moderation policy.
 
-Generic coverage belongs in core. A behavior such as “cover English vowels” belongs in `@scrawlix/en`.
+### Keep first use conservative
 
-### Require deliberate rule selection
+Core's default covers the full semantic target. React keeps source concealed by default with `reveal="never"`. Partial coverage and interactive reveal require explicit caller choice.
 
-`createScrawlix()` with zero rules is a no-op. Adapters should receive rules explicitly. Avoid hidden language detection or surprise bundled moderation behavior.
+### Preserve caller-owned matcher state
 
-### Keep first-use coverage conservative
+Compile internal RegExp copies and leave caller `lastIndex` untouched. Repeated `find()` and `segment()` calls on one engine stay stable.
 
-When rules are supplied without a coverage selector, core covers the full semantic target. Renderers may expose richer partial treatments, but those should be explicit choices. React keeps source concealed by default with `reveal="never"`.
-
-### Preserve caller-owned RegExp state
-
-The engine compiles its own RegExp copies. Never mutate a caller's `lastIndex`. Repeated `find()` / `segment()` calls on the same engine must be stable.
-
-### Keep semantic targets explicit
-
-When a larger match contains the meaningful censored core, use a named capture group and `target: { group: '...' }`. Coverage should operate on the target, not blindly on the full inflected or compound match.
+When a larger lexical match contains the semantic censored core, use a named capture group plus `target: { group: '...' }`; coverage operates on the semantic target.
 
 ### Treat accessibility as source truth
 
-Visual censorship is decorative. When text is transformed, React keeps exactly one visually-hidden source copy in the accessibility tree (`data-scrawlix-a11y`) and marks the complete rendered visual tree `aria-hidden="true"`. Preserve that single accessible reading of the source across every appearance and reveal mode.
+React keeps exactly one visually hidden source copy in the accessibility tree (`data-scrawlix-a11y`) and marks the complete decorative visual tree `aria-hidden="true"`. Preserve that single accessible reading across every appearance and reveal mode.
 
-Passive reveal modes (`hover`, `never`) stay outside the tab order. Keyboard-driven reveal modes must retain an operable focus path and regression coverage.
+Passive reveal modes (`hover`, `never`) stay outside the tab order. Keyboard-driven reveal modes retain an operable focus path and regression coverage. `@scrawlix/react/styles.css` is part of the documented adoption path because it owns built-in treatments and the visually hidden helper.
 
-`@scrawlix/react/styles.css` is part of the documented React adoption path because it owns the built-in treatment CSS and the visually-hidden accessibility helper.
+### Keep framework boundaries explicit
 
-### Keep Next.js rule selection inside the client boundary
+Scrawlix rules contain `RegExp` values and coverage selectors can be functions. In Next.js App Router, application-owned Client Components import the rules and `CensoredText`; Server Components pass serializable application data such as `text`. The packed Next consumer release-gates this recipe.
 
-Scrawlix rule packs contain `RegExp` values and coverage selectors can be functions. In Next.js App Router integrations, keep those values inside an application-owned Client Component that imports the rule pack and `CensoredText`. Server Components should pass serializable application data such as `text` into that wrapper.
+### Keep adapters semantic and reversible
 
-The packed Next consumer release-gates this exact pattern. Keep README and `llms.txt` examples aligned with it.
+`@scrawlix/rehype` transforms eligible HAST text nodes into semantic covered spans, preserves source as text content, skips code/pre/script/style/textarea and its own generated output, and leaves appearance/reveal to consumers. Preserve inline element/link boundaries; matching currently stays within each eligible text node and does not cross markup seams.
 
-### Keep syntax-tree adapters semantic
+`@scrawlix/dom` transforms eligible text nodes locally, marks generated roots with `data-scrawlix-dom-root`, and records exact source strings for controller-owned restoration. Mutation handling processes delivered mutation nodes instead of rescanning the whole document. Editable/form/code-like regions, non-HTML namespaces, and generated output remain excluded by default. Observation restoration disconnects before returning source nodes.
 
-`@scrawlix/rehype` operates on HAST text nodes and emits covered spans with stable data attributes. It preserves the original text as text content and leaves appearance/reveal policy to consumers.
+Keep presentation policy above both adapters.
 
-Keep code/pre/script/style/textarea exclusions safe by default. Preserve inline elements and link boundaries. Never match across separate text nodes or markup seams unless a future API explicitly introduces a higher-level tokenization pass with corpus evidence.
+### Keep extension state in the application
 
-The rehype transform must stay idempotent: existing `data-scrawlix-cover` output is an excluded subtree.
+`apps/extension` owns Chrome storage, host policy, permissions, popup/options UI, and injected presentation. Reusable packages remain browser-application agnostic.
 
-### Keep arbitrary-page DOM work local and reversible
+Preserve the extension's documented storage/policy split and atomic page restoration/reconfiguration lifecycle. Reveal interaction must preserve native control activation. Permission/privacy changes travel with their user-facing browser-product tradeoffs; `apps/extension/README.md` owns the current extension contract.
 
-`@scrawlix/dom` collects eligible text nodes with `TreeWalker`, transforms only nodes with covered ranges, and marks generated roots with `data-scrawlix-dom-root`. Applying the same controller again must leave generated output alone.
+### Record learned linguistic behavior in corpora
 
-Mutation observation must process nodes delivered by `MutationObserver`. Never replace this with a complete document rescan after each mutation.
+When a matcher/rule bug teaches a durable positive or false-positive case, add it to the relevant pack corpus. Prefer data cases over one-off matcher test code.
 
-Keep editable/form/code-like regions and non-HTML namespaces safe by default. Treat `contenteditable="false"` as an explicit island inside an editable ancestor.
+## Change routing
 
-Restoration is controller-owned. A controller records exact source strings for roots it creates and must leave author-owned lookalike attributes alone. When observation is active, use the observation handle's atomic `restore()` lifecycle so disconnect happens before source nodes return.
+### Language packs
 
-Presentation remains above the DOM adapter. Keep black bars, blur, grawlix masks, site preferences, and extension UI out of `@scrawlix/dom`.
+Keep locale vocabulary, morphology, coverage helpers, review assumptions, and corpora inside the pack. Exercise semantic targets, casing, punctuation, compounds/inflections, ambiguity, and deliberate boundary policy. Every package README needs an exact install command and canonical snippet. See `docs/language-packs.md`.
 
-### Keep browser-extension state in the application
+### Appearance and reveal
 
-`apps/extension` owns `chrome.storage`, hostname overrides, popup UI, manifest permissions, and injected presentation. Do not move those concerns into reusable packages.
+Keep matching logic out of renderers. Preserve source width/content, accessibility, interaction behavior, and reduced-motion behavior; add demo coverage plus rendered regressions. Shared appearance work is tracked in issue #26.
 
-Small global preferences belong in `storage.sync`; custom terms currently live in `storage.local`. Host overrides are sparse tri-state policy: absence means inherit, explicit values are `on` or `off`.
+### Coverage
 
-A storage change restarts the page session through `DomObservation.restore()` before a new controller starts. Preserve that atomic restore/reconfigure sequence.
+Generic positional coverage can live in core. Language-character classes, syllables, morphology, and locale-specific selectors belong in a pack.
 
-Extension reveal interaction must avoid stealing native page controls. Generated roots inside links, buttons, inputs, or similar controls stay outside the extension's own focus/click-toggle path.
+### Public API
 
-Broad HTTP/HTTPS host access is a deliberate development choice for persistent automatic per-site behavior. Treat permission minimization as a store-release requirement and document any permission change alongside its UX tradeoff.
+`docs/versioning.md` owns public-contract classification. Documented exports/subpaths, defaults, rule ids, adapter attributes, ignore attributes, React render/CSS attributes, and lifecycle behavior are public contracts. Browser-extension internals stay private unless explicitly promoted.
 
-### Add corpus cases for learned linguistic behavior
+Human quickstarts live in root/package READMEs; coding-agent copy/paste usage lives in the demo `llms.txt`. Keep those surfaces synchronized when public names, defaults, package selection, required stylesheet imports, or framework boundaries change.
 
-When a bug or rule change teaches a durable positive or false-positive example, add it to the relevant pack corpus. Prefer data cases over one-off matcher test code.
+## Sustained work
 
-## Adding a language pack
-
-1. Create `packages/<locale-or-pack-name>` with a dependency on `@scrawlix/core`.
-2. Export one or more `CensorRule[]` collections and a `CensorRulePack` value with locale metadata.
-3. Keep morphology and language-specific coverage helpers inside that package.
-4. Add a reviewable positive corpus and a clean/false-positive corpus.
-5. Test semantic target text, casing, punctuation, compounds/inflections, and known ambiguity.
-6. For phrase lists that can sit beside other letters, use `censorRuleFromTerms(..., { boundary: 'substring' })` deliberately.
-7. Document dialect/severity assumptions. Do not imply complete language coverage from a small pack.
-8. Give the package README an exact install command and canonical consumer snippet.
-
-## Adding a visual appearance
-
-1. Coordinate with the shared appearance contract tracked in issue #26.
-2. Add the appearance name to `ScrawlixAppearance` in `packages/react` when it is a built-in preset.
-3. Keep matching logic out of React.
-4. Prefer CSS/data-attribute presentation over rebuilding source strings.
-5. Add the appearance to the demo specimen sheet.
-6. Preserve reveal modes and reduced-motion behavior.
-7. Extend rendered regressions for any new DOM contract or interaction.
-8. If the extension should expose the same appearance, update its presentation union/CSS and test its mask semantics separately.
-
-## Adding a coverage behavior
-
-Ask whether the behavior is language-neutral. Generic positional coverage may live in core. Character classes, syllables, morphology, or locale-specific rules belong in a pack and can be implemented as `CoverageSelector` callbacks.
-
-## Release discipline
-
-`docs/releasing.md` is the release runbook. The five public packages stay synchronized and `scripts/check-release-version.mjs` refuses mismatched release versions or the workspace placeholder `0.0.0`.
-
-`.github/workflows/publish.yml` is the permanent post-bootstrap publication path. It is manually dispatched from `main`, defaults to dry-run, reruns the release gates, preflights npm package/version state, publishes in dependency order, requests provenance, and carries no long-lived npm write token.
-
-npm trusted publishers are configured per package and require an existing registry package. The first package creation therefore remains an explicit human bootstrap step tracked in issue #18; after all five packages exist and trust `publish.yml`, subsequent releases use GitHub OIDC. Never add an npm write token to the permanent publish workflow to bypass that bootstrap requirement.
-
-## Public API discipline
-
-Scrawlix is pre-release, so breaking changes are still possible. Use that freedom to remove surprising defaults and awkward names before publication. `docs/versioning.md` defines how 0.x releases classify fixes, additions, language-pack scope changes, and intentional breaks.
-
-The documented package exports, rule ids, option defaults, adapter data attributes, ignore attributes, and React CSS/render attributes are public contracts. Keep application-only browser-extension state private unless a document explicitly promotes it to a public contract.
-
-Packed-package smoke tests are a release gate: external consumers must receive compiled JavaScript, declarations, CSS exports, valid package metadata, and source-map targets that resolve inside the tarball. Every new public package belongs in `scripts/smoke-packages.mjs` and the relevant external consumer fixture.
-
-Human quickstarts live in the root/package READMEs. Agent quickstarts live in the demo `llms.txt`. Keep those surfaces synchronized whenever public names, defaults, package selection, required side-effect imports, or framework boundaries change.
+When the maintainer gives a clear objective, continue through concrete reviewable work while useful next actions remain. `docs/agent-work-continuity.md` owns the stop conditions and continuation guidance.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Scrawlix separates four concerns so applications can combine them deliberately:
 - **appearance** — how should the covered part look?
 - **reveal** — when, if ever, should the original text show through?
 
-The same word can become `████`, `f███`, `f██k`, `f█ck`, `f**k`, a blur, an inked-over scrawl, or a grawlix while the caller keeps control of the original source text.
+The same word can become `████`, `f███`, `f██k`, `f█ck`, `f**k`, a blur, an inked-over scrawl, or a grawlix while the caller keeps the original source text.
 
 ## Choose your path
 
@@ -21,7 +21,7 @@ The same word can become `████`, `f███`, `f██k`, `f█ck`, `f*
 | match/segment text or build your own renderer | `@scrawlix/core` plus rules | `createScrawlix` |
 | use packaged English strong-profanity rules | `@scrawlix/en` | `englishStrongProfanityRules` |
 
-The five packages stay deliberately small: core contains no hidden language policy, and adapters receive rules explicitly.
+Core contains no hidden language policy; adapters receive rules explicitly.
 
 ## React — five-minute start
 
@@ -42,9 +42,7 @@ import '@scrawlix/react/styles.css';
 />;
 ```
 
-The first-use defaults are deliberately conservative: full semantic-target coverage, `scrawl` appearance, and `reveal="never"`.
-
-Opt into partial coverage and reveal behavior explicitly:
+Defaults are full semantic-target coverage, `appearance="scrawl"`, and `reveal="never"`. Partial coverage and reveal are explicit:
 
 ```tsx
 <CensoredText
@@ -56,19 +54,17 @@ Opt into partial coverage and reveal behavior explicitly:
 />;
 ```
 
-Current appearances: `scrawl`, `bar`, `blur`, `asterisk`, `grawlix`.
+Appearances: `scrawl`, `bar`, `blur`, `asterisk`, `grawlix`. Reveal modes: `never`, `hover`, `focus`, `click`.
 
-Current reveal modes: `never`, `hover`, `focus`, `click`.
+### React CSS, accessibility, and source text
 
-### React CSS and source text
+`@scrawlix/react/styles.css` provides the built-in treatments and visually hidden accessibility copy. If text appears duplicated or visibly uncensored, check that import first.
 
-`@scrawlix/react/styles.css` is required for the built-in treatments and the visually-hidden accessibility copy. If text appears duplicated or visibly uncensored, check that import first.
-
-`CensoredText` is reversible presentation. It keeps one exact source copy available to assistive technology and marks the decorative visual tree `aria-hidden="true"`. Secrets or destructive redaction belong upstream; Scrawlix intentionally preserves caller-owned source text. See [`docs/privacy-and-output.md`](docs/privacy-and-output.md) for presentation, screenshot, assistive-technology, and sanitized-export guarantees.
+`CensoredText` is reversible presentation: it keeps one exact source copy available to assistive technology and marks the decorative visual tree `aria-hidden="true"`. Secrets or destructive redaction belong upstream. See [`docs/privacy-and-output.md`](docs/privacy-and-output.md).
 
 ### Next.js App Router
 
-`CensoredText` is a Client Component. Rule packs contain `RegExp` values and coverage policies can be functions, so keep rule selection inside a client boundary instead of passing a rule pack from a Server Component.
+`CensoredText` is a Client Component. Rule packs contain `RegExp` values and coverage policies can be functions, so keep rule selection inside a client boundary:
 
 ```tsx
 // app/ScrawlixText.tsx
@@ -82,7 +78,7 @@ export function ScrawlixText({ text }: { text: string }) {
 }
 ```
 
-Server Components can then pass ordinary serializable text to that wrapper. Import `@scrawlix/react/styles.css` from the root layout or your App Router global CSS entry. This exact boundary is production-built in the packed-package smoke suite.
+Server Components pass serializable values such as `text` to that wrapper. Import the stylesheet from the root layout or global CSS entry. The packed-package release gate production-builds this boundary.
 
 ## Core
 
@@ -94,16 +90,11 @@ npm install @scrawlix/core @scrawlix/en
 import { createScrawlix } from '@scrawlix/core';
 import { englishStrongProfanityRules } from '@scrawlix/en';
 
-const scrawlix = createScrawlix({
-  rules: englishStrongProfanityRules,
-});
-
+const scrawlix = createScrawlix({ rules: englishStrongProfanityRules });
 scrawlix.segment('what the fuck');
 ```
 
-The English pack understands semantic targets inside larger matches, so `fuck`, `fucking`, and `motherfucker` can all apply coverage specifically to the `fuck` portion.
-
-Generic core coverage presets are `full`, `tail`, `middle`, and `inner`. `full` is the engine default; partial coverage is an explicit editorial choice.
+The English pack can target the semantic core inside larger matches, so `fuck`, `fucking`, and `motherfucker` can all apply coverage to the `fuck` portion. Generic core presets are `full`, `tail`, `middle`, and `inner`; `full` is the default.
 
 ## Markdown / rehype
 
@@ -111,25 +102,19 @@ Generic core coverage presets are `full`, `tail`, `middle`, and `inner`. `full` 
 npm install @scrawlix/rehype @scrawlix/en
 ```
 
-`@scrawlix/rehype` walks HAST text nodes and marks covered ranges while leaving source text intact:
-
 ```tsx
 import { englishStrongProfanityRules } from '@scrawlix/en';
 import { rehypeScrawlix } from '@scrawlix/rehype';
 import ReactMarkdown from 'react-markdown';
 
 <ReactMarkdown
-  rehypePlugins={[
-    [rehypeScrawlix, { rules: englishStrongProfanityRules }],
-  ]}
+  rehypePlugins={[[rehypeScrawlix, { rules: englishStrongProfanityRules }]]}
 >
   {markdown}
 </ReactMarkdown>;
 ```
 
-Covered fragments become spans carrying `data-scrawlix-cover` and `data-scrawlix-rules`. Appearance policy stays outside the syntax-tree pass so a site can style those spans in its own editorial language.
-
-`code`, `pre`, `script`, `style`, and `textarea` subtrees are skipped by default. Applications can add excluded tags, place `data-scrawlix-ignore` on a subtree, or provide a `shouldSkip` predicate. The transformer skips its own output so repeated processing remains idempotent.
+Covered fragments carry `data-scrawlix-cover` and `data-scrawlix-rules`; appearance policy stays with the consumer. `code`, `pre`, `script`, `style`, and `textarea` are skipped by default. Applications can extend exclusions, use `data-scrawlix-ignore`, or supply `shouldSkip`. Generated output is skipped on repeat transforms.
 
 ## Arbitrary webpages / DOM
 
@@ -141,26 +126,21 @@ npm install @scrawlix/dom @scrawlix/en
 import { createDomScrawlix } from '@scrawlix/dom';
 import { englishStrongProfanityRules } from '@scrawlix/en';
 
-const censor = createDomScrawlix({
-  rules: englishStrongProfanityRules,
-});
-
+const censor = createDomScrawlix({ rules: englishStrongProfanityRules });
 const observation = censor.observe(document.body);
 ```
 
-Only text nodes with covered ranges are wrapped. Generated roots use `data-scrawlix-dom-root`; covered fragments use the same `data-scrawlix-cover` and `data-scrawlix-rules` attributes as the rehype adapter.
-
-Turning a site off can be one lifecycle call:
+Only text nodes with covered ranges are wrapped. Generated roots use `data-scrawlix-dom-root`; covered fragments share the rehype adapter's semantic attributes. Restore exact controller-owned source and disconnect observation with:
 
 ```ts
 observation.restore();
 ```
 
-That disconnects observation, clears pending work, and restores controller-owned source strings. Form/editable/code-like regions, non-HTML namespaces, and generated output are skipped by default. See [`docs/dom.md`](docs/dom.md).
+Form/editable/code-like regions, non-HTML namespaces, and generated output are skipped by default. See [`docs/dom.md`](docs/dom.md).
 
 ## Custom terms and phrases
 
-Profanity is one rule pack. Callers can censor names, spoilers, codenames, or arbitrary phrases:
+Use core for names, spoilers, codenames, or other application-owned terms:
 
 ```ts
 import { censorRuleFromTerms, createScrawlix } from '@scrawlix/core';
@@ -173,54 +153,25 @@ const privateTerms = censorRuleFromTerms('private', [
 const censor = createScrawlix({ rules: [privateTerms] });
 ```
 
-`censorRuleFromTerms()` uses Unicode-aware word boundaries by default. Packs for scripts where matches can sit directly beside other letters can opt into `boundary: 'substring'`.
+`censorRuleFromTerms()` uses Unicode-aware word boundaries by default. Packs for scripts whose matches can sit beside other letters can choose `boundary: 'substring'`.
 
 ## Language packs
 
-`@scrawlix/core` owns matching mechanics and generic positional coverage. Linguistic assumptions live in packages such as `@scrawlix/en`.
+`@scrawlix/core` owns matching mechanics and generic positional coverage; linguistic policy lives in packages such as `@scrawlix/en`.
 
-The English package currently exports:
+The English package exports `englishStrongProfanityRules`, `englishStrongProfanityPack`, `englishVowelCoverage`, and the `@scrawlix/en/corpus` subpath. Combine packs with `rulesFromPacks(...)`. See [`docs/language-packs.md`](docs/language-packs.md).
 
-- `englishStrongProfanityRules`
-- `englishStrongProfanityPack`
-- `englishVowelCoverage`
-- a regression corpus at `@scrawlix/en/corpus`
+## Browser extension and demo
 
-Future language packs can carry their own rules, locale metadata, coverage helpers, and regression corpora. Consumers can combine packs with `rulesFromPacks(...)`. See [`docs/language-packs.md`](docs/language-packs.md).
+`apps/extension` is a Manifest V3 application around `@scrawlix/dom` and `@scrawlix/en`; browser storage, host policy, permissions, UI, and injected presentation stay in the application. Build it with `pnpm build`, then load `apps/extension/dist` as an unpacked Chromium extension. See [`apps/extension/README.md`](apps/extension/README.md).
 
-## Browser extension
+`apps/demo` is the interactive React proof sheet. Run `pnpm dev` to use its live text, coverage/reveal controls, appearance specimens, semantic-match examples, and component snippet.
 
-The unpacked Manifest V3 extension lives in `apps/extension`. It is a thin application around `@scrawlix/dom` and `@scrawlix/en`: page matching/restoration stays in packages, while browser storage, per-host preferences, injected presentation, and popup UI stay in the extension.
+## Documentation and contributing
 
-```sh
-pnpm install
-pnpm build
-```
+[`docs/README.md`](docs/README.md) indexes adoption, compatibility, privacy/output, language-pack, DOM, troubleshooting, and release guidance. [`AGENTS.md`](AGENTS.md) is the maintainer/agent map. The demo serves `llms.txt` with canonical package selection and copy/paste usage for coding agents.
 
-Then load `apps/extension/dist` as an unpacked extension in a Chromium browser.
-
-The popup supports global and per-host enablement, all five appearances, generic plus English-vowel coverage, all reveal modes, and local custom terms. See [`apps/extension/README.md`](apps/extension/README.md) for permission, privacy, build, and lifecycle notes.
-
-## Demo
-
-The interactive proof sheet lives in `apps/demo` and consumes workspace packages like an external React application.
-
-```sh
-pnpm install
-pnpm dev
-```
-
-The demo includes editable live text, coverage/reveal controls, a five-style specimen sheet, semantic-match examples, and a live component snippet.
-
-## Documentation
-
-Start with [`docs/README.md`](docs/README.md) for the recipe index. Maintainers and coding agents should also read [`AGENTS.md`](AGENTS.md), which records package responsibilities, invariants, commands, and extension rules.
-
-The demo serves `llms.txt` with canonical package selection and copy/paste usage for coding agents.
-
-## Contributing
-
-Run the whole workspace with:
+Repository verification:
 
 ```sh
 pnpm typecheck
@@ -229,7 +180,7 @@ pnpm build
 pnpm smoke:packages
 ```
 
-The packed-package smoke test installs real tarballs into external consumers, then typechecks and production-builds React 18, React 19, and Next.js App Router integrations through public package exports.
+The packed-package smoke gate installs real tarballs into external consumers and verifies public exports/declarations plus React 18, React 19, and Next.js App Router production builds.
 
 ## Status
 

--- a/docs/agent-work-continuity.md
+++ b/docs/agent-work-continuity.md
@@ -1,19 +1,9 @@
 # Agent work continuity
 
-Scrawlix benefits from long, self-directed implementation runs once the maintainer has given a clear objective or said to continue.
+A clear maintainer objective authorizes a sustained implementation run. Keep advancing through concrete, reviewable work while useful next actions remain; a green test, commit, or pull request is a checkpoint.
 
-Coding agents should keep advancing through useful, reviewable work for the duration of the current run instead of treating the first green test, commit, or pull request as an automatic stopping point.
+Continue when an issue/checklist has actionable work, CI or review exposes a reproducible follow-up, or implemented behavior still needs its tests, docs, compatibility, packaging, or release polish. Keep long runs reviewable with focused branches, tests, issues, and pull requests.
 
-Good continuation signals include:
+Stop for a genuine human decision, unavailable credential or external action, a safety/privacy boundary needing explicit approval, irreducible product ambiguity, or speculative churn.
 
-- an open issue or release checklist still has concrete unchecked work;
-- CI exposes another actionable failure or edge case;
-- a completed slice naturally reveals a narrow follow-up that can be implemented and tested safely;
-- documentation, browser regressions, packaging, compatibility, or release polish still lag behind implemented behavior;
-- a review uncovers a reproducible race, lifecycle problem, accessibility issue, or permission problem that can be isolated into its own change.
-
-Prefer to keep working when the next action is clear. Use focused branches, tests, issues, and pull requests to keep a long run reviewable instead of stopping merely to report progress.
-
-A long run should stop when it reaches a genuine human decision, an unavailable credential or external action, a safety/privacy boundary that needs explicit approval, irreducible ambiguity about product intent, or a point where further work would be speculative churn.
-
-Do not promise background or asynchronous work. This guidance applies to sustained work performed during the active agent run.
+Perform this work during the active run; avoid promises of background or asynchronous completion.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,24 +1,10 @@
 # Releasing Scrawlix
 
-Scrawlix is still pre-release. This runbook exists so the first registry publish and every later release are deliberate operations with clear stop conditions.
+This runbook owns npm release procedure for the five public packages. Scrawlix is pre-release; registry writes begin only from a reviewed, reproducible release candidate.
 
-## Stop conditions
+## Release set and stop conditions
 
-Do not create registry history until all of these are resolved:
-
-1. **npm scope ownership** — the package names use `@scrawlix/*`. Confirm the npm organization/scope `scrawlix` exists under our control and the publishing identity can create public packages there. If it cannot, rename packages before the bootstrap publish.
-2. **license** — choose an open-source license, add the root license file, and add the matching SPDX `license` field to every publishable package.
-3. **version/tag strategy** — choose the first package version and dist-tag policy. The five public packages release together; `docs/versioning.md` defines the 0.x compatibility policy.
-4. **bootstrap strategy** — npm trusted publishers can only be configured after a package already exists. Decide whether the authenticated bootstrap creates the intended first version or a dedicated bootstrap prerelease, then record that choice in issue #18.
-5. **release commit** — publish only from a clean `main` commit whose complete CI is green.
-
-The repository commits `pnpm-lock.yaml`, pins pnpm through the root `packageManager` field, and uses frozen installs in CI and the permanent publication workflow.
-
-The public demo URL can be treated as either a release gate or an immediate follow-up; record that choice in issue #18.
-
-## Publishable packages
-
-The public package set is:
+The synchronized public release train is:
 
 - `@scrawlix/core`
 - `@scrawlix/en`
@@ -26,11 +12,21 @@ The public package set is:
 - `@scrawlix/rehype`
 - `@scrawlix/dom`
 
-`apps/demo` and `apps/extension` are applications and stay private workspace projects.
+`apps/demo` and `apps/extension` remain private workspace applications.
 
-## 1. Verify the repository
+Before any first registry write, resolve and record in issue #18:
 
-From a clean checkout of the intended release commit:
+1. control of the npm `scrawlix` scope and final package names;
+2. the open-source license, root license file, and matching SPDX metadata in every package;
+3. the synchronized first version and dist-tag policy (`docs/versioning.md` owns compatibility classification);
+4. whether bootstrap publishes the intended first version or a dedicated prerelease;
+5. the exact clean `main` release commit with complete green CI.
+
+The demo URL can be a release gate or immediate follow-up; record that choice in #18.
+
+## 1. Verify the exact release commit
+
+From a clean checkout:
 
 ```sh
 pnpm install --frozen-lockfile
@@ -40,33 +36,21 @@ pnpm build
 pnpm smoke:packages
 ```
 
-The packed-package smoke test is a hard release gate. It packs every public package, validates every emitted JS/declaration map against the actual tarball contents, rejects packed source tests, installs those tarballs into consumers outside the pnpm workspace, typechecks published declarations through React 18 and React 19 consumers, production-builds both React majors, and production-builds the documented Next.js App Router integration.
+Confirm the real Chromium demo/extension smoke also passed in CI on this commit.
 
-Confirm the real Chromium demo/extension smoke tests have also passed in CI on the exact release commit.
+`pnpm smoke:packages` is the packed-package release gate. It validates real tarballs, local JS/declaration source-map targets, absence of packed source tests, public exports/declarations/CSS, external React 18/19 consumers, and the documented Next.js App Router consumer.
 
-## 2. Verify package metadata and tarball contents
+## 2. Verify metadata, version, and tarballs
 
-Before the first publish, inspect each package manifest for:
+Every public package should carry the intended name/version, description, repository/homepage/bugs links, SPDX license, `files`, `exports`, `types`, `sideEffects`, `publishConfig.access = public`, and package README.
 
-- final package name
-- synchronized final version
-- description
-- repository/homepage/bugs links
-- SPDX license
-- `files`
-- `exports`
-- `types`
-- `sideEffects`
-- `publishConfig.access = public`
-- package-specific README
-
-Confirm the version with the repository gate:
+Verify synchronization:
 
 ```sh
 node scripts/check-release-version.mjs <version>
 ```
 
-Then perform registry publish dry-runs from the workspace:
+For a first-release manual review, dry-run each package with the chosen tag:
 
 ```sh
 pnpm --filter @scrawlix/core publish --dry-run --access public --tag next
@@ -76,96 +60,58 @@ pnpm --filter @scrawlix/rehype publish --dry-run --access public --tag next
 pnpm --filter @scrawlix/dom publish --dry-run --access public --tag next
 ```
 
-Use the actual chosen prerelease tag in place of `next`.
+Use the actual chosen tag in place of `next`. Inspect every reported file list. The tarballs must contain their JS/declaration entries, required implementation sources for maps, package README, `@scrawlix/en/corpus`, and `@scrawlix/react/styles.css`; source tests and workspace application/fixture files stay out. pnpm converts internal `workspace:*` specs to publishable registry ranges.
 
-Review the file list reported by every dry run. Verify:
+## 3. Verify npm identity before writes
 
-- JS entry points exist
-- declaration entry points exist
-- every local JS/declaration source-map target exists in the tarball (the package smoke enforces this)
-- curated implementation sources are present while `*.test.*` sources are absent
-- `@scrawlix/en/corpus` exists
-- `@scrawlix/react/styles.css` exists
-- each package README is included
-- workspace fixtures, demo files, and extension files are absent from package tarballs
-- workspace dependency specs are converted into publishable registry ranges by pnpm
+Authenticate with the intended npm account, verify control of the `scrawlix` scope, and check every final package name. An unused package name does not establish scope control. The package-creation/trust account must satisfy npm's current authentication/2FA requirements.
 
-## 3. Verify registry identity before any write
+## 4. Version one release train
 
-Authenticate with the intended npm account and prove the publishing identity controls the `scrawlix` scope. Also search the registry for every final package name.
+Until dedicated monorepo version tooling exists:
 
-A missing package name does not prove control of the organization scope; scope access is the authoritative check.
+- set the same version on all five public packages;
+- keep internal `workspace:*` relationships in source manifests;
+- update `CHANGELOG.md`;
+- commit the version/changelog change;
+- let complete CI pass on that exact commit;
+- rerun `node scripts/check-release-version.mjs <version>`.
 
-The npm account used for package creation/trust configuration must meet npm's current 2FA requirements.
+Publish from that clean reviewed commit.
 
-## 4. Version the package set
+## 5. Bootstrap brand-new packages once
 
-Until Scrawlix adopts dedicated monorepo version tooling, treat the five public packages as one release train:
+npm trusted publishing can be configured only after a package exists. Perform this one-time creation with an interactively authenticated maintainer account from the reviewed release checkout, in dependency order: core → en → react → rehype → dom.
 
-- give every public package the same release version
-- keep internal `workspace:*` relationships in source manifests
-- update `CHANGELOG.md`
-- commit the version/changelog change
-- let the complete CI pass on that exact commit
-- run `node scripts/check-release-version.mjs <version>`
+Choose one policy in #18 before the write:
 
-Avoid publishing from a dirty tree or from a commit that differs from the reviewed release commit.
+- **first-version bootstrap** — manually publish the intended first release; OIDC starts next release.
+- **bootstrap prerelease** — publish a clearly labeled prerelease/tag, configure trusted publishing, then publish the intended supported release through OIDC.
 
-## 5. Bootstrap brand-new npm packages once
+Registry history is durable. Keep the interactive bootstrap credential out of GitHub Actions and repository secrets.
 
-npm trusted publishing has a chicken-and-egg constraint: a package must already exist on the registry before its trusted-publisher configuration can be created.
+## 6. Configure trusted publishing
 
-For each of the five package names, perform the one-time bootstrap from the exact reviewed release checkout with an interactively authenticated npm account. Publish in dependency order: core first, then `en`, `react`, `rehype`, and `dom`.
-
-Two deliberate bootstrap policies are available:
-
-- **first-version bootstrap** — publish the intended first release manually once; OIDC begins with the next release.
-- **bootstrap prerelease** — create each package with a clearly labeled prerelease/dist-tag, configure trusted publishing, then publish the intended first supported release through GitHub OIDC.
-
-Choose one policy in issue #18 before any registry write. npm registry history is durable, so a bootstrap prerelease also becomes permanent public history.
-
-Do not store the bootstrap credential in GitHub Actions. Use the maintainer's interactive npm login/2FA flow for this one operation.
-
-## 6. Configure npm trusted publishing
-
-After every package exists, configure its npm Trusted Publisher with these exact GitHub values:
+After each package exists, configure its npm Trusted Publisher with:
 
 - owner/user: `teamleaderleo`
 - repository: `scrawlix`
 - workflow filename: `publish.yml`
 - allowed action: publish
 
-Trusted publishing is configured per package, so repeat it for all five. npm currently requires the package to exist before this configuration can be saved.
+Repeat for all five packages. The permanent `.github/workflows/publish.yml` grants `contents: read` and `id-token: write`, runs on Node 24, carries no long-lived npm write token, and publishes with provenance.
 
-The permanent workflow is `.github/workflows/publish.yml`. Its publish job grants only `contents: read` and `id-token: write`, runs on a GitHub-hosted runner, contains no npm write token, and uses `pnpm publish --provenance`.
+## 7. Publish through GitHub OIDC
 
-## 7. Publish subsequent releases through GitHub OIDC
+Dispatch **Publish npm packages** from `main` with the exact committed synchronized `version`, chosen `dist_tag`, and `dry_run=true` first. Review that run before a real publish.
 
-Dispatch **Publish npm packages** from `main` with:
+The workflow installs the frozen dependency graph, reruns typecheck/tests/build/package smokes, validates the synchronized version, and for real writes verifies that all five packages already exist and that none already has the target version. It publishes core → en → react → rehype → dom with the requested tag and provenance. Its concurrency group prevents overlapping publish jobs.
 
-- `version` — the exact synchronized version already committed to all five package manifests
-- `dist_tag` — for example `next`, `beta`, or eventually `latest`
-- `dry_run` — leave this enabled first; disable it only after the dry run is reviewed
+Use this OIDC path after bootstrap; keep `NPM_TOKEN`/`NODE_AUTH_TOKEN` out of the permanent workflow.
 
-The workflow:
+## 8. Verify the registry release
 
-1. installs the committed lockfile with pinned pnpm
-2. reruns typecheck, tests, build, and packed-package smokes
-3. refuses the workspace placeholder version `0.0.0`
-4. refuses mismatched package versions
-5. for a real publish, verifies all five package names already exist (the bootstrap/trusted-publisher prerequisite)
-6. refuses to start if any target package/version already exists, reducing partial-release mistakes
-7. publishes core → English → React → rehype → DOM with the requested dist-tag and provenance
-
-OIDC uses short-lived credentials. No long-lived `NPM_TOKEN`/`NODE_AUTH_TOKEN` belongs in repository secrets for this workflow.
-
-For public packages published through npm trusted publishing from a public GitHub repository, provenance is attached automatically; the workflow also requests provenance explicitly.
-
-## 8. Verify from a clean registry consumer
-
-After registry publication, create a directory outside the repository and install from the registry using the chosen dist-tag.
-
-Verify at minimum:
+From a clean directory outside the repository, install the chosen dist-tag and verify the public surface:
 
 ```ts
 import { censorRuleFromTerms, createScrawlix } from '@scrawlix/core';
@@ -180,32 +126,14 @@ import { rehypeScrawlix } from '@scrawlix/rehype';
 import { createDomScrawlix } from '@scrawlix/dom';
 ```
 
-Typecheck and production-build that consumer. Confirm core finds an English match, React CSS resolves, and public subpath imports resolve.
+Typecheck and production-build the consumer. Confirm core matching, React CSS resolution, and public subpaths.
 
-## 9. Inspect public registry pages
+Inspect each npm page for the intended version/tag, README, repository links, license, declarations, dependency metadata, and provenance for OIDC publications.
 
-For every package, verify the npm page shows the intended:
+## 9. Tag the verified commit
 
-- version and dist-tag
-- package-local README
-- repository/homepage links
-- license
-- TypeScript declarations
-- dependencies/peer dependencies
-- provenance for OIDC-published versions
+After registry verification, create the matching Git tag/release from the published commit, use the relevant `CHANGELOG.md` entry for release notes, and state the package set plus pre-release stability expectation. Include the demo URL when public. Browser-store distribution remains a separate release unless explicitly coordinated.
 
-Then add registry links from the repository README/demo.
+## Correcting a bad publish
 
-## 10. Tag and release notes
-
-After registry verification:
-
-- create the matching Git tag/release from the published commit
-- copy the relevant `CHANGELOG.md` entry into GitHub release notes
-- include the demo URL if public
-- state the supported package set and pre-release stability expectation
-- keep browser-store distribution separate from the npm package release unless intentionally coordinated
-
-## Rollback mindset
-
-npm registry history is durable. Prefer a corrected follow-up version over trying to erase a published mistake. That makes dry-run tarball review, the bootstrap policy, trusted publication, and clean-consumer verification especially valuable for the first release.
+npm registry history is durable. Prefer a corrected follow-up version. Dry-run review, synchronized-package gates, trusted publishing, dependency-order publication, and clean-consumer verification exist to catch mistakes before and immediately after registry writes.


### PR DESCRIPTION
## Summary

- compress `AGENTS.md` into the Scrawlix-specific maintainer map: package routing, canonical public names/defaults, repository verification, and durable product invariants
- let `docs/agent-work-continuity.md` own sustained-work guidance and `docs/releasing.md` own npm bootstrap/OIDC/release procedure
- keep the root README consumer-first, preserving install/copy-paste examples, accessibility/source truth, framework boundaries, adapter usage, and package/application responsibilities
- preserve release safety: synchronized five-package train, exact release commit, frozen verification, packed-package smoke gate, dry-run review, registry bootstrap, trusted publisher configuration, dependency-order OIDC publication, and clean-registry verification

## Semantic owners after this change

- root/package READMEs: human installation and consumer quickstarts
- `AGENTS.md`: Scrawlix-specific routing, canonical names/defaults, invariants, and the minimal repository gate
- `docs/agent-work-continuity.md`: sustained agent-work continuation and stop conditions
- `docs/releasing.md`: registry/release mechanics and safety sequence
- `docs/compatibility.md`: runtime/framework baselines
- `docs/versioning.md`: public-contract classification
- `docs/dom.md`: DOM lifecycle, exclusions, and restoration detail
- demo `llms.txt`: coding-agent copy/paste adoption guidance

## Token measurement

Measured the four primary surfaces with OpenAI `tiktoken` 0.14.0 using `cl100k_base` against base `0bff9f8f0085aa80d703faffc684463c0a5800ad`:

| File | Before | After | Removed |
| --- | ---: | ---: | ---: |
| `README.md` | 2,103 | 1,803 | 300 |
| `AGENTS.md` | 2,801 | 1,724 | 1,077 |
| `docs/agent-work-continuity.md` | 268 | 146 | 122 |
| `docs/releasing.md` | 2,068 | 1,488 | 580 |
| **Total** | **7,240** | **5,161** | **2,079** |

**Reduction: 28.72%.**

## Intentional repetition

A small amount of public guidance remains repeated where readers need it in place: canonical API/defaults, the React stylesheet/accessibility rule, the Next.js Client Component boundary, and repository verification commands. Release-specific mechanics live in `docs/releasing.md`; `AGENTS.md` keeps only the release gate/routing needed during implementation.

## Verification

- final diff is documentation-only and contains exactly the four issue surfaces
- inspected retained public install/import examples for React, Next.js, core, rehype, DOM, and custom terms
- full repository CI passed on final branch SHA `010d0be4e1069cbc72858fe89d0042a6a7d330f4`: frozen install, typecheck, tests, build, core benchmark smoke, Chromium demo smoke, Chromium extension smoke, and packed-package smoke

Closes #150
